### PR TITLE
Catch the launcher path's inexactness with a sustained case

### DIFF
--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -2420,6 +2420,30 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     }
 
     {
+        auto value = newCase("session.launch.sustained",
+                             "a launched slot holding a level, where ULP noise has something to "
+                             "ride on",
+                             launching(plainTrack()));
+        value.endBeat = 8.0;
+
+        // Steps rather than the impulses session.launch plays, and that is the
+        // whole case (#2458). Impulses are silence between impulses, so a path
+        // that is a bit-or-two inexact on a sustained level nulls anyway --
+        // there is nothing for the error to ride on. A held level puts every
+        // sample of the render under the comparison.
+        //
+        // The same material on an arrangement clip nulls at -inf, so what this
+        // measures is the launcher's path rather than the material.
+        const auto source = writeSource(scratchDirectory, "session_sustained", steps());
+        value.sources.push_back(source);
+
+        value.clips.push_back(inSlot(audioClip(401, 0.0, 16.0, source), 0));
+        value.launches.push_back(LaunchInfo{kTrack, 0, 0.0});
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
         auto value = newCase("session.launch.midi", "a MIDI slot playing from the first sample",
                              launching(instrumentTrack()));
         value.endBeat = 8.0;

--- a/tests/engine/test_null_diff_corpus.cpp
+++ b/tests/engine/test_null_diff_corpus.cpp
@@ -36,7 +36,7 @@ juce::File scratch() {
 TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
     const auto corpus = sharedCorpus(scratch());
 
-    REQUIRE(corpus.size() == 73);
+    REQUIRE(corpus.size() == 74);
 
     std::set<std::string> names;
     for (const auto& value : corpus)
@@ -102,6 +102,7 @@ TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corp
                                  "midi.fold",
                                  "midi.offset",
                                  "session.launch",
+                                 "session.launch.sustained",
                                  "session.launch.midi",
                                  "session.mode.holds.slot",
                                  "plugin.wetdry",

--- a/tests/engine/test_null_diff_juce.cpp
+++ b/tests/engine/test_null_diff_juce.cpp
@@ -262,6 +262,15 @@ class NullDiffCorpusTests : public juce::UnitTest {
         //    really are the same sound. Their envelope lock is not yet reliable
         //    on all of them, because the search window holds too few swells to
         //    be sure of, and no bound goes in until it is.
+        //  - session.launch.sustained sits at -110 dB, and it is the fork's
+        //    launcher path that is inexact rather than anything moving: the
+        //    engine emits a held 0.5 bit for bit, the fork wobbles by one or
+        //    two ULP per sample, and the same material on an arrangement clip
+        //    nulls at -inf. Its reported shift is not a shift. A held level has
+        //    nothing to correlate, so the aligner returns whatever the noise
+        //    prefers -- which is what -23 samples on the trimmed variant of
+        //    this case was, and #2458 read that as a trim landing in the wrong
+        //    place. No bound until the fork's own arithmetic is named.
         const std::set<std::string> underCalibration{
             "rate.48k",
             "speed.ratio",
@@ -271,6 +280,7 @@ class NullDiffCorpusTests : public juce::UnitTest {
             "stretch.signalsmith",
             "stretch.soundtouch.normal",
             "stretch.soundtouch.better",
+            "session.launch.sustained",
         };
 
         const auto complaints =


### PR DESCRIPTION
Adds `session.launch.sustained` — a slot launched from the render's first sample holding a steady level. It is `session.launch` with steps material instead of impulses. Declared under calibration, measured and printed like every other case.

## What #2458 actually is

#2458 reports a trimmed session slot landing **23 samples** away from the fork's. It does not. The residual is one to two ULP per sample scattered across the whole render — the engine emits a held `0.5` bit for bit, the fork wobbles in the last bit — and the 23 is the aligner's answer on material that has nothing to correlate.

Four runs, one variable at a time:

| material | path | trim | peak | reported shift |
|---|---|---|---|---|
| steps | arrangement | none | **-inf** | 0 |
| steps | slot + launch | none | -110.2 dB | -23.000 |
| steps | slot + launch | 0.5 s | -110.2 dB | -23.000 |
| steps | slot + launch | 0.375 s | -112.0 dB | -1.000 |
| impulses | slot + launch | none | -133.0 dB | 0 (`session.launch`, passes) |

Rows two and three are identical to the decimal **with the trim and without it**, so the trim is not involved. Row four moves the reported shift from -23 to -1 while leaving the residual where it was, which is not how a positional error behaves — a 23-sample slip of a full-scale steps signal would put the residual near 0 dB at every flip edge, not at -110 dB. Row one is the same material on an arrangement clip, nulling exactly.

The original artefacts from when the issue was filed (still on disk, dated Sep 6) say the same thing directly:

```
sample 0: native= 0.50000000  incumbent= 0.50000012
sample 3: native= 0.50000000  incumbent= 0.49999985
sample 6: native= 0.50000000  incumbent= 0.50000012
```

15799 single-sample regions above -140 dB, peak -113.5 dB. Scattered last-bit noise, not a shift.

## Why the corpus could not already see it

`session.launch` plays impulses, which are silence between impulses. A path that is a bit or two inexact on a sustained level has nothing to be inexact on, so it nulls at -133 dB whatever the launcher does to a held signal. This case gives it something to ride on, and that is the whole point of it.

## Why no bound

What the fork does arithmetically on the launcher path — a per-block ramp, a summing order, a resampler at unity — is not named yet, and the residual is random per sample rather than a consistent scale factor, so it is not a gain. A bound without a mechanism is how a real difference ends up inside an expected one, which is the rule the rest of that list already keeps. It goes in `underCalibration` with the reasoning, where membership is asserted in both directions.

## Verification

- `make test-juce` — all suites pass; the case is measured, printed and declared.
- `make test` — 3859 passed, 0 failed (corpus count 73 → 74, name added to the coverage list).
- Negative: before the declaration the suite failed with `did not hold: session.launch.sustained`, so the entry is load-bearing.

#2458 stays open — its title and premise both want rewriting, and that is a call for @lucaromagnoli. Tests only; no engine code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
