### PR TITLE
Finish the daw/ui ranges sweep and drop the iterator pairs

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -13,9 +13,10 @@ CompileFlags:
   # Pointing at the directory CMake writes means there is only ever one.
   CompilationDatabase: cmake-build-debug
 
-  # Treat all files as C++20
+  # The project moved to C++23 in #2543. Without this the editor compiled every
+  # file as C++20 and reported std::views::zip as missing.
   Add:
-    - -std=c++20
+    - -std=c++23
     - -Wall
     - -Wextra
 

--- a/magda/daw/ui/components/automation/AutomationClipComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationClipComponent.cpp
@@ -131,17 +131,12 @@ void AutomationClipComponent::paintMiniCurve(juce::Graphics& g, juce::Rectangle<
     // mouse-up commit.
     std::vector<AutomationPoint> points = clip->points;
     if (previewPointId_ != INVALID_AUTOMATION_POINT_ID) {
-        for (auto& point : points) {
-            if (point.id == previewPointId_) {
-                point.beatPosition = previewPointBeat_;
-                point.value = previewPointValue_;
-                break;
-            }
+        const auto dragged = std::ranges::find(points, previewPointId_, &AutomationPoint::id);
+        if (dragged != points.end()) {
+            dragged->beatPosition = previewPointBeat_;
+            dragged->value = previewPointValue_;
         }
-        std::sort(points.begin(), points.end(),
-                  [](const AutomationPoint& a, const AutomationPoint& b) {
-                      return a.beatPosition < b.beatPosition;
-                  });
+        std::ranges::sort(points, {}, &AutomationPoint::beatPosition);
     }
 
     // Sample the model's interpolation (bezier / step / tension aware) at
@@ -514,8 +509,7 @@ void AutomationClipComponent::automationPointDragPreview(AutomationLaneId laneId
     const auto* clip = getClipInfo();
     if (!clip || clip->laneId != laneId)
         return;
-    const bool ours = std::any_of(clip->points.begin(), clip->points.end(),
-                                  [pointId](const AutomationPoint& p) { return p.id == pointId; });
+    const bool ours = std::ranges::contains(clip->points, pointId, &AutomationPoint::id);
     if (!ours)
         return;
     previewPointId_ = pointId;

--- a/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
+++ b/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
@@ -803,8 +803,7 @@ void AutomationCurveEditor::syncSelectionState() {
     for (auto& pc : pointComponents_) {
         bool isSelected = false;
         if (isOurSelection) {
-            isSelected = std::find(selection.pointIds.begin(), selection.pointIds.end(),
-                                   pc->getPointId()) != selection.pointIds.end();
+            isSelected = std::ranges::contains(selection.pointIds, pc->getPointId());
         }
         pc->setSelected(isSelected);
         if (isSelected)

--- a/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneComponent.cpp
@@ -608,18 +608,17 @@ void AutomationLaneComponent::simplifyLane(AutomationLaneId laneId, double epsil
     };
 
     std::vector<AutomationPointId> filterSorted(pointIdFilter.begin(), pointIdFilter.end());
-    std::sort(filterSorted.begin(), filterSorted.end());
+    std::ranges::sort(filterSorted);
     const bool hasFilter = !filterSorted.empty();
 
     std::vector<Entry> entries;
     entries.reserve(lane->absolutePoints.size());
     for (const auto& pt : lane->absolutePoints) {
-        bool inScope =
-            !hasFilter || std::binary_search(filterSorted.begin(), filterSorted.end(), pt.id);
+        bool inScope = !hasFilter || std::ranges::binary_search(filterSorted, pt.id);
         entries.push_back({pt.id, {pt.beatPosition, pt.value}, inScope});
     }
-    std::sort(entries.begin(), entries.end(),
-              [](const Entry& a, const Entry& b) { return a.p.beatPosition < b.p.beatPosition; });
+    const auto beatPositionOf = [](const Entry& entry) { return entry.p.beatPosition; };
+    std::ranges::sort(entries, {}, beatPositionOf);
 
     std::vector<AutomationCurveSimplifier::Point> polyline;
     polyline.reserve(entries.size());

--- a/magda/daw/ui/components/automation/MasterAutomationLanes.cpp
+++ b/magda/daw/ui/components/automation/MasterAutomationLanes.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 #include "AutomationLaneComponent.hpp"
 #include "core/AutomationInfo.hpp"
@@ -15,6 +16,11 @@ int laneHeightPx(const AutomationLaneInfo& lane, double verticalZoom) {
                             static_cast<int>(lane.height * verticalZoom) +
                             AutomationLaneComponent::RESIZE_HANDLE_HEIGHT)
                          : AutomationLaneComponent::HEADER_HEIGHT;
+}
+
+/** @brief The lane a header-button row belongs to. */
+AutomationLaneId laneIdOf(const std::unique_ptr<AutoLaneHeaderButtons>& entry) {
+    return entry->laneId;
 }
 
 }  // namespace
@@ -111,14 +117,12 @@ void MasterAutomationHeaderPanel::rebuildButtons() {
 
     // Drop orphans.
     std::erase_if(buttons_, [&](const std::unique_ptr<AutoLaneHeaderButtons>& entry) {
-        return std::find(wanted.begin(), wanted.end(), entry->laneId) == wanted.end();
+        return !std::ranges::contains(wanted, entry->laneId);
     });
 
     auto& manager = AutomationManager::getInstance();
     for (auto laneId : wanted) {
-        auto existing = std::find_if(
-            buttons_.begin(), buttons_.end(),
-            [&](const std::unique_ptr<AutoLaneHeaderButtons>& e) { return e->laneId == laneId; });
+        const auto existing = std::ranges::find(buttons_, laneId, laneIdOf);
         if (existing == buttons_.end())
             buttons_.push_back(makeAutoLaneHeaderButtons(laneId, *this));
     }
@@ -136,9 +140,7 @@ void MasterAutomationHeaderPanel::layoutButtons() {
         const auto* lane = manager.getLane(laneId);
         if (!lane)
             continue;
-        auto it = std::find_if(
-            buttons_.begin(), buttons_.end(),
-            [&](const std::unique_ptr<AutoLaneHeaderButtons>& e) { return e->laneId == laneId; });
+        const auto it = std::ranges::find(buttons_, laneId, laneIdOf);
         if (it != buttons_.end())
             layoutAutoLaneHeaderButtons(**it, *lane, y, getWidth(),
                                         AutomationLaneComponent::RESIZE_HANDLE_HEIGHT);

--- a/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
+++ b/magda/daw/ui/components/chain/drum_grid/PadChainPanel.cpp
@@ -2,6 +2,8 @@
 
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <algorithm>
+
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
 #include "audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
 #include "core/TrackManager.hpp"
@@ -76,8 +78,7 @@ void PadChainPanel::setCollapsedPlugins(const std::vector<tracktion::engine::Plu
     if (plugins.empty())
         return;
     for (auto& slot : slots_) {
-        if (slot->getPlugin() &&
-            std::find(plugins.begin(), plugins.end(), slot->getPlugin()) != plugins.end()) {
+        if (slot->getPlugin() && std::ranges::contains(plugins, slot->getPlugin())) {
             if (!slot->isCollapsed()) {
                 // Temporarily detach callback to avoid per-slot layout cascade
                 auto saved = std::move(slot->onLayoutChanged);
@@ -253,8 +254,7 @@ void PadChainPanel::rebuildSlots() {
             onSlotSetup(*slot, info);
 
         // Restore collapsed state from before rebuild
-        if (info.plugin && std::find(collapsedPlugins.begin(), collapsedPlugins.end(),
-                                     info.plugin) != collapsedPlugins.end()) {
+        if (info.plugin && std::ranges::contains(collapsedPlugins, info.plugin)) {
             slot->setCollapsed(true);
         }
 

--- a/magda/daw/ui/components/chain/layout/FaustDeviceLayout.cpp
+++ b/magda/daw/ui/components/chain/layout/FaustDeviceLayout.cpp
@@ -68,8 +68,7 @@ const std::vector<FaustDeviceLayout::GroupPage>& FaustDeviceLayout::pagesFor(
     for (int i = 0; i < static_cast<int>(device.parameters.size()); ++i) {
         const auto& param = device.parameters[static_cast<size_t>(i)];
         const auto name = param.group.isEmpty() ? juce::String("Params") : param.group;
-        auto it = std::find_if(groups.begin(), groups.end(),
-                               [&name](const Group& group) { return group.name == name; });
+        auto it = std::ranges::find(groups, name, &Group::name);
         if (it == groups.end())
             groups.push_back({name, {i}});
         else

--- a/magda/daw/ui/components/chain/slot/DeviceParameterChangeHandler.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceParameterChangeHandler.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 
 #include "audio/AudioBridge.hpp"
 #include "audio/plugins/compiled/CompiledFaustInterface.hpp"
@@ -140,13 +141,13 @@ void updateCurrentPageParameterSlotValue(const magda::DeviceInfo& device,
     // up changing whatever cell sits at grid index 14, which under the EQ
     // column-major mapping is a different band entirely).
     const auto& layout = paramGrid.getLayout();
-    const auto findIt = std::find_if(
-        device.parameters.begin(), device.parameters.end(),
-        [paramIndex](const magda::ParameterInfo& p) { return p.paramIndex == paramIndex; });
+    const auto findIt =
+        std::ranges::find(device.parameters, paramIndex, &magda::ParameterInfo::paramIndex);
     if (findIt == device.parameters.end())
         return;
 
-    const int paramArrayIndex = static_cast<int>(std::distance(device.parameters.begin(), findIt));
+    const int paramArrayIndex =
+        static_cast<int>(std::ranges::distance(device.parameters.begin(), findIt));
 
     for (int slotIndex = 0; slotIndex < paramsPerPage; ++slotIndex) {
         const auto cell = layout.cellFor(device, slotIndex, currentPage);

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -85,10 +85,11 @@ void layoutExpandedDeviceSlotHeader(juce::Rectangle<int>& headerArea,
             placeLeft(headerArea, spec.component, buttonSize);
     }
 
-    for (auto& spec : std::views::reverse(specs)) {
-        if (spec.side == HeaderControlSide::Right && spec.expandedVisible)
-            placeRight(headerArea, spec.component, buttonSize);
-    }
+    const auto placedRight = [](const auto& spec) {
+        return spec.side == HeaderControlSide::Right && spec.expandedVisible;
+    };
+    for (auto& spec : specs | std::views::reverse | std::views::filter(placedRight))
+        placeRight(headerArea, spec.component, buttonSize);
 }
 
 void layoutCollapsedDeviceSlotControls(juce::Rectangle<int>& area,

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -3,8 +3,10 @@
 #include <BinaryData.h>
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include <algorithm>
 #include <cmath>
 #include <numeric>
+#include <ranges>
 #include <unordered_set>
 
 #include "../../dialogs/AISettingsDialog.hpp"
@@ -740,6 +742,20 @@ ClipComponent::EffectiveFades ClipComponent::computeEffectiveFades(const ClipInf
             return ClipManager::effectiveFadesIn(previewLane, clipId_, tempo);
     }
     return ClipManager::getInstance().getEffectiveFades(clipId_, tempo);
+}
+
+std::vector<ClipId> ClipComponent::selectedClipsInTimelineOrder() const {
+    const auto& selected = SelectionManager::getInstance().getSelectedClips();
+    std::vector<ClipId> ordered(selected.begin(), selected.end());
+
+    auto& clipManager = ClipManager::getInstance();
+    const double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
+    const auto startSeconds = [&clipManager, tempo](ClipId id) {
+        const auto* clip = clipManager.getClip(id);
+        return clip != nullptr ? timelineStartSeconds(*clip, tempo) : 0.0;
+    };
+    std::ranges::sort(ordered, {}, startSeconds);
+    return ordered;
 }
 
 ClipId ClipComponent::findCrossfadeNeighbour(bool atStart) const {
@@ -3164,16 +3180,13 @@ namespace {
 /// Repaint only when the ranges actually moved: these are pushed on every lane
 /// update, most of which change nothing.
 bool sameRanges(const std::vector<BeatRange>& a, const std::vector<BeatRange>& b) {
-    if (a.size() != b.size())
-        return false;
-    constexpr double tolBeats = 1e-6;
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (std::abs(a[i].start.value - b[i].start.value) >= tolBeats ||
-            std::abs(a[i].end.value - b[i].end.value) >= tolBeats) {
-            return false;
-        }
-    }
-    return true;
+    const auto samePair = [](const auto& pair) {
+        constexpr double tolBeats = 1e-6;
+        const auto& [lhs, rhs] = pair;
+        return std::abs(lhs.start.value - rhs.start.value) < tolBeats &&
+               std::abs(lhs.end.value - rhs.end.value) < tolBeats;
+    };
+    return a.size() == b.size() && std::ranges::all_of(std::views::zip(a, b), samePair);
 }
 
 }  // namespace
@@ -3503,16 +3516,7 @@ void ClipComponent::showContextMenu() {
     // Join Clips (need 2+ adjacent clips on same track)
     bool canJoin = false;
     if (selectionManager.getSelectedClipCount() >= 2) {
-        auto selected = selectionManager.getSelectedClips();
-        std::vector<ClipId> sorted(selected.begin(), selected.end());
-        std::sort(sorted.begin(), sorted.end(), [&](ClipId a, ClipId b) {
-            auto* ca = clipManager.getClip(a);
-            auto* cb = clipManager.getClip(b);
-            if (!ca || !cb)
-                return false;
-            const double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
-            return timelineStartSeconds(*ca, tempo) < timelineStartSeconds(*cb, tempo);
-        });
+        const auto sorted = selectedClipsInTimelineOrder();
         canJoin = true;
         for (size_t i = 1; i < sorted.size() && canJoin; ++i) {
             JoinClipsCommand testCmd(sorted[i - 1], sorted[i]);
@@ -4149,17 +4153,8 @@ void ClipComponent::showContextMenu() {
             }
 
             case 8: {  // Join Clips
-                auto selectedClips = selectionManager.getSelectedClips();
-                if (selectedClips.size() >= 2) {
-                    std::vector<ClipId> sorted(selectedClips.begin(), selectedClips.end());
-                    std::sort(sorted.begin(), sorted.end(), [&](ClipId a, ClipId b) {
-                        auto* ca = clipManager.getClip(a);
-                        auto* cb = clipManager.getClip(b);
-                        if (!ca || !cb)
-                            return false;
-                        const double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
-                        return timelineStartSeconds(*ca, tempo) < timelineStartSeconds(*cb, tempo);
-                    });
+                if (selectionManager.getSelectedClipCount() >= 2) {
+                    const auto sorted = selectedClipsInTimelineOrder();
 
                     if (sorted.size() > 2)
                         UndoManager::getInstance().beginCompoundOperation("Join Clips");

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -263,6 +263,10 @@ class ClipComponent : public juce::Component,
     // (next) that a crossfade could be created with. INVALID_CLIP_ID if none.
     ClipId findCrossfadeNeighbour(bool atStart) const;
 
+    /// The selected clips ordered by where they start, which is the order Join
+    /// consumes them in.
+    std::vector<ClipId> selectedClipsInTimelineOrder() const;
+
     // Painting helpers
     /// The clip's background, translucent where a clip below it is still heard.
     void paintClipBody(juce::Graphics& g, juce::Rectangle<int> bounds, juce::Colour bgColour,

--- a/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
+++ b/magda/daw/ui/components/common/curve/CurveEditorBase.cpp
@@ -1077,9 +1077,10 @@ void CurveEditorBase::updateTensionHandlePositions() {
         const auto& p2 = *points[i + 1];
 
         if (p1.curveType == CurveType::Linear || p1.curveType == CurveType::HardCorner) {
-            auto handleIt =
-                std::find_if(tensionHandles_.begin(), tensionHandles_.end(),
-                             [&p1](const auto& handle) { return handle->getPointId() == p1.id; });
+            const auto isHandleForPoint = [&p1](const auto& handle) {
+                return handle->getPointId() == p1.id;
+            };
+            const auto handleIt = std::ranges::find_if(tensionHandles_, isHandleForPoint);
             if (handleIt == tensionHandles_.end())
                 continue;
             auto& handle = **handleIt;

--- a/magda/daw/ui/components/common/curve/CurveRenderOrder.hpp
+++ b/magda/daw/ui/components/common/curve/CurveRenderOrder.hpp
@@ -16,10 +16,8 @@ std::vector<const CurvePoint*> getCurveRenderOrder(const std::vector<CurvePoint>
         ordered.push_back(&point);
 
     if (previewActive) {
-        std::stable_sort(ordered.begin(), ordered.end(),
-                         [&effectiveX](const auto* a, const auto* b) {
-                             return effectiveX(*a) < effectiveX(*b);
-                         });
+        const auto xOf = [&effectiveX](const CurvePoint* point) { return effectiveX(*point); };
+        std::ranges::stable_sort(ordered, {}, xOf);
     }
 
     return ordered;

--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -112,7 +112,7 @@ inline void populateAudioInputOptions(RoutingSelector* selector, juce::AudioIODe
         for (const auto& t : allTracks) {
             if (t.id == currentTrackId)
                 continue;
-            if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
+            if (std::ranges::contains(descendants, t.id))
                 continue;
             if (trackManager.wouldCreateInputRoutingCycle(currentTrackId, t.id))
                 continue;
@@ -165,7 +165,7 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
         int id = 200;
         for (const auto& t : allTracks) {
             if (t.type == TrackType::Group && t.id != currentTrackId) {
-                if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
+                if (std::ranges::contains(descendants, t.id))
                     continue;
                 groupOptions.push_back({id++, t.name});
             }
@@ -212,7 +212,7 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
             // Hide source track from its own multi-out tracks
             if (t.id == multiOutSourceId)
                 continue;
-            if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
+            if (std::ranges::contains(descendants, t.id))
                 continue;
             trackOptions.push_back({id++, t.name});
         }
@@ -312,7 +312,7 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
         int id = 200;
         for (const auto& t : allTracks) {
             if (t.type == TrackType::Group && t.id != currentTrackId) {
-                if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
+                if (std::ranges::contains(descendants, t.id))
                     continue;
                 outTrackMapping[id++] = t.id;
             }
@@ -326,7 +326,7 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
         id = 400;
         for (const auto& t : allTracks) {
             if (t.type == TrackType::Media && t.id != currentTrackId) {
-                if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
+                if (std::ranges::contains(descendants, t.id))
                     continue;
                 outTrackMapping[id++] = t.id;
             }

--- a/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
@@ -284,8 +284,7 @@ void CCLaneComponent::updatePointsCache() const {
         }
     }
 
-    // Sort by x position
-    std::sort(cachedPoints_.begin(), cachedPoints_.end());
+    std::ranges::sort(cachedPoints_, {}, &CurvePoint::x);
 
     pointsCacheDirty_ = false;
 }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -153,9 +153,7 @@ void PianoRollGridComponent::paint(juce::Graphics& g) {
         if (!selectedRegions.empty()) {
             g.setColour(DarkTheme::getColour(DarkTheme::TEXT_DARK).withAlpha(0x20 / 255.0f));
             int prevEnd = bounds.getX();
-            // Sort by startX
-            std::sort(selectedRegions.begin(), selectedRegions.end(),
-                      [](const ClipRegion& a, const ClipRegion& b) { return a.startX < b.startX; });
+            std::ranges::sort(selectedRegions, {}, &ClipRegion::startX);
             for (const auto& region : selectedRegions) {
                 if (region.startX > prevEnd) {
                     g.fillRect(prevEnd, 0, region.startX - prevEnd, getHeight());
@@ -1023,7 +1021,7 @@ void PianoRollGridComponent::adjustVelocityForNote(ClipId clipId, size_t noteInd
     // A note that is part of the current selection scales the whole selection;
     // an unselected note is edited on its own without disturbing the selection.
     std::vector<size_t> targets = selectedNoteIndicesForClip(clipId);
-    if (std::find(targets.begin(), targets.end(), noteIndex) == targets.end())
+    if (!std::ranges::contains(targets, noteIndex))
         targets = {noteIndex};
     adjustMidiNoteVelocities(clipId, targets, velocityDelta);
     flashVelocityReadout(clipId, noteIndex);
@@ -1853,8 +1851,7 @@ void PianoRollGridComponent::clipPropertyChanged(ClipId clipId) {
     // track's clip changes
     if (!overlayTrackIds_.empty()) {
         const auto* clip = ClipManager::getInstance().getClip(clipId);
-        if (clip && std::find(overlayTrackIds_.begin(), overlayTrackIds_.end(), clip->trackId) !=
-                        overlayTrackIds_.end()) {
+        if (clip && std::ranges::contains(overlayTrackIds_, clip->trackId)) {
             repaint();
         }
     }
@@ -2599,8 +2596,7 @@ juce::Colour PianoRollGridComponent::getColourForClip(ClipId clipId) const {
 }
 
 bool PianoRollGridComponent::isClipSelected(ClipId clipId) const {
-    return std::find(selectedClipIds_.begin(), selectedClipIds_.end(), clipId) !=
-           selectedClipIds_.end();
+    return std::ranges::contains(selectedClipIds_, clipId);
 }
 
 void PianoRollGridComponent::setLoopRegion(double offsetBeats, double lengthBeats, bool enabled) {
@@ -3320,8 +3316,8 @@ void PianoRollGridComponent::commitExpressionEdit() {
         return;
 
     auto points = expressionWorkingPoints_;
-    std::sort(points.begin(), points.end(),
-              [](const auto& a, const auto& b) { return a.beat < b.beat; });
+    const auto beatOf = [](const auto& point) { return point.beat; };
+    std::ranges::sort(points, {}, beatOf);
 
     onPitchExpressionChanged(expressionClipId_, expressionNoteIndex_, std::move(points));
 }

--- a/magda/daw/ui/components/pianoroll/PitchFoldMap.cpp
+++ b/magda/daw/ui/components/pianoroll/PitchFoldMap.cpp
@@ -17,7 +17,7 @@ void PitchFoldMap::rebuild(const std::vector<int>& usedPitches) {
         if (p >= kMinNote && p <= kMaxNote)
             rowsDescending_.push_back(p);
     }
-    std::sort(rowsDescending_.begin(), rowsDescending_.end(), std::greater<>());
+    std::ranges::sort(rowsDescending_, std::ranges::greater{});
     rowsDescending_.erase(std::unique(rowsDescending_.begin(), rowsDescending_.end()),
                           rowsDescending_.end());
 

--- a/magda/daw/ui/components/pianoroll/VelocityLaneComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/VelocityLaneComponent.cpp
@@ -1,5 +1,7 @@
 #include "VelocityLaneComponent.hpp"
 
+#include <algorithm>
+
 #include "../../state/TimelineController.hpp"
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
@@ -149,8 +151,7 @@ size_t VelocityLaneComponent::findNoteAtX(int x) const {
             bestIndex = i;
         } else if (dist == bestDist && bestIndex != SIZE_MAX) {
             // Prefer selected notes when equidistant
-            if (std::find(selectedNoteIndices_.begin(), selectedNoteIndices_.end(), i) !=
-                selectedNoteIndices_.end()) {
+            if (std::ranges::contains(selectedNoteIndices_, i)) {
                 bestIndex = i;
             }
         }
@@ -402,9 +403,7 @@ void VelocityLaneComponent::paint(juce::Graphics& g) {
 
             // Draw circle on top — selected notes are larger and brighter
             bool isBeingDragged = isDragging_ && isPrimaryClip && i == draggingNoteIndex_;
-            bool isSelected =
-                isPrimaryClip && std::find(selectedNoteIndices_.begin(), selectedNoteIndices_.end(),
-                                           i) != selectedNoteIndices_.end();
+            bool isSelected = isPrimaryClip && std::ranges::contains(selectedNoteIndices_, i);
             float radius = isSelected ? 4.5f : circleRadius;
             auto circleColour = isBeingDragged ? noteColour.brighter(0.5f)
                                 : isSelected   ? noteColour.brighter(0.3f)
@@ -510,10 +509,10 @@ void VelocityLaneComponent::mouseDown(const juce::MouseEvent& e) {
             }
             if (sortedSelectedIndices_.size() < 2)
                 return;
-            std::sort(sortedSelectedIndices_.begin(), sortedSelectedIndices_.end(),
-                      [&clip](size_t a, size_t b) {
-                          return clip->midiNotes[a].startBeat < clip->midiNotes[b].startBeat;
-                      });
+            const auto startBeatOf = [&clip](size_t index) {
+                return clip->midiNotes[index].startBeat;
+            };
+            std::ranges::sort(sortedSelectedIndices_, {}, startBeatOf);
 
             isRampDragging_ = true;
             isCurveHandleVisible_ = false;
@@ -545,9 +544,7 @@ void VelocityLaneComponent::mouseDown(const juce::MouseEvent& e) {
 
             // B5: Store starting velocities of all selected notes
             selectionDragStartVelocities_.clear();
-            bool noteIsSelected =
-                std::find(selectedNoteIndices_.begin(), selectedNoteIndices_.end(), noteIndex) !=
-                selectedNoteIndices_.end();
+            bool noteIsSelected = std::ranges::contains(selectedNoteIndices_, noteIndex);
             if (noteIsSelected && selectedNoteIndices_.size() > 1) {
                 for (size_t idx : selectedNoteIndices_) {
                     if (idx < clip->midiNotes.size()) {

--- a/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
+++ b/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
@@ -197,8 +197,7 @@ int MarkerLaneComponent::markerAt(juce::Point<int> point) const {
 }
 
 const TimelineMarker* MarkerLaneComponent::findMarker(int markerId) const {
-    auto it = std::find_if(markers_.begin(), markers_.end(),
-                           [&](const TimelineMarker& marker) { return marker.id == markerId; });
+    const auto it = std::ranges::find(markers_, markerId, &TimelineMarker::id);
     return it != markers_.end() ? &*it : nullptr;
 }
 
@@ -292,10 +291,10 @@ void MarkerLaneComponent::showLaneMenu(juce::Point<int> screenPosition) {
     const auto& state = controller->getState();
     const double playheadBeats = state.playhead.getCurrentPositionBeats();
     constexpr double kSamePositionEpsilon = 1e-6;
-    const bool markerAtPlayhead =
-        std::any_of(state.markers.begin(), state.markers.end(), [&](const TimelineMarker& m) {
-            return std::abs(m.positionBeats - playheadBeats) <= kSamePositionEpsilon;
-        });
+    const auto sitsAtPlayhead = [playheadBeats](const TimelineMarker& marker) {
+        return std::abs(marker.positionBeats - playheadBeats) <= kSamePositionEpsilon;
+    };
+    const bool markerAtPlayhead = std::ranges::any_of(state.markers, sitsAtPlayhead);
     if (markerAtPlayhead)
         return;
 

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <tuple>
 
 #include "../../interaction/ArrangementHitTester.hpp"
 #include "../../panels/state/PanelController.hpp"
@@ -190,13 +191,13 @@ void TrackContentPanel::viewModeChanged(ViewMode mode, const AudioEngineProfile&
 std::vector<ClipInfo> TrackContentPanel::previewLaneClips(TrackId trackId) const {
     auto& clipManager = ClipManager::getInstance();
 
-    const bool laneIsDragging =
-        std::any_of(clipComponents_.begin(), clipComponents_.end(), [&](const auto& comp) {
-            if (!comp->isCurrentlyDragging())
-                return false;
-            const auto* clip = clipManager.getClip(comp->getClipId());
-            return clip != nullptr && clip->trackId == trackId;
-        });
+    const auto isDraggingFromThisLane = [&](const auto& comp) {
+        if (!comp->isCurrentlyDragging())
+            return false;
+        const auto* clip = clipManager.getClip(comp->getClipId());
+        return clip != nullptr && clip->trackId == trackId;
+    };
+    const bool laneIsDragging = std::ranges::any_of(clipComponents_, isDraggingFromThisLane);
     if (!laneIsDragging)
         return {};
 
@@ -1143,7 +1144,7 @@ bool TrackContentPanel::tryBeginTimeSelectionGrab(const juce::MouseEvent& event)
         originalClipsInSelection_.clear();
         const auto& clips = ClipManager::getInstance().getArrangementClips();
         for (const auto& clip : clips) {
-            auto it = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), clip.trackId);
+            auto it = std::ranges::find(visibleTrackIds_, clip.trackId);
             if (it == visibleTrackIds_.end())
                 continue;
 
@@ -2444,18 +2445,15 @@ void TrackContentPanel::rebuildClipComponents() {
     // level, which keeps a later clip above the one it crossfades into (#1499)
     // instead of following hash-map iteration order.
     auto clips = ClipManager::getInstance().getArrangementClips();
-    std::sort(clips.begin(), clips.end(), [](const ClipInfo& a, const ClipInfo& b) {
-        if (a.stackOrder != b.stackOrder)
-            return a.stackOrder < b.stackOrder;
-        if (a.placement.startBeat != b.placement.startBeat)
-            return a.placement.startBeat < b.placement.startBeat;
-        return a.id < b.id;
-    });
+    const auto stackThenStart = [](const ClipInfo& clip) {
+        return std::tuple{clip.stackOrder, clip.placement.startBeat, clip.id};
+    };
+    std::ranges::sort(clips, {}, stackThenStart);
 
     // Create a component for each clip that belongs to a visible track
     for (const auto& clip : clips) {
         // Check if clip's track is visible
-        auto it = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), clip.trackId);
+        auto it = std::ranges::find(visibleTrackIds_, clip.trackId);
         if (it == visibleTrackIds_.end()) {
             continue;  // Track not visible
         }
@@ -2656,7 +2654,7 @@ void TrackContentPanel::updateClipComponentPositions() {
         }
 
         // Find the track index
-        auto it = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), clip->trackId);
+        auto it = std::ranges::find(visibleTrackIds_, clip->trackId);
         if (it == visibleTrackIds_.end()) {
             clipComp->setVisible(false);
             continue;
@@ -3106,7 +3104,7 @@ bool TrackContentPanel::isAutomationLaneVisible(TrackId trackId, AutomationLaneI
     auto it = visibleAutomationLanes_.find(trackId);
     if (it != visibleAutomationLanes_.end()) {
         const auto& lanes = it->second;
-        return std::find(lanes.begin(), lanes.end(), laneId) != lanes.end();
+        return std::ranges::contains(lanes, laneId);
     }
     return false;
 }
@@ -3132,7 +3130,7 @@ bool TrackContentPanel::getAutomationLaneStripAtY(int y, int& trackIndex,
         if (y < bounds.getY() || y >= bounds.getY() + AutomationLaneComponent::HEADER_HEIGHT)
             continue;
 
-        auto trackIt = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), entry.trackId);
+        auto trackIt = std::ranges::find(visibleTrackIds_, entry.trackId);
         if (trackIt == visibleTrackIds_.end())
             return false;
 
@@ -3226,7 +3224,7 @@ void TrackContentPanel::rebuildAutomationLaneComponents() {
                 if (!onAutomationTimeSelectionBeatsChanged || tempoBPM <= 0.0)
                     return;
 
-                auto trackIt = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), trackId);
+                auto trackIt = std::ranges::find(visibleTrackIds_, trackId);
                 if (trackIt == visibleTrackIds_.end())
                     return;
 

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -204,7 +204,7 @@ void TrackContentPanel::endClipDragTargets() {
 }
 
 int TrackContentPanel::clipDragSlotOfTrack(TrackId trackId) const {
-    const auto it = std::find(clipDragHostTrackIds_.begin(), clipDragHostTrackIds_.end(), trackId);
+    const auto it = std::ranges::find(clipDragHostTrackIds_, trackId);
     if (it == clipDragHostTrackIds_.end())
         return -1;
     return static_cast<int>(std::distance(clipDragHostTrackIds_.begin(), it));
@@ -327,7 +327,7 @@ void TrackContentPanel::startMultiClipDrag(ClipId anchorClipId, const juce::Poin
             info.originalTrackId = clip->trackId;
 
             // Find track index
-            auto it = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), clip->trackId);
+            auto it = std::ranges::find(visibleTrackIds_, clip->trackId);
             if (it != visibleTrackIds_.end()) {
                 info.originalTrackIndex =
                     static_cast<int>(std::distance(visibleTrackIds_.begin(), it));
@@ -603,7 +603,7 @@ bool isOnFrozenTrack(ClipId clipId) {
 }
 
 bool anyClipOnFrozenTrack(const std::vector<ClipId>& clips) {
-    return std::any_of(clips.begin(), clips.end(), isOnFrozenTrack);
+    return std::ranges::any_of(clips, isOnFrozenTrack);
 }
 
 }  // namespace
@@ -664,14 +664,14 @@ bool TrackContentPanel::nudgeSelectedClipsHorizontally(int direction) {
     // it, with the surviving clip decided by unordered_set iteration order.
     // Moving the far clip first keeps the path clear.
     std::vector<ClipId> ordered = clips;
-    std::sort(ordered.begin(), ordered.end(), [&](ClipId lhs, ClipId rhs) {
-        const auto* a = clipManager.getClip(lhs);
-        const auto* b = clipManager.getClip(rhs);
-        if (a == nullptr || b == nullptr)
-            return false;
-        return direction > 0 ? a->placement.startBeat > b->placement.startBeat
-                             : a->placement.startBeat < b->placement.startBeat;
-    });
+    const auto startBeatOf = [&clipManager](ClipId id) {
+        const auto* clip = clipManager.getClip(id);
+        return clip != nullptr ? clip->placement.startBeat : 0.0;
+    };
+    if (direction > 0)
+        std::ranges::sort(ordered, std::ranges::greater{}, startBeatOf);
+    else
+        std::ranges::sort(ordered, {}, startBeatOf);
 
     // Always compound, even for one clip: consecutive MoveClipCommands on the
     // same clip merge into a single history entry, which would fold a run of
@@ -736,7 +736,7 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
         const auto* clip = clipManager.getClip(clipId);
         if (clip == nullptr)
             continue;
-        auto it = std::find(hostTrackIds.begin(), hostTrackIds.end(), clip->trackId);
+        auto it = std::ranges::find(hostTrackIds, clip->trackId);
         if (it == hostTrackIds.end())
             return false;  // e.g. a chord clip: the selection moves whole or not at all
 
@@ -761,9 +761,11 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
     // Same back-to-front rule as the horizontal path: landing on a track a
     // still-unmoved selected clip occupies would let overlap resolution trim
     // or delete that clip. Vacate the far track first.
-    std::sort(moves.begin(), moves.end(), [direction](const auto& lhs, const auto& rhs) {
-        return direction > 0 ? lhs.trackIndex > rhs.trackIndex : lhs.trackIndex < rhs.trackIndex;
-    });
+    const auto trackIndexOf = [](const auto& move) { return move.trackIndex; };
+    if (direction > 0)
+        std::ranges::sort(moves, std::ranges::greater{}, trackIndexOf);
+    else
+        std::ranges::sort(moves, {}, trackIndexOf);
 
     CompoundOperationScope undoScope("Move Clips to Track");
     for (const auto& move : moves) {
@@ -801,7 +803,7 @@ void TrackContentPanel::splitClipsAtSelectionBoundaries() {
     std::vector<SplitInfo> clipsToSplit;
 
     for (const auto& clip : clips) {
-        auto it = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), clip.trackId);
+        auto it = std::ranges::find(visibleTrackIds_, clip.trackId);
         if (it == visibleTrackIds_.end())
             continue;
 
@@ -877,7 +879,7 @@ void TrackContentPanel::captureClipsInTimeSelection() {
 
     for (const auto& clip : clips) {
         // Check if clip's track is in the selection
-        auto it = std::find(visibleTrackIds_.begin(), visibleTrackIds_.end(), clip.trackId);
+        auto it = std::ranges::find(visibleTrackIds_, clip.trackId);
         if (it == visibleTrackIds_.end()) {
             continue;  // Track not visible
         }

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -2914,7 +2914,7 @@ void TrackHeadersPanel::showContextMenu(int trackIndex, juce::Point<int> positio
             // Don't allow moving a group into its own descendants
             if (track->isGroup()) {
                 auto descendants = trackManager.getAllDescendants(header.trackId);
-                if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
+                if (std::ranges::contains(descendants, t.id))
                     continue;
             }
             moveToGroupMenu.addItem(MoveToGroupBase + t.id, t.name);
@@ -2957,7 +2957,7 @@ void TrackHeadersPanel::showContextMenu(int trackIndex, juce::Point<int> positio
             for (const auto& t : allTracks) {
                 if (t.type != type || t.id == track->id || t.type == TrackType::Master)
                     continue;
-                if (std::find(descendants.begin(), descendants.end(), t.id) != descendants.end())
+                if (std::ranges::contains(descendants, t.id))
                     continue;
 
                 bool alreadyConnected = false;
@@ -3268,7 +3268,7 @@ bool TrackHeadersPanel::canDropIntoGroup(int draggedIndex, int targetGroupIndex)
         auto& trackManager = TrackManager::getInstance();
         auto descendants = trackManager.getAllDescendants(draggedHeader.trackId);
         TrackId targetId = trackHeaders[targetGroupIndex]->trackId;
-        if (std::find(descendants.begin(), descendants.end(), targetId) != descendants.end()) {
+        if (std::ranges::contains(descendants, targetId)) {
             return false;
         }
     }
@@ -3291,7 +3291,7 @@ void TrackHeadersPanel::executeDrop() {
     if (isMultiDrag) {
         // Collect selected track IDs in display order (ascending index)
         std::vector<int> sortedIndices(selectedTrackIndices_.begin(), selectedTrackIndices_.end());
-        std::sort(sortedIndices.begin(), sortedIndices.end());
+        std::ranges::sort(sortedIndices);
         for (int idx : sortedIndices) {
             if (idx >= 0 && idx < static_cast<int>(trackHeaders.size()))
                 tracksToMove.push_back(trackHeaders[idx]->trackId);
@@ -3363,9 +3363,9 @@ void TrackHeadersPanel::executeDrop() {
                 // moving selection, the drop lands inside the block being moved.
                 // Reordering relative to a sibling that is also about to move
                 // scrambles the order, so treat it as a no-op.
-                const bool dropInsideSelection = dropBeforeTrackId != INVALID_TRACK_ID &&
-                                                 std::find(tracksToMove.begin(), tracksToMove.end(),
-                                                           dropBeforeTrackId) != tracksToMove.end();
+                const bool dropInsideSelection =
+                    dropBeforeTrackId != INVALID_TRACK_ID &&
+                    std::ranges::contains(tracksToMove, dropBeforeTrackId);
                 if (dropInsideSelection)
                     continue;
 

--- a/magda/daw/ui/components/waveform/WarpedWaveformRenderer.hpp
+++ b/magda/daw/ui/components/waveform/WarpedWaveformRenderer.hpp
@@ -49,8 +49,7 @@ inline void drawWarpedWaveform(juce::Graphics& g, magda::AudioThumbnailManager& 
     if (markers.size() < 2 || !spec.warpToPixelX || spec.clipArea.isEmpty())
         return;
 
-    std::sort(markers.begin(), markers.end(),
-              [](const auto& a, const auto& b) { return a.warpTime < b.warpTime; });
+    std::ranges::sort(markers, {}, &magda::WarpMarkerInfo::warpTime);
 
     const double leftX = spec.clipArea.getX();
     const double rightX = spec.clipArea.getRight();

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -1256,7 +1256,7 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
                 for (const auto& m : warpMarkers_) {
                     sorted.emplace_back(m.warpTime, m.sourceTime);
                 }
-                std::sort(sorted.begin(), sorted.end());
+                std::ranges::sort(sorted);
 
                 // Find the two markers that span our warpTime
                 for (size_t i = 0; i + 1 < sorted.size(); ++i) {

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -2,7 +2,9 @@
 
 #include <juce_llm/juce_llm.h>
 
+#include <algorithm>
 #include <array>
+#include <ranges>
 #include <utility>
 
 #include "../../../agents/llama_model_manager.hpp"
@@ -372,6 +374,14 @@ class AISettingsDialog::CloudPage : public juce::Component {
         }
     };
 
+    /** @brief The registered-list row for a provider, or entries_.end(). */
+    auto findListEntry(const std::string& providerId) {
+        const auto isForProvider = [&providerId](const ListEntry& entry) {
+            return entry.providerId == providerId;
+        };
+        return std::ranges::find_if(entries_, isForProvider);
+    }
+
     std::string getSelectedProviderId() const {
         int idx = providerCombo_.getSelectedId() - 1;
         const auto& providers = getKnownProviders();
@@ -393,19 +403,12 @@ class AISettingsDialog::CloudPage : public juce::Component {
         // Store credential
         credentials_[providerId] = key;
 
-        // Check if already in list, update; otherwise add
-        bool found = false;
-        for (auto& entry : entries_) {
-            if (entry.providerId == providerId) {
-                entry.statusLabel->setText("Updated", juce::dontSendNotification);
-                entry.statusLabel->setColour(juce::Label::textColourId, juce::Colours::yellow);
-                found = true;
-                break;
-            }
-        }
-
-        if (!found)
+        if (auto entry = findListEntry(providerId); entry != entries_.end()) {
+            entry->statusLabel->setText("Updated", juce::dontSendNotification);
+            entry->statusLabel->setColour(juce::Label::textColourId, juce::Colours::yellow);
+        } else {
             addListEntry(providerId);
+        }
 
         keyEditor_.clear();
         statusLabel_.setText("Added", juce::dontSendNotification);
@@ -417,17 +420,13 @@ class AISettingsDialog::CloudPage : public juce::Component {
     void removeProvider(const std::string& providerId) {
         credentials_.erase(providerId);
 
-        // Remove list entry
-        for (auto it = entries_.begin(); it != entries_.end(); ++it) {
-            if (it->providerId == providerId) {
-                listContainer_.removeChildComponent(it->iconComp);
-                listContainer_.removeChildComponent(it->nameLabel);
-                listContainer_.removeChildComponent(it->statusLabel);
-                listContainer_.removeChildComponent(it->removeBtn);
-                entries_.erase(it);
-                updateProviderComboState();
-                break;
-            }
+        if (auto entry = findListEntry(providerId); entry != entries_.end()) {
+            listContainer_.removeChildComponent(entry->iconComp);
+            listContainer_.removeChildComponent(entry->nameLabel);
+            listContainer_.removeChildComponent(entry->statusLabel);
+            listContainer_.removeChildComponent(entry->removeBtn);
+            entries_.erase(entry);
+            updateProviderComboState();
         }
 
         resized();
@@ -490,12 +489,12 @@ class AISettingsDialog::CloudPage : public juce::Component {
         // If current selection is disabled, select the first enabled one
         auto selectedId = providerCombo_.getSelectedId();
         if (selectedId > 0 && !providerCombo_.isItemEnabled(selectedId)) {
-            for (int i = 0; i < static_cast<int>(providers.size()); ++i) {
-                if (providerCombo_.isItemEnabled(i + 1)) {
-                    providerCombo_.setSelectedId(i + 1, juce::dontSendNotification);
-                    break;
-                }
-            }
+            const auto isEnabled = [this](int itemId) {
+                return providerCombo_.isItemEnabled(itemId);
+            };
+            const auto itemIds = std::views::iota(1, static_cast<int>(providers.size()) + 1);
+            if (const auto first = std::ranges::find_if(itemIds, isEnabled); first != itemIds.end())
+                providerCombo_.setSelectedId(*first, juce::dontSendNotification);
         }
     }
 

--- a/magda/daw/ui/dialogs/ControllersDialog.cpp
+++ b/magda/daw/ui/dialogs/ControllersDialog.cpp
@@ -794,8 +794,7 @@ class LuaScriptsPage : public juce::Component {
                                auto& cfg = magda::Config::getInstance();
                                auto enabled = cfg.getEnabledFactoryLuaScripts();
                                const auto name = availableCopy[idx].getFileName().toStdString();
-                               if (std::find(enabled.begin(), enabled.end(), name) ==
-                                   enabled.end()) {
+                               if (!std::ranges::contains(enabled, name)) {
                                    enabled.push_back(name);
                                    cfg.setEnabledFactoryLuaScripts(std::move(enabled));
                                    cfg.save();

--- a/magda/daw/ui/dialogs/PluginSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/PluginSettingsDialog.cpp
@@ -420,7 +420,7 @@ PluginSettingsDialog::PluginSettingsDialog(AudioEngine* engine)
             if (idx >= 0 && idx < static_cast<int>(excludedPlugins_.size()))
                 indices.push_back(idx);
         }
-        std::sort(indices.rbegin(), indices.rend());
+        std::ranges::sort(indices, std::ranges::greater{});
         for (int idx : indices) {
             excludedPlugins_.erase(excludedPlugins_.begin() + idx);
         }

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <string>
 #include <thread>
+#include <tuple>
 
 #include "../../../../agents/agent_tool_bridge.hpp"
 #include "../../../../agents/automation_agent.hpp"
@@ -1293,8 +1294,8 @@ juce::String AIChatConsoleContent::resolveAliases(const juce::String& text) {
     // Sort by alias length descending to avoid prefix collisions
     // (e.g. @pro matching inside @pro_q_3)
     auto sorted = allAliases_;
-    std::sort(sorted.begin(), sorted.end(),
-              [](const auto& a, const auto& b) { return a.alias.length() > b.alias.length(); });
+    const auto aliasLength = [](const AliasEntry& entry) { return entry.alias.length(); };
+    std::ranges::sort(sorted, std::ranges::greater{}, aliasLength);
 
     // Convert @alias to <alias> token format for the LLM — resolved at DSL execution time
     auto resolved = text;
@@ -2034,17 +2035,15 @@ std::vector<magda::ClipId> getSelectedDrummerContextClipIds() {
             ids.push_back(clipId);
     }
 
-    std::sort(ids.begin(), ids.end(), [](auto a, auto b) {
+    const auto inArrangementOrder = [](magda::ClipId a, magda::ClipId b) {
         const auto* clipA = magda::ClipManager::getInstance().getClip(a);
         const auto* clipB = magda::ClipManager::getInstance().getClip(b);
         if (clipA == nullptr || clipB == nullptr)
             return a < b;
-        if (clipA->trackId != clipB->trackId)
-            return clipA->trackId < clipB->trackId;
-        if (clipA->placement.startBeat != clipB->placement.startBeat)
-            return clipA->placement.startBeat < clipB->placement.startBeat;
-        return a < b;
-    });
+        return std::tuple{clipA->trackId, clipA->placement.startBeat, a} <
+               std::tuple{clipB->trackId, clipB->placement.startBeat, b};
+    };
+    std::ranges::sort(ids, inArrangementOrder);
 
     return ids;
 }
@@ -2196,9 +2195,10 @@ void AIChatConsoleContent::toggleMidiContextTrack(magda::TrackId trackId) {
     if (midiClipIds.empty())
         return;
 
-    const bool allSelected =
-        std::all_of(midiClipIds.begin(), midiClipIds.end(),
-                    [this](auto clipId) { return midiContextClipIds_.contains(clipId); });
+    const auto isInMidiContext = [this](magda::ClipId clipId) {
+        return midiContextClipIds_.contains(clipId);
+    };
+    const bool allSelected = std::ranges::all_of(midiClipIds, isInMidiContext);
     for (auto clipId : midiClipIds) {
         if (allSelected)
             midiContextClipIds_.erase(clipId);
@@ -2485,9 +2485,7 @@ void AIChatConsoleContent::buildAliasList() {
         DBG("AIChatConsole: failed to load plugin aliases: " << e.what());
     }
 
-    // Sort by alias
-    std::sort(allAliases_.begin(), allAliases_.end(),
-              [](const AliasEntry& a, const AliasEntry& b) { return a.alias < b.alias; });
+    std::ranges::sort(allAliases_, {}, &AliasEntry::alias);
 }
 
 void AIChatConsoleContent::showAutocomplete(const juce::String& filter) {
@@ -2552,9 +2550,7 @@ std::vector<AIChatConsoleContent::ParamAliasEntry> AIChatConsoleContent::collect
     walk(magda::AliasLayer::Curated);
     walk(magda::AliasLayer::AutoGen);
 
-    std::sort(out.begin(), out.end(), [](const ParamAliasEntry& a, const ParamAliasEntry& b) {
-        return a.paramAlias < b.paramAlias;
-    });
+    std::ranges::sort(out, {}, &ParamAliasEntry::paramAlias);
     return out;
 }
 

--- a/magda/daw/ui/panels/content/ChordClipContent.cpp
+++ b/magda/daw/ui/panels/content/ChordClipContent.cpp
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <memory>
+#include <ranges>
 #include <vector>
 
 #include "../../state/TimelineController.hpp"
@@ -98,6 +100,24 @@ std::pair<int, int> partsFromQuality(ChordQuality q) {
             if (t[static_cast<size_t>(b)][static_cast<size_t>(e)].quality == q)
                 return {b, e};
     return {0, 0};
+}
+
+/** @brief A predicate matching the notes linked to a chord group; group 0 links none. */
+auto isInChordGroup(int group) {
+    return [group](const magda::MidiNote& note) { return group != 0 && note.chordGroup == group; };
+}
+
+/** @brief A chord group's note indices, highest first so deleting keeps them valid. */
+std::vector<size_t> noteIndicesInChordGroup(const magda::ClipInfo& clip, int group) {
+    const auto isInGroup = [&clip, group](size_t i) {
+        return isInChordGroup(group)(clip.midiNotes[i]);
+    };
+    std::vector<size_t> indices;
+    std::ranges::copy(std::views::iota(size_t{0}, clip.midiNotes.size()) |
+                          std::views::filter(isInGroup),
+                      std::back_inserter(indices));
+    std::ranges::reverse(indices);
+    return indices;
 }
 
 /// Root / base-quality / extension / octave / inversion editor (CallOutBox).
@@ -432,11 +452,15 @@ bool ChordClipContent::keyPressed(const juce::KeyPress& key) {
         selectedGroup_ != 0) {
         const auto* clip = magda::ClipManager::getInstance().getClip(getEditingClipId());
         if (clip != nullptr) {
-            for (int i = 0; i < static_cast<int>(clip->chordAnnotations.size()); ++i)
-                if (clip->chordAnnotations[static_cast<size_t>(i)].chordGroup == selectedGroup_) {
-                    deleteChord(i);
-                    return true;
-                }
+            const auto isSelectedGroup = [this](const magda::ClipInfo::ChordAnnotation& ann) {
+                return ann.chordGroup == selectedGroup_;
+            };
+            const auto& annotations = clip->chordAnnotations;
+            if (const auto it = std::ranges::find_if(annotations, isSelectedGroup);
+                it != annotations.end()) {
+                deleteChord(static_cast<int>(std::ranges::distance(annotations.begin(), it)));
+                return true;
+            }
         }
     }
     return PianoRollContent::keyPressed(key);
@@ -507,13 +531,10 @@ void ChordClipContent::openChordEditor(int annIndex) {
     const auto spec = magda::music::ChordEngine::parseChordName(ann.chordName);
 
     // Derive the octave from the chord's lowest linked note.
-    int octave = 4;
-    int lowest = 128;
-    for (const auto& n : clip->midiNotes)
-        if (ann.chordGroup != 0 && n.chordGroup == ann.chordGroup)
-            lowest = std::min(lowest, n.noteNumber);
-    if (lowest <= 127)
-        octave = lowest / 12 - 1;
+    auto groupPitches = clip->midiNotes | std::views::filter(isInChordGroup(ann.chordGroup)) |
+                        std::views::transform(&magda::MidiNote::noteNumber);
+    const int octave =
+        std::ranges::empty(groupPitches) ? 4 : std::ranges::min(groupPitches) / 12 - 1;
 
     // Anchor the editor at the block; capture the bar (stable across edits, where
     // the annotation index is not).
@@ -555,13 +576,9 @@ void ChordClipContent::replaceChordNotes(int annIndex, const std::vector<int>& p
 
     auto& undo = magda::UndoManager::getInstance();
 
-    // Delete the chord's existing notes (highest index first so earlier indices
-    // stay valid), then insert the new voicing at the same bar/length.
-    std::vector<size_t> indices;
-    for (size_t i = 0; i < clip->midiNotes.size(); ++i)
-        if (group != 0 && clip->midiNotes[i].chordGroup == group)
-            indices.push_back(i);
-    std::sort(indices.rbegin(), indices.rend());
+    // Delete the chord's existing notes, then insert the new voicing at the same
+    // bar/length.
+    const auto indices = noteIndicesInChordGroup(*clip, group);
     for (size_t idx : indices)
         undo.executeCommand(std::make_unique<magda::DeleteMidiNoteCommand>(clipId, idx));
 
@@ -580,9 +597,9 @@ std::vector<int> ChordClipContent::chordPitches(int annIndex) const {
         annIndex >= static_cast<int>(clip->chordAnnotations.size()))
         return pitches;
     const int group = clip->chordAnnotations[static_cast<size_t>(annIndex)].chordGroup;
-    for (const auto& n : clip->midiNotes)
-        if (group != 0 && n.chordGroup == group)
-            pitches.push_back(n.noteNumber);
+    std::ranges::copy(clip->midiNotes | std::views::filter(isInChordGroup(group)) |
+                          std::views::transform(&magda::MidiNote::noteNumber),
+                      std::back_inserter(pitches));
     return pitches;
 }
 
@@ -622,11 +639,7 @@ void ChordClipContent::deleteChord(int annIndex) {
         return;
     const int group = clip->chordAnnotations[static_cast<size_t>(annIndex)].chordGroup;
 
-    std::vector<size_t> indices;
-    for (size_t i = 0; i < clip->midiNotes.size(); ++i)
-        if (group != 0 && clip->midiNotes[i].chordGroup == group)
-            indices.push_back(i);
-    std::sort(indices.rbegin(), indices.rend());
+    const auto indices = noteIndicesInChordGroup(*clip, group);
 
     auto& undo = magda::UndoManager::getInstance();
     for (size_t idx : indices)
@@ -713,10 +726,11 @@ bool ChordClipContent::insertChordAtBeat(double clipRelativeBeat, const std::vec
     constexpr int kDefaultVelocity = 100;
 
     // A bar that already has a chord is for editing it, not stacking a new one.
-    for (const auto& ann : clip->chordAnnotations) {
-        if (bar >= ann.beatPosition && bar < ann.beatPosition + ann.lengthBeats)
-            return false;
-    }
+    const auto coversBar = [bar](const magda::ClipInfo::ChordAnnotation& ann) {
+        return bar >= ann.beatPosition && bar < ann.beatPosition + ann.lengthBeats;
+    };
+    if (std::ranges::any_of(clip->chordAnnotations, coversBar))
+        return false;
 
     // Insert the notes, then detection builds the (linked) chord-lane block, so
     // later note edits re-sync the chord via syncChordAnnotations().

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -68,9 +68,7 @@ PrimaryInstance primaryInstanceForClip(magda::ClipId clipId) {
 }
 
 const magda::KitRow* findKitRow(const std::vector<magda::KitRow>& rows, int noteNumber) {
-    auto it = std::find_if(rows.begin(), rows.end(), [noteNumber](const magda::KitRow& r) {
-        return r.noteNumber == noteNumber;
-    });
+    const auto it = std::ranges::find(rows, noteNumber, &magda::KitRow::noteNumber);
     return it == rows.end() ? nullptr : &(*it);
 }
 
@@ -500,8 +498,7 @@ class DrumGridClipGrid : public juce::Component,
         // overlay track's clip changes
         if (!overlayTrackIds_.empty()) {
             const auto* clip = magda::ClipManager::getInstance().getClip(clipId);
-            if (clip && std::find(overlayTrackIds_.begin(), overlayTrackIds_.end(),
-                                  clip->trackId) != overlayTrackIds_.end()) {
+            if (clip && std::ranges::contains(overlayTrackIds_, clip->trackId)) {
                 repaint();
             }
         }
@@ -736,7 +733,7 @@ class DrumGridClipGrid : public juce::Component,
     // an unselected note is edited alone.
     void adjustVelocityForNote(size_t noteIndex, int velocityDelta) {
         std::vector<size_t> targets = selectedNoteIndices();
-        if (std::find(targets.begin(), targets.end(), noteIndex) == targets.end())
+        if (!std::ranges::contains(targets, noteIndex))
             targets = {noteIndex};
         magda::adjustMidiNoteVelocities(clipId_, targets, velocityDelta);
         flashVelocityReadout(noteIndex);
@@ -3026,8 +3023,7 @@ void DrumGridClipContent::buildPadRows() {
 
     for (int i = 0; i < numPads_; ++i) {
         int noteNumber = baseNote_ + i;
-        if (filterToUsed &&
-            std::find(usedNotes.begin(), usedNotes.end(), noteNumber) == usedNotes.end())
+        if (filterToUsed && !std::ranges::contains(usedNotes, noteNumber))
             continue;
         bool hasChain = false;
         if (drumGrid_) {

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -347,7 +347,7 @@ std::vector<std::string> parseTags(const juce::String& raw) {
         const auto clean = token.trim().toLowerCase();
         if (clean.isNotEmpty()) {
             const auto s = clean.toStdString();
-            if (std::find(out.begin(), out.end(), s) == out.end()) {
+            if (!std::ranges::contains(out, s)) {
                 out.push_back(s);
             }
         }

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -2031,8 +2031,7 @@ void MediaExplorerContent::fileClicked(const juce::File& file, const juce::Mouse
         juce::PopupMenu menu;
         auto favorites = magda::Config::getInstance().getBrowserFavorites();
         auto path = file.getFullPathName().toStdString();
-        bool alreadyFavorite =
-            std::find(favorites.begin(), favorites.end(), path) != favorites.end();
+        bool alreadyFavorite = std::ranges::contains(favorites, path);
 
         if (alreadyFavorite) {
             menu.addItem(1, "Remove from favorites");

--- a/magda/daw/ui/panels/content/MidiEditorContent.cpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.cpp
@@ -4,6 +4,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
+#include <ranges>
 #include <set>
 
 #include "audio/MidiBridge.hpp"
@@ -50,8 +52,8 @@ std::vector<int> MidiEditorContent::collectUsedPitches() const {
     std::set<int> used;
     if (editingClipId_ != magda::INVALID_CLIP_ID) {
         if (const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_))
-            for (const auto& note : clip->midiNotes)
-                used.insert(note.noteNumber);
+            std::ranges::copy(clip->midiNotes | std::views::transform(&magda::MidiNote::noteNumber),
+                              std::inserter(used, used.end()));
     }
     return {used.begin(), used.end()};
 }
@@ -792,21 +794,17 @@ void MidiEditorContent::showOverlayTracksMenu(juce::Component* anchor,
         if (track.id == activeTrackId)
             continue;
 
-        bool hasMidi = false;
-        for (magda::ClipId cid : clipManager.getClipsOnTrack(track.id)) {
+        const auto isMidiClip = [&clipManager](magda::ClipId cid) {
             const auto* clip = clipManager.getClip(cid);
-            if (clip && clip->isMidi()) {
-                hasMidi = true;
-                break;
-            }
-        }
-        if (!hasMidi)
+            return clip != nullptr && clip->isMidi();
+        };
+        const auto clipIds = clipManager.getClipsOnTrack(track.id);
+        if (!std::ranges::any_of(clipIds, isMidiClip))
             continue;
 
         juce::PopupMenu::Item item(track.name);
         item.itemID = static_cast<int>(menuTracks.size()) + 1;
-        item.isTicked = std::find(overlayTrackIds_.begin(), overlayTrackIds_.end(), track.id) !=
-                        overlayTrackIds_.end();
+        item.isTicked = std::ranges::contains(overlayTrackIds_, track.id);
         item.colour = track.colour;
         menu.addItem(item);
         menuTracks.push_back(track.id);
@@ -838,7 +836,7 @@ void MidiEditorContent::showOverlayTracksMenu(juce::Component* anchor,
                 overlayTrackIds_.clear();
             } else if (result >= 1 && result <= static_cast<int>(menuTracks.size())) {
                 const auto trackId = menuTracks[static_cast<size_t>(result - 1)];
-                auto it = std::find(overlayTrackIds_.begin(), overlayTrackIds_.end(), trackId);
+                const auto it = std::ranges::find(overlayTrackIds_, trackId);
                 if (it != overlayTrackIds_.end())
                     overlayTrackIds_.erase(it);
                 else

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <limits>
+#include <iterator>
+#include <optional>
+#include <ranges>
 #include <set>
 
 #include "../../core/SelectionManager.hpp"
@@ -37,6 +39,35 @@
 #include "ui/components/timeline/TimeRuler.hpp"
 
 namespace magda::daw::ui {
+
+namespace {
+
+struct SelectionSpan {
+    double startBeat;
+    double endBeat;
+};
+
+/** @brief The beat span of a multi-clip selection, empty when no clip resolves. */
+std::optional<SelectionSpan> selectionSpanBeats(const std::vector<magda::ClipId>& clipIds) {
+    auto& clipManager = magda::ClipManager::getInstance();
+    const auto clipFor = [&clipManager](magda::ClipId id) { return clipManager.getClip(id); };
+    const auto stillExists = [](const magda::ClipInfo* clip) { return clip != nullptr; };
+    const auto startBeat = [](const magda::ClipInfo* clip) { return clip->placement.startBeat; };
+    const auto endBeat = [](const magda::ClipInfo* clip) { return clip->placement.endBeat(); };
+
+    auto clips = clipIds | std::views::transform(clipFor) | std::views::filter(stillExists);
+    if (std::ranges::empty(clips))
+        return std::nullopt;
+
+    return SelectionSpan{std::ranges::min(clips | std::views::transform(startBeat)),
+                         std::ranges::max(clips | std::views::transform(endBeat))};
+}
+
+double noteEndBeat(const magda::MidiNote& note) {
+    return note.startBeat + note.lengthBeats;
+}
+
+}  // namespace
 
 bool PianoRollContent::showProgressionOverlay_ = false;
 
@@ -751,19 +782,20 @@ void PianoRollContent::setupGridCallbacks() {
         if (!clip || !clip->isMidi())
             return;
 
-        double minStart = std::numeric_limits<double>::max();
-        double maxEnd = 0.0;
+        const auto isInClip = [&clip](size_t idx) { return idx < clip->midiNotes.size(); };
+        const auto noteAt = [&clip](size_t idx) { return clip->midiNotes[idx]; };
+
         std::vector<magda::MidiNote> notesToDuplicate;
-        for (size_t idx : noteIndices) {
-            if (idx < clip->midiNotes.size()) {
-                const auto& note = clip->midiNotes[idx];
-                notesToDuplicate.push_back(note);
-                minStart = std::min(minStart, note.startBeat);
-                maxEnd = std::max(maxEnd, note.startBeat + note.lengthBeats);
-            }
-        }
+        std::ranges::copy(noteIndices | std::views::filter(isInClip) |
+                              std::views::transform(noteAt),
+                          std::back_inserter(notesToDuplicate));
+
         if (!notesToDuplicate.empty()) {
-            double offset = maxEnd - minStart;
+            const auto starts =
+                notesToDuplicate | std::views::transform(&magda::MidiNote::startBeat);
+            const double offset =
+                std::ranges::max(notesToDuplicate | std::views::transform(noteEndBeat)) -
+                std::ranges::min(starts);
             for (auto& note : notesToDuplicate) {
                 note.startBeat += offset;
             }
@@ -1306,17 +1338,10 @@ void PianoRollContent::updateGridSize() {
     // When multiple clips are selected, compute the combined range
     const auto& selectedClipIds = gridComponent_->getSelectedClipIds();
     if (selectedClipIds.size() > 1) {
-        double earliestStartBeat = std::numeric_limits<double>::max();
-        double latestEndBeat = 0.0;
-        for (magda::ClipId id : selectedClipIds) {
-            const auto* c = clipManager.getClip(id);
-            if (!c)
-                continue;
-            earliestStartBeat = juce::jmin(earliestStartBeat, c->placement.startBeat);
-            latestEndBeat = juce::jmax(latestEndBeat, c->placement.endBeat());
+        if (const auto span = selectionSpanBeats(selectedClipIds)) {
+            clipStartBeats = span->startBeat;
+            clipLengthBeats = span->endBeat - span->startBeat;
         }
-        clipStartBeats = earliestStartBeat;
-        clipLengthBeats = latestEndBeat - earliestStartBeat;
     } else if (clip) {
         if (clip->loopEnabled || clip->view == magda::ClipView::Session) {
             // Looped clips and session clips: show content from bar 1
@@ -2086,28 +2111,29 @@ void PianoRollContent::syncChordAnnotations(magda::ClipId clipId) {
             continue;  // Skip unlinked annotations
         }
 
-        // Find all notes in this chord group
-        std::vector<magda::music::ChordNote> chordNotes;
-        double minBeat = std::numeric_limits<double>::max();
-        double maxEnd = 0.0;
+        const auto isInThisGroup = [group = it->chordGroup](const magda::MidiNote& note) {
+            return note.chordGroup == group;
+        };
+        const auto asChordNote = [](const magda::MidiNote& note) {
+            return magda::music::ChordNote(note.noteNumber, note.velocity);
+        };
+        auto groupNotes = clip->midiNotes | std::views::filter(isInThisGroup);
 
-        for (const auto& note : clip->midiNotes) {
-            if (note.chordGroup == it->chordGroup) {
-                chordNotes.emplace_back(note.noteNumber, note.velocity);
-                minBeat = std::min(minBeat, note.startBeat);
-                maxEnd = std::max(maxEnd, note.startBeat + note.lengthBeats);
-            }
-        }
-
-        if (chordNotes.empty()) {
+        if (std::ranges::empty(groupNotes)) {
             // All notes in group deleted — remove annotation
             it = clip->chordAnnotations.erase(it);
             continue;
         }
 
-        // Update position and length from note extents
+        std::vector<magda::music::ChordNote> chordNotes;
+        std::ranges::copy(groupNotes | std::views::transform(asChordNote),
+                          std::back_inserter(chordNotes));
+
+        const double minBeat =
+            std::ranges::min(groupNotes | std::views::transform(&magda::MidiNote::startBeat));
         it->beatPosition = minBeat;
-        it->lengthBeats = maxEnd - minBeat;
+        it->lengthBeats =
+            std::ranges::max(groupNotes | std::views::transform(noteEndBeat)) - minBeat;
 
         // Re-detect chord name if pitches changed
         if (chordNotes.size() >= 2) {
@@ -2230,17 +2256,8 @@ void PianoRollContent::updateVelocityLane() {
         const auto& selectedClipIds =
             gridComponent_ ? gridComponent_->getSelectedClipIds() : std::vector<magda::ClipId>{};
         if (selectedClipIds.size() > 1) {
-            double earliestStart = std::numeric_limits<double>::max();
-            auto& clipManager = magda::ClipManager::getInstance();
-            for (magda::ClipId id : selectedClipIds) {
-                const auto* c = clipManager.getClip(id);
-                if (c) {
-                    earliestStart = juce::jmin(earliestStart, c->placement.startBeat);
-                }
-            }
-            if (earliestStart < std::numeric_limits<double>::max()) {
-                midiDrawer_->setClipStartBeats(earliestStart);
-            }
+            if (const auto span = selectionSpanBeats(selectedClipIds))
+                midiDrawer_->setClipStartBeats(span->startBeat);
         }
 
         // Sync loop region and clip length
@@ -2268,17 +2285,8 @@ void PianoRollContent::updateVelocityLane() {
     const auto& selectedClipIds =
         gridComponent_ ? gridComponent_->getSelectedClipIds() : std::vector<magda::ClipId>{};
     if (selectedClipIds.size() > 1) {
-        double earliestStart = std::numeric_limits<double>::max();
-        auto& clipManager = magda::ClipManager::getInstance();
-        for (magda::ClipId id : selectedClipIds) {
-            const auto* c = clipManager.getClip(id);
-            if (c) {
-                earliestStart = juce::jmin(earliestStart, c->placement.startBeat);
-            }
-        }
-        if (earliestStart < std::numeric_limits<double>::max()) {
-            velocityLane_->setClipStartBeats(earliestStart);
-        }
+        if (const auto span = selectionSpanBeats(selectedClipIds))
+            velocityLane_->setClipStartBeats(span->startBeat);
     }
 
     if (gridComponent_) {

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -3,6 +3,7 @@
 #include <BinaryData.h>
 
 #include <algorithm>
+#include <iterator>
 #include <ranges>
 #include <utility>
 
@@ -559,18 +560,26 @@ std::vector<PluginBrowserInfo> PluginBrowserContent::getInternalPlugins() {
     // Native + TE internal devices: the registry is the single source of truth.
     // A device appears here by setting showInBrowser on its InternalPluginSpec -
     // no separate hand-maintained list to keep in sync.
-    for (const auto* spec : audio::getAllInternalPluginSpecs()) {
-        if (spec->showInBrowser)
-            list.push_back(PluginBrowserInfo::createInternal(
-                spec->displayName, spec->pluginId, spec->isInstrument, spec->browserCategory,
-                searchKeywordsForInternalSpec(*spec)));
-    }
+    const auto listedInBrowser = [](const audio::InternalPluginSpec* spec) {
+        return spec->showInBrowser;
+    };
+    const auto asBrowserEntry = [](const audio::InternalPluginSpec* spec) {
+        return PluginBrowserInfo::createInternal(spec->displayName, spec->pluginId,
+                                                 spec->isInstrument, spec->browserCategory,
+                                                 searchKeywordsForInternalSpec(*spec));
+    };
+    std::ranges::copy(audio::getAllInternalPluginSpecs() | std::views::filter(listedInBrowser) |
+                          std::views::transform(asBrowserEntry),
+                      std::back_inserter(list));
+
     // Compiled-Faust devices come from their own registry.
-    for (const auto* spec : audio::compiled::getAllCompiledPluginSpecs()) {
-        list.push_back(PluginBrowserInfo::createInternal(spec->displayName, spec->pluginId,
-                                                         spec->isInstrument, spec->browserCategory,
-                                                         searchKeywordsForCompiledSpec(*spec)));
-    }
+    const auto asCompiledBrowserEntry = [](const audio::compiled::CompiledPluginSpec* spec) {
+        return PluginBrowserInfo::createInternal(spec->displayName, spec->pluginId,
+                                                 spec->isInstrument, spec->browserCategory,
+                                                 searchKeywordsForCompiledSpec(*spec));
+    };
+    std::ranges::transform(audio::compiled::getAllCompiledPluginSpecs(), std::back_inserter(list),
+                           asCompiledBrowserEntry);
     // External hardware insert: one registry kind (te::InsertPlugin), surfaced as
     // two browser entries — External FX (audio send/return) and External
     // Instrument (MIDI send + audio return). The split is carried by isInstrument

--- a/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
@@ -4,6 +4,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
+#include <ranges>
 #include <vector>
 
 #include "../../../audio/AudioBridge.hpp"
@@ -1194,23 +1196,21 @@ void TrackInspector::updateFromMultiTrackSelection() {
     trackNameValue_.setEditable(false);
 
     // Check button states: "on" only if ALL selected tracks share that state
-    bool allMuted = true;
-    bool allSoloed = true;
-    bool allRecordArmed = true;
-    bool allEnabled = true;
-    for (auto tid : selectedTrackIds_) {
-        const auto* track = tm.getTrack(tid);
-        if (!track)
-            continue;
-        if (!track->muted)
-            allMuted = false;
-        if (!track->soloed)
-            allSoloed = false;
-        if (!track->recordArmed)
-            allRecordArmed = false;
-        if (!tm.isChainEnabled(tid))
-            allEnabled = false;
-    }
+    const auto trackFor = [&tm](magda::TrackId tid) { return tm.getTrack(tid); };
+    const auto stillExists = [](const magda::TrackInfo* track) { return track != nullptr; };
+    const auto chainEnabled = [&tm](const magda::TrackInfo* track) {
+        return tm.isChainEnabled(track->id);
+    };
+
+    std::vector<const magda::TrackInfo*> tracks;
+    std::ranges::copy(selectedTrackIds_ | std::views::transform(trackFor) |
+                          std::views::filter(stillExists),
+                      std::back_inserter(tracks));
+
+    const bool allMuted = std::ranges::all_of(tracks, &magda::TrackInfo::muted);
+    const bool allSoloed = std::ranges::all_of(tracks, &magda::TrackInfo::soloed);
+    const bool allRecordArmed = std::ranges::all_of(tracks, &magda::TrackInfo::recordArmed);
+    const bool allEnabled = std::ranges::all_of(tracks, chainEnabled);
 
     muteButton_->setToggleState(allMuted, juce::dontSendNotification);
     soloButton_->setToggleState(allSoloed, juce::dontSendNotification);
@@ -1573,7 +1573,7 @@ void TrackInspector::showAddSendMenu() {
                 continue;
             if (track.type == magda::TrackType::Master)
                 continue;
-            if (std::find(descendants.begin(), descendants.end(), track.id) != descendants.end())
+            if (std::ranges::contains(descendants, track.id))
                 continue;
 
             // Filter out tracks that already have a send from this track

--- a/magda/daw/ui/panels/state/PanelController.cpp
+++ b/magda/daw/ui/panels/state/PanelController.cpp
@@ -35,12 +35,12 @@ void applyPersistedTabOrder(PanelState& panel, const std::vector<std::string>& s
         auto type = contentTypeFromId(juce::String(id));
         if (!type.has_value() || !panel.hasContentType(*type))
             continue;
-        if (std::find(ordered.begin(), ordered.end(), *type) == ordered.end())
+        if (!std::ranges::contains(ordered, *type))
             ordered.push_back(*type);
     }
 
     for (auto type : panel.tabs) {
-        if (std::find(ordered.begin(), ordered.end(), type) == ordered.end())
+        if (!std::ranges::contains(ordered, type))
             ordered.push_back(type);
     }
 
@@ -180,7 +180,7 @@ void PanelController::resetToDefaults() {
 }
 
 void PanelController::addListener(PanelStateListener* listener) {
-    if (listener && std::find(listeners_.begin(), listeners_.end(), listener) == listeners_.end()) {
+    if (listener && !std::ranges::contains(listeners_, listener)) {
         listeners_.push_back(listener);
     }
 }

--- a/magda/daw/ui/state/TimelineController.cpp
+++ b/magda/daw/ui/state/TimelineController.cpp
@@ -1,6 +1,7 @@
 #include "TimelineController.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 #include "../../core/ClipManager.hpp"
 #include "../../core/GridDivision.hpp"
@@ -52,7 +53,7 @@ void TimelineController::dispatch(const TimelineEvent& event) {
 }
 
 void TimelineController::addListener(TimelineStateListener* listener) {
-    if (listener && std::find(listeners.begin(), listeners.end(), listener) == listeners.end()) {
+    if (listener && !std::ranges::contains(listeners, listener)) {
         listeners.push_back(listener);
     }
 }
@@ -62,8 +63,7 @@ void TimelineController::removeListener(TimelineStateListener* listener) {
 }
 
 void TimelineController::addAudioEngineListener(AudioEngineListener* listener) {
-    if (listener && std::find(audioEngineListeners.begin(), audioEngineListeners.end(), listener) ==
-                        audioEngineListeners.end()) {
+    if (listener && !std::ranges::contains(audioEngineListeners, listener)) {
         audioEngineListeners.push_back(listener);
     }
 }
@@ -1135,8 +1135,7 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const AddMarkerE
 }
 
 TimelineController::ChangeFlags TimelineController::handleEvent(const UpdateMarkerEvent& e) {
-    auto it = std::find_if(state.markers.begin(), state.markers.end(),
-                           [&](const TimelineMarker& marker) { return marker.id == e.markerId; });
+    auto it = std::ranges::find(state.markers, e.markerId, &TimelineMarker::id);
     if (it == state.markers.end())
         return ChangeFlags::None;
 
@@ -1171,8 +1170,7 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const SetMarkers
         state.nextMarkerId = juce::jmax(state.nextMarkerId, marker.id + 1);
     // Drop a stale selection that no longer points at a live marker.
     if (state.selectedMarkerId != 0 &&
-        std::none_of(state.markers.begin(), state.markers.end(),
-                     [&](const TimelineMarker& m) { return m.id == state.selectedMarkerId; }))
+        !std::ranges::contains(state.markers, state.selectedMarkerId, &TimelineMarker::id))
         state.selectedMarkerId = 0;
     ProjectManager::getInstance().markDirty();
     return ChangeFlags::Markers;
@@ -1180,9 +1178,7 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const SetMarkers
 
 TimelineController::ChangeFlags TimelineController::handleEvent(const SelectMarkerEvent& e) {
     if (e.markerId != 0) {
-        auto it =
-            std::find_if(state.markers.begin(), state.markers.end(),
-                         [&](const TimelineMarker& marker) { return marker.id == e.markerId; });
+        auto it = std::ranges::find(state.markers, e.markerId, &TimelineMarker::id);
         if (it == state.markers.end())
             return ChangeFlags::None;
     }
@@ -1195,8 +1191,7 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const SelectMark
 }
 
 TimelineController::ChangeFlags TimelineController::handleEvent(const GoToMarkerEvent& e) {
-    auto it = std::find_if(state.markers.begin(), state.markers.end(),
-                           [&](const TimelineMarker& marker) { return marker.id == e.markerId; });
+    auto it = std::ranges::find(state.markers, e.markerId, &TimelineMarker::id);
     if (it == state.markers.end())
         return ChangeFlags::None;
 
@@ -1213,10 +1208,10 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const GoToNextMa
         return ChangeFlags::None;
 
     const double current = state.playhead.getCurrentPositionBeats();
-    auto it =
-        std::find_if(state.markers.begin(), state.markers.end(), [&](const TimelineMarker& marker) {
-            return marker.positionBeats > current + 0.000001;
-        });
+    const auto isAfterPlayhead = [current](const TimelineMarker& marker) {
+        return marker.positionBeats > current + 0.000001;
+    };
+    auto it = std::ranges::find_if(state.markers, isAfterPlayhead);
     if (it == state.markers.end())
         it = state.markers.begin();
 
@@ -1229,10 +1224,12 @@ TimelineController::ChangeFlags TimelineController::handleEvent(
         return ChangeFlags::None;
 
     const double current = state.playhead.getCurrentPositionBeats();
-    auto it = std::find_if(
-        state.markers.rbegin(), state.markers.rend(),
-        [&](const TimelineMarker& marker) { return marker.positionBeats < current - 0.000001; });
-    const int markerId = it != state.markers.rend() ? it->id : state.markers.back().id;
+    const auto isBeforePlayhead = [current](const TimelineMarker& marker) {
+        return marker.positionBeats < current - 0.000001;
+    };
+    auto earlierMarkers = state.markers | std::views::reverse;
+    const auto it = std::ranges::find_if(earlierMarkers, isBeforePlayhead);
+    const int markerId = it != earlierMarkers.end() ? it->id : state.markers.back().id;
     return handleEvent(GoToMarkerEvent{markerId});
 }
 

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <iterator>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 
 #include "../../audio/AudioBridge.hpp"
@@ -64,13 +65,10 @@ juce::String formatTrackIds(const std::vector<TrackId>& trackIds) {
 
 juce::String formatSessionClips() {
     auto clips = ClipManager::getInstance().getSessionClips();
-    std::sort(clips.begin(), clips.end(), [](const ClipInfo& a, const ClipInfo& b) {
-        if (a.trackId != b.trackId)
-            return a.trackId < b.trackId;
-        if (a.sceneIndex != b.sceneIndex)
-            return a.sceneIndex < b.sceneIndex;
-        return a.id < b.id;
-    });
+    const auto gridPosition = [](const ClipInfo& clip) {
+        return std::tuple{clip.trackId, clip.sceneIndex, clip.id};
+    };
+    std::ranges::sort(clips, {}, gridPosition);
 
     juce::String text("[");
     for (size_t i = 0; i < clips.size(); ++i) {
@@ -82,6 +80,21 @@ juce::String formatSessionClips() {
     }
     text << "]";
     return text;
+}
+
+/** @brief Whether an id names a clip that lives in the session grid. */
+bool isSessionClip(ClipId clipId) {
+    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    return clip != nullptr && clip->view == ClipView::Session;
+}
+
+/** @brief The current clip selection, narrowed to the session grid. */
+std::vector<ClipId> selectedSessionClipIds() {
+    const auto& selected = SelectionManager::getInstance().getSelectedClips();
+    std::vector<ClipId> sessionClipIds;
+    sessionClipIds.reserve(selected.size());
+    std::ranges::copy_if(selected, std::back_inserter(sessionClipIds), isSessionClip);
+    return sessionClipIds;
 }
 
 float gainToDb(float gain) {
@@ -2754,32 +2767,16 @@ ClipId SessionView::duplicateSessionClipToNextEmptyScene(ClipId clipId) {
 }
 
 bool SessionView::duplicateSelectedSessionClips() {
-    auto selectedClips = SelectionManager::getInstance().getSelectedClips();
-    if (selectedClips.empty())
-        return false;
-
-    std::vector<ClipId> sessionClipIds;
-    sessionClipIds.reserve(selectedClips.size());
-    auto& clipManager = ClipManager::getInstance();
-    for (ClipId clipId : selectedClips) {
-        const auto* clip = clipManager.getClip(clipId);
-        if (clip && clip->view == ClipView::Session)
-            sessionClipIds.push_back(clipId);
-    }
+    auto sessionClipIds = selectedSessionClipIds();
     if (sessionClipIds.empty())
         return false;
 
-    std::sort(sessionClipIds.begin(), sessionClipIds.end(), [&clipManager](ClipId a, ClipId b) {
-        const auto* clipA = clipManager.getClip(a);
-        const auto* clipB = clipManager.getClip(b);
-        int sceneA = clipA ? clipA->sceneIndex : 0;
-        int sceneB = clipB ? clipB->sceneIndex : 0;
-        if (sceneA != sceneB)
-            return sceneA < sceneB;
-        TrackId trackA = clipA ? clipA->trackId : INVALID_TRACK_ID;
-        TrackId trackB = clipB ? clipB->trackId : INVALID_TRACK_ID;
-        return trackA < trackB;
-    });
+    auto& clipManager = ClipManager::getInstance();
+    const auto sceneThenTrack = [&clipManager](ClipId clipId) {
+        const auto* clip = clipManager.getClip(clipId);
+        return std::tuple{clip ? clip->sceneIndex : 0, clip ? clip->trackId : INVALID_TRACK_ID};
+    };
+    std::ranges::sort(sessionClipIds, {}, sceneThenTrack);
 
     if (sessionClipIds.size() > 1)
         UndoManager::getInstance().beginCompoundOperation("Duplicate Session Clips");
@@ -2802,18 +2799,7 @@ bool SessionView::duplicateSelectedSessionClips() {
 }
 
 bool SessionView::deleteSelectedSessionClips() {
-    auto selectedClips = SelectionManager::getInstance().getSelectedClips();
-    if (selectedClips.empty())
-        return false;
-
-    std::vector<ClipId> sessionClipIds;
-    sessionClipIds.reserve(selectedClips.size());
-    auto& clipManager = ClipManager::getInstance();
-    for (ClipId clipId : selectedClips) {
-        const auto* clip = clipManager.getClip(clipId);
-        if (clip && clip->view == ClipView::Session)
-            sessionClipIds.push_back(clipId);
-    }
+    const auto sessionClipIds = selectedSessionClipIds();
     if (sessionClipIds.empty())
         return false;
 
@@ -3080,7 +3066,7 @@ bool SessionView::canDropIntoGroup(int draggedIndex, int targetIndex) const {
     const auto* dragged = tm.getTrack(visibleTrackIds_[draggedIndex]);
     if (dragged && dragged->isGroup()) {
         auto desc = tm.getAllDescendants(dragged->id);
-        if (std::find(desc.begin(), desc.end(), target->id) != desc.end())
+        if (std::ranges::contains(desc, target->id))
             return false;
     }
     return true;

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -1483,15 +1483,12 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                 double tempo =
                     mainView ? mainView->getTimelineController().getState().tempo.bpm : 120.0;
 
-                // Sort clips by start time
                 std::vector<ClipId> sortedClips(selectedClips.begin(), selectedClips.end());
-                std::sort(sortedClips.begin(), sortedClips.end(), [&](ClipId a, ClipId b) {
-                    auto* ca = clipManager.getClip(a);
-                    auto* cb = clipManager.getClip(b);
-                    if (!ca || !cb)
-                        return false;
-                    return timelineStartSeconds(*ca, tempo) < timelineStartSeconds(*cb, tempo);
-                });
+                const auto startSeconds = [&clipManager, tempo](ClipId id) {
+                    const auto* clip = clipManager.getClip(id);
+                    return clip != nullptr ? timelineStartSeconds(*clip, tempo) : 0.0;
+                };
+                std::ranges::sort(sortedClips, {}, startSeconds);
 
                 // Join sequentially: left absorbs right, then result absorbs next, etc.
                 if (sortedClips.size() > 2) {


### PR DESCRIPTION
Closes #2147. Two things: the sites #2545 listed as still to come, and the pre-ranges algorithm calls that a loop sweep by definition never looks at.

## The listed remainder

- **`AISettingsDialog`** — one `findListEntry()` behind both the add and the remove path, and the first-enabled-item scan through `views::iota`.
- **`SessionView`** — the two byte-identical filters of the selection down to session clips are `selectedSessionClipIds()`; the duplicate order is a projection rather than a five-branch comparator.
- **`PianoRollContent`** — three copies of the multi-clip extent walk are `selectionSpanBeats()`; note extents go through `ranges::min` / `ranges::max`.
- **`ClipComponent`** — `sameRanges()` compares through `views::zip`, and the two Join Clips sorts are one `selectedClipsInTimelineOrder()`.
- **`ChordClipContent`** — `isInChordGroup()` and `noteIndicesInChordGroup()` replace four hand-written walks over a chord group's notes.
- **`AIChatConsoleContent`, `DeviceSlotHeaderControls`, `PluginBrowserContent`, `MidiEditorContent`, `TrackInspector`** — sorts by projection, a `reverse | filter`, a `filter | transform`, an `any_of` and an `all_of`.

## The iterator pairs

43 `std::find(a.begin(), a.end(), v)` calls became `ranges::contains` or `ranges::find`, plus the `find_if` / `any_of` / `all_of` / `none_of` / `binary_search` calls and 19 sorts. Two more dedupes fell out: four searches for a marker by id in `TimelineController` are one `ranges::find` with a projection, and `MasterAutomationLanes` had the same lane lookup written twice.

## Two behaviour changes, both in the same direction

The Join Clips comparator returned `false` whenever either clip was missing, which is not a strict weak ordering. The projection sorts a missing clip to `0.0`.

The PianoRoll multi-clip extent left `clipStartBeats` at `double::max` and the length at `-max` when no selected clip resolved. It now leaves both at 0, the same way the single-clip branch starts.

## `CurvePoint` is not `totally_ordered`

It orders on `x` and compares on `id`, so the bare `ranges::sort` overload rejects it where `std::sort` accepted it through `operator<` alone. `CCLaneComponent` now sorts through `&CurvePoint::x`, which is what the line's comment already claimed it did.

## The editor was a standard behind

`.clangd` added `-std=c++20`, which overrides the compile database, so clangd reported `std::views::zip` as missing in code that builds — including the zips merged in #2545. The project has been C++23 since #2543. `clangd --check` on `ClipComponent.cpp` reports 0 errors with the bump.

## One finding for #2149

`std::ranges::to` is libstdc++ 14, and Linux CI builds GCC 13.3, so `filter | transform | to` does not compile on the floor the README documents. This branch collects with `ranges::copy` into a `back_inserter` instead. #2149 needs either a `toStd<C>` beside `toJuce<C>` or a floor moved to GCC 14, stated in the README.

## Verification

Debug build clean. Catch2: 3871 cases, 2356250 assertions, 0 failures. JUCE suite green, all nine real-project corpus cases through both engines.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi