### PR TITLE
Sweep api, project, music, agents and engine onto ranges algorithms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,9 @@ jobs:
         sudo cp ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
         # The runner image ships a Google Chrome apt source that intermittently serves an
         # index whose hash does not match, which fails the whole update. Nothing here
-        # installs from it.
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        # installs from it. Match on the host rather than a file name: the image writes
+        # it as .list or .sources depending on the version.
+        sudo grep -rlZ 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
       run: |
         mkdir -p ~/apt-cache
         sudo cp ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+        # The runner image ships a Google Chrome apt source that intermittently serves an
+        # index whose hash does not match, which fails the whole update. Nothing here
+        # installs from it.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,8 +42,9 @@ jobs:
       run: |
         # The runner image ships a Google Chrome apt source that intermittently serves an
         # index whose hash does not match, which fails the whole update. Nothing here
-        # installs from it.
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        # installs from it. Match on the host rather than a file name: the image writes
+        # it as .list or .sources depending on the version.
+        sudo grep -rlZ 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,10 @@ jobs:
 
     - name: Install dependencies (Linux)
       run: |
+        # The runner image ships a Google Chrome apt source that intermittently serves an
+        # index whose hash does not match, which fails the whole update. Nothing here
+        # installs from it.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -46,8 +46,9 @@ jobs:
       run: |
         # The runner image ships a Google Chrome apt source that intermittently serves an
         # index whose hash does not match, which fails the whole update. Nothing here
-        # installs from it.
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        # installs from it. Match on the host rather than a file name: the image writes
+        # it as .list or .sources depending on the version.
+        sudo grep -rlZ 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -44,6 +44,10 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # The runner image ships a Google Chrome apt source that intermittently serves an
+        # index whose hash does not match, which fails the whole update. Nothing here
+        # installs from it.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/periodic-analysis.yml
+++ b/.github/workflows/periodic-analysis.yml
@@ -26,6 +26,10 @@ jobs:
 
     - name: Install analysis tools
       run: |
+        # The runner image ships a Google Chrome apt source that intermittently serves an
+        # index whose hash does not match, which fails the whole update. Nothing here
+        # installs from it.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
         sudo apt-get update
         sudo apt-get install -y cloc grep ripgrep
 

--- a/.github/workflows/periodic-analysis.yml
+++ b/.github/workflows/periodic-analysis.yml
@@ -28,8 +28,9 @@ jobs:
       run: |
         # The runner image ships a Google Chrome apt source that intermittently serves an
         # index whose hash does not match, which fails the whole update. Nothing here
-        # installs from it.
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        # installs from it. Match on the host rather than a file name: the image writes
+        # it as .list or .sources depending on the version.
+        sudo grep -rlZ 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f
         sudo apt-get update
         sudo apt-get install -y cloc grep ripgrep
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1025,6 +1025,10 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # The runner image ships a Google Chrome apt source that intermittently serves an
+        # index whose hash does not match, which fails the whole update. Nothing here
+        # installs from it.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1027,8 +1027,9 @@ jobs:
       run: |
         # The runner image ships a Google Chrome apt source that intermittently serves an
         # index whose hash does not match, which fails the whole update. Nothing here
-        # installs from it.
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+        # installs from it. Match on the host rather than a file name: the image writes
+        # it as .list or .sources depending on the version.
+        sudo grep -rlZ 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f
         sudo apt-get update
         sudo apt-get install -y \
           build-essential \

--- a/magda/agents/agent_runtime.cpp
+++ b/magda/agents/agent_runtime.cpp
@@ -30,8 +30,7 @@ juce::String callFingerprint(const ToolCall& call, std::uint64_t revision) {
 }
 
 const ToolDefinition* findTool(const AgentDefinition& definition, const juce::String& name) {
-    const auto it = std::find_if(definition.tools.begin(), definition.tools.end(),
-                                 [&name](const ToolDefinition& tool) { return tool.name == name; });
+    const auto it = std::ranges::find(definition.tools, name, &ToolDefinition::name);
     return it == definition.tools.end() ? nullptr : &*it;
 }
 
@@ -280,13 +279,12 @@ RunResult AgentRuntime::run(const AgentDefinition& definition, AgentRunInput inp
             return stop(TerminalReason::Completed);
         }
 
+        const auto mutates = [&effectiveDefinition](const ToolCall& call) {
+            const auto* tool = findTool(effectiveDefinition, call.name);
+            return tool != nullptr && tool->access == ToolAccess::Mutation;
+        };
         if (response.toolCallExecution == ModelResponse::ToolCallExecution::Parallel &&
-            response.toolCalls.size() > 1 &&
-            std::any_of(response.toolCalls.begin(), response.toolCalls.end(),
-                        [&](const ToolCall& call) {
-                            const auto* tool = findTool(effectiveDefinition, call.name);
-                            return tool != nullptr && tool->access == ToolAccess::Mutation;
-                        })) {
+            response.toolCalls.size() > 1 && std::ranges::any_of(response.toolCalls, mutates)) {
             completeUnexecutedCalls(0, "unsafe_parallel_mutation",
                                     "Parallel mutation batch was not executed");
             result.trace.push_back(std::move(trace));
@@ -409,10 +407,8 @@ RunResult AgentRuntime::run(const AgentDefinition& definition, AgentRunInput inp
         }
 
         if (isDirectPlanStep) {
-            const bool succeeded =
-                !trace.toolResults.empty() &&
-                std::all_of(trace.toolResults.begin(), trace.toolResults.end(),
-                            [](const ToolResult& toolResult) { return toolResult.success; });
+            const bool succeeded = !trace.toolResults.empty() &&
+                                   std::ranges::all_of(trace.toolResults, &ToolResult::success);
             result.trace.push_back(std::move(trace));
             if (succeeded) {
                 result.finalText = "OK";

--- a/magda/agents/agent_tool_bridge.cpp
+++ b/magda/agents/agent_tool_bridge.cpp
@@ -81,8 +81,8 @@ ToolResult RemoteAgentToolExecutor::execute(const ToolExecutionRequest& request,
                 .mutated = false};
     };
 
-    const bool allowed = std::find(surface_.toolAllowlist.begin(), surface_.toolAllowlist.end(),
-                                   request.call.name.toStdString()) != surface_.toolAllowlist.end();
+    const bool allowed =
+        std::ranges::contains(surface_.toolAllowlist, request.call.name.toStdString());
     if (!allowed)
         return failure("tool_not_allowed", "Operation '" + request.call.name + "' is not in the " +
                                                surface_.name + " surface's allowlist");

--- a/magda/agents/command_model.cpp
+++ b/magda/agents/command_model.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
+#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -389,9 +390,8 @@ std::string canonPitch(const std::string& text) {
     size_t b = text.find_last_not_of(" \t\r\n");
     std::string t = (a == std::string::npos) ? "" : text.substr(a, b - a + 1);
     // all digits → MIDI number, unchanged
-    if (!t.empty() && std::all_of(t.begin(), t.end(), [](char c) {
-            return std::isdigit(static_cast<unsigned char>(c));
-        }))
+    const auto isDigit = [](char c) { return std::isdigit(static_cast<unsigned char>(c)) != 0; };
+    if (!t.empty() && std::ranges::all_of(t, isDigit))
         return t;
     // [a-gA-G][b]?[0-9]
     if (t.size() == 2 || t.size() == 3) {
@@ -522,13 +522,10 @@ int subseq(const std::vector<std::string>& lower, const std::vector<std::string>
     if (words.size() > lower.size())
         return -1;
     for (size_t i = 0; i + words.size() <= lower.size(); ++i) {
-        bool ok = true;
-        for (size_t j = 0; j < words.size(); ++j)
-            if (lower[i + j] != words[j]) {
-                ok = false;
-                break;
-            }
-        if (ok)
+        const auto window =
+            std::ranges::subrange(lower.begin() + static_cast<long>(i),
+                                  lower.begin() + static_cast<long>(i + words.size()));
+        if (std::ranges::equal(window, words))
             return static_cast<int>(i);
     }
     return -1;
@@ -557,7 +554,7 @@ std::vector<std::string> pluginsFromTokens(const std::vector<std::string>& token
     for (const auto& t : tokens) {
         if (!t.empty() && t[0] == '@') {
             std::string tok = aliasToken(t);
-            if (std::find(out.begin(), out.end(), tok) == out.end())
+            if (!std::ranges::contains(out, tok))
                 out.push_back(tok);
         }
     }

--- a/magda/agents/command_model_onnx.cpp
+++ b/magda/agents/command_model_onnx.cpp
@@ -144,9 +144,7 @@ std::string expandAliasBrackets(const std::string& text) {
             const size_t close = text.find('>', i + 1);
             if (close != std::string::npos && close > i + 1) {
                 const std::string inner = text.substr(i + 1, close - i - 1);
-                const bool simple =
-                    std::all_of(inner.begin(), inner.end(), [](char c) { return isCore(c); });
-                if (simple) {
+                if (std::ranges::all_of(inner, isCore)) {
                     out += "@" + inner;
                     i = close + 1;
                     continue;
@@ -383,7 +381,7 @@ CommandModelMaps parseCommandModelMaps(const std::string& mapsJson) {
             seen[id] = true;
             out[static_cast<size_t>(id)] = prop.name.toString().toStdString();
         }
-        if (std::find(seen.begin(), seen.end(), false) != seen.end())
+        if (std::ranges::contains(seen, false))
             throw CommandModelOnnxError(std::string("maps.json has a sparse ") + mapName +
                                         " id map");
     };

--- a/magda/agents/compact_parser.cpp
+++ b/magda/agents/compact_parser.cpp
@@ -146,14 +146,10 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
 
             // TRACK FX <alias> — create track named after plugin + add plugin
             if (parts[1].toUpperCase() == "FX" && parts.size() >= 3) {
-                payload.fxAlias = parts[2];
-                for (int i = 3; i < parts.size(); ++i)
-                    payload.fxAlias += " " + parts[i];
+                payload.fxAlias = parts.joinIntoString(" ", 2);
                 // name left empty — executor will resolve from plugin
             } else {
-                payload.name = parts[1];
-                for (int i = 2; i < parts.size(); ++i)
-                    payload.name += " " + parts[i];
+                payload.name = parts.joinIntoString(" ", 1);
             }
             instructions.push_back({OpCode::Track, payload});
         } else if (op == "DEL") {
@@ -172,9 +168,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
             } else if (isInteger(parts[1])) {
                 payload.target.id = parts[1].getIntValue();
             } else {
-                payload.target.name = parts[1];
-                for (int i = 2; i < parts.size(); ++i)
-                    payload.target.name += " " + parts[i];
+                payload.target.name = parts.joinIntoString(" ", 1);
             }
             instructions.push_back({OpCode::Mute, payload});
         } else if (op == "SOLO") {
@@ -184,9 +178,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
             } else if (isInteger(parts[1])) {
                 payload.target.id = parts[1].getIntValue();
             } else {
-                payload.target.name = parts[1];
-                for (int i = 2; i < parts.size(); ++i)
-                    payload.target.name += " " + parts[i];
+                payload.target.name = parts.joinIntoString(" ", 1);
             }
             instructions.push_back({OpCode::Solo, payload});
         } else if (op == "SET") {
@@ -226,9 +218,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
                 payload.bar = parts[2].getDoubleValue();
                 payload.lengthBars = parts[3].getDoubleValue();
                 if (parts.size() > 4) {
-                    payload.name = parts[4];
-                    for (int i = 5; i < parts.size(); ++i)
-                        payload.name += " " + parts[i];
+                    payload.name = parts.joinIntoString(" ", 4);
                 }
             } else {
                 // Implicit track: CLIP <bar> <len> [name...]
@@ -236,9 +226,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
                 payload.bar = parts[1].getDoubleValue();
                 payload.lengthBars = parts[2].getDoubleValue();
                 if (parts.size() > 3) {
-                    payload.name = parts[3];
-                    for (int i = 4; i < parts.size(); ++i)
-                        payload.name += " " + parts[i];
+                    payload.name = parts.joinIntoString(" ", 3);
                 }
             }
             instructions.push_back({OpCode::Clip, payload});
@@ -264,9 +252,7 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
                 payload.field = parts[3].toLowerCase();
                 payload.op = parts[4];
                 if (parts.size() > 5) {
-                    payload.value = parts[5];
-                    for (int i = 6; i < parts.size(); ++i)
-                        payload.value += " " + parts[i];
+                    payload.value = parts.joinIntoString(" ", 5);
                 }
             }
             instructions.push_back({OpCode::Select, payload});
@@ -286,15 +272,11 @@ std::vector<Instruction> CompactParser::parse(const juce::String& compact) {
             } else if (isInteger(parts[1])) {
                 // Numeric first arg -> explicit track by index
                 payload.target = parseRef(parts[1]);
-                payload.fxName = parts[2];
-                for (int i = 3; i < parts.size(); ++i)
-                    payload.fxName += " " + parts[i];
+                payload.fxName = parts.joinIntoString(" ", 2);
             } else {
                 // All args are the fx name (implicit track)
                 payload.target.implicit = true;
-                payload.fxName = parts[1];
-                for (int i = 2; i < parts.size(); ++i)
-                    payload.fxName += " " + parts[i];
+                payload.fxName = parts.joinIntoString(" ", 1);
             }
             instructions.push_back({OpCode::Fx, payload});
         } else if (op == "ARP") {

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -1074,7 +1074,7 @@ bool Interpreter::executeGroupTracks(const Params& params) {
                 ctx_.setError("Track " + juce::String(oneBasedIndex) + " not found");
                 return false;
             }
-            if (std::find(trackIds.begin(), trackIds.end(), trackId) == trackIds.end())
+            if (!std::ranges::contains(trackIds, trackId))
                 trackIds.push_back(trackId);
         }
     } else if (ctx_.inFilterContext) {
@@ -1254,13 +1254,14 @@ bool Interpreter::executeRenameClip(const Params& params) {
         if (!selected.empty()) {
             // Sort clips by start time so {i} numbering follows timeline order
             std::vector<ClipId> sorted(selected.begin(), selected.end());
-            std::sort(sorted.begin(), sorted.end(), [&](ClipId a, ClipId b) {
-                auto* ca = cm.getClip(a);
-                auto* cb = cm.getClip(b);
+            const auto inTimelineOrder = [&cm](ClipId a, ClipId b) {
+                const auto* ca = cm.getClip(a);
+                const auto* cb = cm.getClip(b);
                 if (!ca || !cb)
                     return a < b;
                 return ca->startTime < cb->startTime;
-            });
+            };
+            std::ranges::sort(sorted, inTimelineOrder);
 
             int idx = 1;
             for (auto clipId : sorted) {
@@ -2068,16 +2069,10 @@ juce::String Interpreter::buildStateSnapshot(MagdaApi& api) {
         root->setProperty("scope", "all_tracks");
     } else if (selTrack != INVALID_TRACK_ID) {
         // Find 1-based index for the selected track
-        int selIndex = 1;
-        bool found = false;
-        for (const auto& track : tm.getTracks()) {
-            if (track.id == selTrack) {
-                found = true;
-                break;
-            }
-            selIndex++;
-        }
-        if (found) {
+        const auto& tracks = tm.getTracks();
+        const auto selected = std::ranges::find(tracks, selTrack, &TrackInfo::id);
+        const int selIndex = static_cast<int>(std::ranges::distance(tracks.begin(), selected)) + 1;
+        if (selected != tracks.end()) {
             root->setProperty("selected_track_id", selIndex);
             if (const auto* selectedTrack = tm.getTrack(selTrack)) {
                 auto* selectedTrackObj = new juce::DynamicObject();
@@ -2457,7 +2452,7 @@ bool Interpreter::executeAddArpeggio(const Params& params) {
     }
 
     // Sort pitches ascending for pattern application
-    std::sort(midiNotes.begin(), midiNotes.end());
+    std::ranges::sort(midiNotes);
 
     // Apply pattern ordering
     std::vector<int> ordered;

--- a/magda/agents/instruction_executor.cpp
+++ b/magda/agents/instruction_executor.cpp
@@ -130,8 +130,8 @@ double InstructionExecutor::findNonOverlappingClipStartBeats(TrackId trackId,
             ranges.push_back({start, end});
     }
 
-    std::sort(ranges.begin(), ranges.end(),
-              [](const auto& a, const auto& b) { return a.start < b.start; });
+    const auto startOf = [](const auto& range) { return range.start; };
+    std::ranges::sort(ranges, {}, startOf);
 
     for (const auto& range : ranges) {
         if (range.end <= candidate + epsilon)
@@ -858,7 +858,7 @@ bool InstructionExecutor::executeArp(const ArpOp& op) {
     }
 
     // Sort ascending as the canonical starting order
-    std::sort(midiNotes.begin(), midiNotes.end());
+    std::ranges::sort(midiNotes);
 
     // Apply pattern ordering: up (default), down, updown
     auto pattern = op.pattern.trim().toLowerCase();

--- a/magda/agents/internal_plugins.hpp
+++ b/magda/agents/internal_plugins.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_core/juce_core.h>
 
+#include <algorithm>
+#include <ranges>
 #include <vector>
 
 #include "../daw/audio/plugins/InternalPluginRegistry.hpp"
@@ -207,11 +209,10 @@ inline void makePrimaryAliasesUnique(std::vector<InternalPluginInfo>& entries) {
     for (size_t i = 0; i < entries.size(); ++i) {
         auto& entry = entries[i];
         const auto isTaken = [&](const juce::String& alias) {
-            for (size_t previous = 0; previous < i; ++previous) {
-                if (entries[previous].primaryAlias.equalsIgnoreCase(alias))
-                    return true;
-            }
-            return false;
+            const auto matchesAlias = [&alias](const InternalPluginInfo& earlier) {
+                return earlier.primaryAlias.equalsIgnoreCase(alias);
+            };
+            return std::ranges::any_of(entries | std::views::take(i), matchesAlias);
         };
 
         if (!isTaken(entry.primaryAlias))

--- a/magda/agents/music_helpers.hpp
+++ b/magda/agents/music_helpers.hpp
@@ -2,9 +2,11 @@
 
 #include <juce_core/juce_core.h>
 
+#include <algorithm>
 #include <cctype>
 #include <cstdlib>
 #include <map>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -20,14 +22,9 @@ inline int parseNoteName(const std::string& name) {
         return -1;
 
     // Plain number → return directly
-    bool allDigits = true;
-    size_t start = (name[0] == '-') ? 1 : 0;
-    for (size_t i = start; i < name.size(); i++) {
-        if (!std::isdigit(static_cast<unsigned char>(name[i]))) {
-            allDigits = false;
-            break;
-        }
-    }
+    const auto isDigit = [](char c) { return std::isdigit(static_cast<unsigned char>(c)) != 0; };
+    const size_t start = (name[0] == '-') ? 1 : 0;
+    const bool allDigits = std::ranges::all_of(name | std::views::drop(start), isDigit);
     if (allDigits && !name.empty())
         return std::atoi(name.c_str());
 

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -129,11 +129,7 @@ std::vector<DeviceCatalogEntry> DeviceApiLive::getCatalog() const {
     for (auto& entry : catalog) {
         if (entry.catalogId.isEmpty())
             continue;
-        const auto duplicate =
-            std::any_of(unique.begin(), unique.end(), [&entry](const DeviceCatalogEntry& seen) {
-                return seen.catalogId == entry.catalogId;
-            });
-        if (!duplicate)
+        if (!std::ranges::contains(unique, entry.catalogId, &DeviceCatalogEntry::catalogId))
             unique.push_back(std::move(entry));
     }
 
@@ -237,9 +233,8 @@ bool DeviceApiLive::setDeviceParameter(const ChainNodePath& devicePath, int para
     if (device == nullptr)
         return false;
 
-    const auto match = std::find_if(
-        device->parameters.begin(), device->parameters.end(),
-        [paramIndex](const ParameterInfo& info) { return info.paramIndex == paramIndex; });
+    const auto match =
+        std::ranges::find(device->parameters, paramIndex, &ParameterInfo::paramIndex);
     if (match == device->parameters.end())
         return false;
 
@@ -256,7 +251,7 @@ bool DeviceApiLive::setDeviceParameter(const ChainNodePath& devicePath, int para
     if (device->format != PluginFormat::Internal) {
         const auto position = static_cast<int>(match - device->parameters.begin());
         const auto& allowed = device->aiSoundDesignerParameters;
-        if (std::find(allowed.begin(), allowed.end(), position) == allowed.end())
+        if (!std::ranges::contains(allowed, position))
             return false;
     }
 
@@ -279,9 +274,9 @@ bool DeviceApiLive::setDeviceParameterConfig(const ChainNodePath& devicePath,
         return false;
 
     const auto count = static_cast<int>(device->parameters.size());
-    const auto inRange = [count](const std::optional<std::vector<int>>& indices) {
-        return !indices || std::all_of(indices->begin(), indices->end(),
-                                       [count](int index) { return index >= 0 && index < count; });
+    const auto isKnownIndex = [count](int index) { return index >= 0 && index < count; };
+    const auto inRange = [&isKnownIndex](const std::optional<std::vector<int>>& indices) {
+        return !indices || std::ranges::all_of(*indices, isKnownIndex);
     };
     if (!inRange(update.visibleParameters) || !inRange(update.miniMixerParameters) ||
         !inRange(update.aiAgentParameters))
@@ -315,8 +310,7 @@ bool DeviceApiLive::setDeviceParameterConfig(const ChainNodePath& devicePath,
         if (!indices)
             return;
         for (auto& entry : config.entries)
-            entry.*flag =
-                std::find(indices->begin(), indices->end(), entry.index) != indices->end();
+            entry.*flag = std::ranges::contains(*indices, entry.index);
     };
     applySelection(update.visibleParameters, &PluginParameterConfigEntry::visible);
     applySelection(update.miniMixerParameters, &PluginParameterConfigEntry::miniMixer);

--- a/magda/daw/api/osc_feedback_live.cpp
+++ b/magda/daw/api/osc_feedback_live.cpp
@@ -240,9 +240,10 @@ void OscFeedbackProjector::syncSurfaces() {
     const auto peers = router_.peers().snapshot();
 
     const auto stillThere = [&peers](const Surface& surface) {
-        return std::any_of(peers.begin(), peers.end(), [&surface](const osc::OscPeers::Peer& peer) {
+        const auto answersForSurface = [&surface](const osc::OscPeers::Peer& peer) {
             return peer.answerable && peer.id == surface.peer && peer.host == surface.host;
-        });
+        };
+        return std::ranges::any_of(peers, answersForSurface);
     };
 
     // The host is compared as well as the id. The id alone is enough, since ids
@@ -258,10 +259,10 @@ void OscFeedbackProjector::syncSurfaces() {
         if (!peer.answerable)
             continue;
 
-        auto known =
-            std::find_if(surfaces_.begin(), surfaces_.end(), [&peer](const Surface& surface) {
-                return surface.peer == peer.id && surface.host == peer.host;
-            });
+        const auto isPeerSurface = [&peer](const Surface& surface) {
+            return surface.peer == peer.id && surface.host == peer.host;
+        };
+        auto known = std::ranges::find_if(surfaces_, isPeerSurface);
         if (known != surfaces_.end()) {
             if (peer.resumptions != known->resumptions) {
                 known->feedback->requestSnapshot();
@@ -564,11 +565,7 @@ void OscFeedbackProjector::projectBindings() {
         if (!binding.source.isOsc() || binding.source.oscAddress.isEmpty())
             continue;
 
-        const bool seen = std::any_of(boundValues_.begin(), boundValues_.end(),
-                                      [&binding](const BoundValue& candidate) {
-                                          return candidate.address == binding.source.oscAddress;
-                                      });
-        if (seen)
+        if (std::ranges::contains(boundValues_, binding.source.oscAddress, &BoundValue::address))
             continue;
 
         const auto resolved = resolver.resolve(binding.target);

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -20,9 +20,12 @@ bool schemaDeclaresType(const juce::var& schema, const char* expected) {
     const auto type = object->getProperty("type");
     if (type.isString())
         return type.toString() == expected;
-    if (auto* types = type.getArray())
-        return std::any_of(types->begin(), types->end(),
-                           [&](const auto& candidate) { return candidate.toString() == expected; });
+    if (auto* types = type.getArray()) {
+        const auto namesExpected = [&expected](const juce::var& candidate) {
+            return candidate.toString() == expected;
+        };
+        return std::ranges::any_of(*types, namesExpected);
+    }
     return false;
 }
 
@@ -638,8 +641,10 @@ bool typeMatches(const juce::var& value, const juce::var& declaredType) {
     if (declaredType.isString())
         return matchesType(value, declaredType.toString());
     if (auto* types = declaredType.getArray()) {
-        return std::any_of(types->begin(), types->end(),
-                           [&](const auto& type) { return matchesType(value, type.toString()); });
+        const auto matchesOneType = [&value](const juce::var& type) {
+            return matchesType(value, type.toString());
+        };
+        return std::ranges::any_of(*types, matchesOneType);
     }
     return true;
 }
@@ -729,9 +734,7 @@ void validateValue(const juce::var& value, const juce::var& schema, const juce::
         addIssue(issues, path, "const", "Value does not match the required constant");
 
     if (auto* allowed = schemaObject->getProperty("enum").getArray()) {
-        const auto found = std::any_of(allowed->begin(), allowed->end(),
-                                       [&](const auto& candidate) { return candidate == value; });
-        if (!found)
+        if (!std::ranges::contains(*allowed, value))
             addIssue(issues, path, "enum", "Value is not one of the allowed values");
     }
 
@@ -2196,8 +2199,7 @@ OperationRegistry::OperationRegistry() {
 
     for (const auto& [name, scope] : kWriteScopes) {
         const auto found =
-            std::find_if(operations_.begin(), operations_.end(),
-                         [&](const OperationDescriptor& op) { return op.name == name; });
+            std::ranges::find(operations_, juce::String(name), &OperationDescriptor::name);
         // A policy entry naming an operation that does not exist is a rename
         // that updated one side. Silently ignoring it would leave the renamed
         // operation on the `read` default, which the check below catches — but
@@ -2246,8 +2248,7 @@ const std::vector<OperationDescriptor>& OperationRegistry::operations() const {
 }
 
 const OperationDescriptor* OperationRegistry::find(const juce::String& name) const {
-    const auto found = std::find_if(operations_.begin(), operations_.end(),
-                                    [&](const auto& operation) { return operation.name == name; });
+    const auto found = std::ranges::find(operations_, name, &OperationDescriptor::name);
     return found == operations_.end() ? nullptr : &*found;
 }
 

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <atomic>
+#include <tuple>
 
 #include "../core/AutomationInfo.hpp"
 #include "../core/ClipInfo.hpp"
@@ -380,7 +381,7 @@ DeviceCatalogEntryDto makeDeviceCatalogEntryDto(const DeviceCatalogEntry& entry)
 
 std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device) {
     const auto contains = [](const std::vector<int>& positions, int position) {
-        return std::find(positions.begin(), positions.end(), position) != positions.end();
+        return std::ranges::contains(positions, position);
     };
     // The customization lists key on position in `parameters`, while the wire
     // `index` is `paramIndex` — the address parameter writes take. The two are
@@ -428,7 +429,7 @@ SelectionDto makeSelectionDto(MagdaApi& api) {
     if (selection.getSelectedClip() != INVALID_CLIP_ID)
         dto.clipId = selection.getSelectedClip();
     dto.clipIds.assign(selection.getSelectedClips().begin(), selection.getSelectedClips().end());
-    std::sort(dto.clipIds.begin(), dto.clipIds.end());
+    std::ranges::sort(dto.clipIds);
     if (selection.getSelectedAutomationLaneId() != INVALID_AUTOMATION_LANE_ID)
         dto.automationLaneId = selection.getSelectedAutomationLaneId();
     if (selection.getSelectedAutomationClipId() != INVALID_AUTOMATION_CLIP_ID)
@@ -463,9 +464,10 @@ SessionDto makeSessionDto(MagdaApi& api) {
                                  sessionStateName(api.session().getClipPlayState(clip->id))});
         }
     }
-    std::sort(dto.slots.begin(), dto.slots.end(), [](const auto& a, const auto& b) {
-        return a.sceneIndex != b.sceneIndex ? a.sceneIndex < b.sceneIndex : a.trackId < b.trackId;
-    });
+    const auto sceneThenTrack = [](const auto& slot) {
+        return std::tuple{slot.sceneIndex, slot.trackId};
+    };
+    std::ranges::sort(dto.slots, {}, sceneThenTrack);
     return dto;
 }
 

--- a/magda/daw/api/remote_audit.cpp
+++ b/magda/daw/api/remote_audit.cpp
@@ -159,7 +159,7 @@ void registerRemoteSecret(const juce::String& secret) {
 
     const std::scoped_lock lock(secretsMutex());
     auto& values = secrets();
-    if (std::find(values.begin(), values.end(), secret) == values.end())
+    if (!std::ranges::contains(values, secret))
         values.push_back(secret);
 }
 

--- a/magda/daw/api/remote_clients.cpp
+++ b/magda/daw/api/remote_clients.cpp
@@ -114,10 +114,8 @@ void RemoteClientRegistry::noteConnected(ConnectedClient client) {
     // Replace rather than append on a repeated id. A transport that reuses one
     // would otherwise leave a phantom row that no disconnect could clear,
     // because `noteDisconnected` removes a single entry.
-    const auto found = std::find_if(connections_.begin(), connections_.end(),
-                                    [&](const ConnectedClient& existing) {
-                                        return existing.connectionId == client.connectionId;
-                                    });
+    const auto found =
+        std::ranges::find(connections_, client.connectionId, &ConnectedClient::connectionId);
     if (found != connections_.end())
         *found = std::move(client);
     else
@@ -154,9 +152,8 @@ bool RemoteClientRegistry::disconnect(const juce::String& connectionId) {
     DisconnectHandler handler;
     {
         const std::scoped_lock lock(mutex_);
-        const auto found = std::find_if(
-            connections_.begin(), connections_.end(),
-            [&](const ConnectedClient& client) { return client.connectionId == connectionId; });
+        const auto found =
+            std::ranges::find(connections_, connectionId, &ConnectedClient::connectionId);
         if (found == connections_.end())
             return false;
 

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -211,9 +211,8 @@ bool targetResolves(MagdaApi& api, const AutomationTarget& target) {
         if (api.devices().getDevice(target.devicePath) == nullptr)
             return false;
         const auto parameters = api.devices().getDeviceParameters(target.devicePath);
-        return std::any_of(parameters.begin(), parameters.end(), [&target](const auto& parameter) {
-            return parameter.index == target.paramIndex;
-        });
+        const auto indexOfParameter = [](const auto& parameter) { return parameter.index; };
+        return std::ranges::contains(parameters, target.paramIndex, indexOfParameter);
     }
 
     if (target.kind == ControlTarget::Kind::TrackVolume ||
@@ -222,9 +221,8 @@ bool targetResolves(MagdaApi& api, const AutomationTarget& target) {
     if (target.kind == ControlTarget::Kind::SendLevel) {
         if (target.devicePath.getType() != ChainNodeType::Track)
             return false;
-        return std::any_of(track->sends.begin(), track->sends.end(), [&target](const auto& send) {
-            return send.busIndex == target.sendBusIndex;
-        });
+        const auto busIndexOf = [](const auto& send) { return send.busIndex; };
+        return std::ranges::contains(track->sends, target.sendBusIndex, busIndexOf);
     }
 
     const MacroArray* macros = nullptr;
@@ -260,10 +258,8 @@ bool targetResolves(MagdaApi& api, const AutomationTarget& target) {
         return target.paramIndex >= 0 &&
                static_cast<std::size_t>(target.paramIndex) < macros->size();
     if (target.kind == ControlTarget::Kind::ModParam) {
-        const auto found = std::find_if(mods->begin(), mods->end(), [&target](const auto& mod) {
-            return mod.id == target.modId;
-        });
-        return found != mods->end() && target.modParamIndex == 0;
+        const auto idOf = [](const auto& mod) { return mod.id; };
+        return std::ranges::contains(*mods, target.modId, idOf) && target.modParamIndex == 0;
     }
 
     return false;
@@ -579,10 +575,7 @@ HandlerResult devicesSetParameter(MagdaApi& api, const juce::var& input, const R
 
     const auto parameterIndex = readInt(input, "parameterIndex", -1);
     const auto parameters = makeDeviceParameterDtos(*device);
-    const auto named = std::find_if(parameters.begin(), parameters.end(),
-                                    [parameterIndex](const DeviceParameterDto& parameter) {
-                                        return parameter.index == parameterIndex;
-                                    });
+    const auto named = std::ranges::find(parameters, parameterIndex, &DeviceParameterDto::index);
     if (named == parameters.end())
         return notFound("parameter", parameterIndex);
 
@@ -782,8 +775,7 @@ HandlerResult racksSetBypassed(MagdaApi& api, const juce::var& input, const Requ
     if (track == nullptr)
         return notFound("track", trackId);
     const auto graph = makeDeviceGraphDto({*track});
-    const auto found = std::find_if(graph.racks.begin(), graph.racks.end(),
-                                    [rackId](const RackDto& rack) { return rack.id == rackId; });
+    const auto found = std::ranges::find(graph.racks, rackId, &RackDto::id);
     if (found == graph.racks.end())
         return notFound("rack", rackId);
     return HandlerResult::ok(toJson(*found));

--- a/magda/daw/api/remote_http_auth.cpp
+++ b/magda/daw/api/remote_http_auth.cpp
@@ -31,7 +31,7 @@ bool isOriginAllowed(bool originPresent, const juce::String& origin,
                      const std::vector<juce::String>& allowedOrigins) {
     if (!originPresent)
         return true;
-    return std::find(allowedOrigins.begin(), allowedOrigins.end(), origin) != allowedOrigins.end();
+    return std::ranges::contains(allowedOrigins, origin);
 }
 
 }  // namespace magda::remote

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -229,7 +229,7 @@ McpEra eraForVersion(const juce::String& version) {
 
 bool isSupportedVersion(const juce::String& version) {
     const auto& versions = mcpProtocolVersions();
-    return std::find(versions.begin(), versions.end(), version) != versions.end();
+    return std::ranges::contains(versions, version);
 }
 
 const juce::String& latestProtocolVersion() {
@@ -515,8 +515,7 @@ McpEndpoint::ListenFilter McpEndpoint::parseListenFilter(const juce::var& params
             // waiting on a stream for an event with no source.
             if (!topicForResource(uri).has_value())
                 continue;
-            if (std::find(filter.resourceSubscriptions.begin(), filter.resourceSubscriptions.end(),
-                          uri) == filter.resourceSubscriptions.end()) {
+            if (!std::ranges::contains(filter.resourceSubscriptions, uri)) {
                 filter.resourceSubscriptions.push_back(uri);
             }
         }
@@ -528,7 +527,7 @@ std::vector<Topic> McpEndpoint::topicsFor(const ListenFilter& filter) const {
     std::vector<Topic> topics;
     for (const auto& uri : filter.resourceSubscriptions) {
         if (const auto topic = topicForResource(uri)) {
-            if (std::find(topics.begin(), topics.end(), *topic) == topics.end())
+            if (!std::ranges::contains(topics, *topic))
                 topics.push_back(*topic);
         }
     }

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -603,9 +603,10 @@ struct RemoteMcpServer::Impl {
         std::shared_ptr<EventStream> target;
         {
             const std::scoped_lock lock(streamMutex);
-            const auto found = std::find_if(
-                streams.begin(), streams.end(),
-                [&](const std::shared_ptr<EventStream>& s) { return s->handle == handle; });
+            const auto hasHandle = [&handle](const std::shared_ptr<EventStream>& stream) {
+                return stream->handle == handle;
+            };
+            const auto found = std::ranges::find_if(streams, hasHandle);
             if (found != streams.end())
                 target = *found;
         }
@@ -1178,7 +1179,7 @@ struct RemoteMcpServer::Impl {
             }
 
             auto& uris = it->second.subscribedUris;
-            const auto existing = std::find(uris.begin(), uris.end(), uri);
+            const auto existing = std::ranges::find(uris, uri);
             if (subscribe) {
                 if (existing == uris.end())
                     uris.push_back(uri);

--- a/magda/daw/api/remote_service.cpp
+++ b/magda/daw/api/remote_service.cpp
@@ -570,9 +570,7 @@ juce::String RemoteApiService::idempotencyKey(const RequestContext& context) {
 
 std::optional<Response> RemoteApiService::cachedResponse(const juce::String& key) const {
     const std::scoped_lock lock(cacheMutex_);
-    const auto found =
-        std::find_if(cache_.begin(), cache_.end(),
-                     [&key](const CachedResponse& entry) { return entry.key == key; });
+    const auto found = std::ranges::find(cache_, key, &CachedResponse::key);
     if (found == cache_.end())
         return std::nullopt;
     return found->response;
@@ -580,9 +578,7 @@ std::optional<Response> RemoteApiService::cachedResponse(const juce::String& key
 
 void RemoteApiService::cacheResponse(const juce::String& key, const Response& response) {
     const std::scoped_lock lock(cacheMutex_);
-    const auto found =
-        std::find_if(cache_.begin(), cache_.end(),
-                     [&key](const CachedResponse& entry) { return entry.key == key; });
+    const auto found = std::ranges::find(cache_, key, &CachedResponse::key);
     if (found != cache_.end()) {
         found->response = response;
         return;

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -167,8 +167,8 @@ Diff diffElements(Topic topic, const juce::var& previous, const juce::var& curre
         beforeByKey.reserve(static_cast<std::size_t>(before->size()));
         for (const auto& element : *before)
             beforeByKey.emplace_back(keyOf(element, fields), &element);
-        std::sort(beforeByKey.begin(), beforeByKey.end(),
-                  [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
+        const auto keyPart = [](const auto& entry) { return entry.first; };
+        std::ranges::sort(beforeByKey, {}, keyPart);
     }
 
     const auto find = [&beforeByKey](const juce::String& key) -> const juce::var* {
@@ -193,9 +193,9 @@ Diff diffElements(Topic topic, const juce::var& previous, const juce::var& curre
         seen.push_back(std::move(key));
     }
 
-    std::sort(seen.begin(), seen.end());
+    std::ranges::sort(seen);
     for (const auto& [key, element] : beforeByKey)
-        if (!std::binary_search(seen.begin(), seen.end(), key))
+        if (!std::ranges::binary_search(seen, key))
             diff.removed.add(identityOf(*element, fields));
 
     return diff;
@@ -403,15 +403,14 @@ bool SubscriptionHub::isSubscriptionMethod(const juce::String& method) {
 }
 
 SubscriptionHub::Client* SubscriptionHub::findLocked(ClientId client) {
-    const auto found = std::find_if(clients_.begin(), clients_.end(),
-                                    [client](const Client& c) { return c.id == client; });
+    const auto found = std::ranges::find(clients_, client, &Client::id);
     return found == clients_.end() ? nullptr : &*found;
 }
 
 bool SubscriptionHub::anySubscriberLocked(Topic topic) const {
     const auto index = indexOf(topic);
-    return std::any_of(clients_.begin(), clients_.end(),
-                       [index](const Client& client) { return client.subscribed[index]; });
+    const auto isSubscribed = [index](const Client& client) { return client.subscribed[index]; };
+    return std::ranges::any_of(clients_, isSubscribed);
 }
 
 void SubscriptionHub::releaseIdleTopicsLocked() {
@@ -629,9 +628,10 @@ void SubscriptionHub::foldFlushOutcomesLocked() {
 
 bool SubscriptionHub::owesSnapshotLocked(Topic topic) const {
     const auto index = indexOf(topic);
-    return std::any_of(clients_.begin(), clients_.end(), [index](const Client& client) {
+    const auto owesSnapshot = [index](const Client& client) {
         return client.subscribed[index] && client.needsSnapshot[index];
-    });
+    };
+    return std::ranges::any_of(clients_, owesSnapshot);
 }
 
 void SubscriptionHub::publishTopicLocked(Topic topic, Revision revision) {
@@ -862,7 +862,7 @@ bool SubscriptionHub::handle(ClientId client, const juce::String& method, const 
                                              "unknown topic: " + entry.toString(), revision));
                 return true;
             }
-            if (std::find(requested.begin(), requested.end(), *topic) == requested.end())
+            if (!std::ranges::contains(requested, *topic))
                 requested.push_back(*topic);
         }
     }
@@ -953,8 +953,7 @@ Response SubscriptionHub::execute(ClientId client, const juce::String& method,
             // going away rather than narrowing what it watches.
             for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {
                 const auto topic = static_cast<Topic>(index);
-                if (!topicsGiven ||
-                    std::find(requested.begin(), requested.end(), topic) != requested.end())
+                if (!topicsGiven || std::ranges::contains(requested, topic))
                     entry->subscribed[index] = false;
             }
             releaseIdleTopicsLocked();
@@ -964,8 +963,7 @@ Response SubscriptionHub::execute(ClientId client, const juce::String& method,
                 const auto topic = static_cast<Topic>(index);
                 if (!entry->subscribed[index])
                     continue;
-                if (topicsGiven &&
-                    std::find(requested.begin(), requested.end(), topic) == requested.end())
+                if (topicsGiven && !std::ranges::contains(requested, topic))
                     continue;
                 targets.push_back(topic);
             }

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -545,9 +545,10 @@ struct RemoteWebSocketServer::Impl {
      */
     bool disconnectByHandle(const juce::String& handle) {
         const std::scoped_lock lock(liveMutex);
-        const auto found =
-            std::find_if(live.begin(), live.end(),
-                         [&](const std::shared_ptr<Connection>& c) { return c->handle == handle; });
+        const auto hasHandle = [&handle](const std::shared_ptr<Connection>& connection) {
+            return connection->handle == handle;
+        };
+        const auto found = std::ranges::find_if(live, hasHandle);
         if (found == live.end())
             return false;
         (*found)->shutdown();

--- a/magda/daw/engine/TempoLaneBridge.cpp
+++ b/magda/daw/engine/TempoLaneBridge.cpp
@@ -69,9 +69,7 @@ void TempoLaneBridge::writePointsToSequence(const std::vector<AutomationPoint>& 
         return;  // TE requires >=1 tempo; nothing to reconcile against.
 
     auto points = pointsIn;
-    std::sort(points.begin(), points.end(), [](const AutomationPoint& a, const AutomationPoint& b) {
-        return a.beatPosition < b.beatPosition;
-    });
+    std::ranges::sort(points, {}, &AutomationPoint::beatPosition);
 
     auto& ts = edit.tempoSequence;
 

--- a/magda/daw/engine/TempoSequenceRippleMath.hpp
+++ b/magda/daw/engine/TempoSequenceRippleMath.hpp
@@ -72,19 +72,15 @@ std::vector<T> rippleEvents(const std::vector<T>& in, Mode mode, double startBea
         }
     }
 
-    std::sort(out.begin(), out.end(), [](const T& a, const T& b) { return a.beat < b.beat; });
+    std::ranges::sort(out, {}, &T::beat);
     return out;
 }
 
 // Compare two event lists. Ripple never changes an event's payload, only its
 // beat position and set membership, so size + beats settle equality.
 template <typename T> bool sameBeats(const std::vector<T>& a, const std::vector<T>& b) {
-    if (a.size() != b.size())
-        return false;
-    for (std::size_t i = 0; i < a.size(); ++i)
-        if (std::abs(a[i].beat - b[i].beat) > kBeatEps)
-            return false;
-    return true;
+    const auto nearBeat = [](double lhs, double rhs) { return std::abs(lhs - rhs) <= kBeatEps; };
+    return std::ranges::equal(a, b, nearBeat, &T::beat, &T::beat);
 }
 
 }  // namespace magda::temporipple

--- a/magda/daw/engine/TracktionEngineWrapperDevices.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperDevices.cpp
@@ -1,5 +1,6 @@
 #include "../audio/AudioBridge.hpp"
 #include "TracktionEngineWrapper.hpp"
+#include "WaveDeviceChannels.hpp"
 
 namespace magda {
 
@@ -72,16 +73,10 @@ void TracktionEngineWrapper::handlePlaybackContextReallocation(tracktion::Device
             juce::MessageManager::getInstance()->runDispatchLoopUntil(0);
 
             int numInputChannels = device->getInputChannelNames().size();
-            for (auto* dev : dm.getWaveInputDevices()) {
-                bool shouldEnable = false;
-                for (const auto& ch : dev->getChannels()) {
-                    if (ch.indexInDevice < numInputChannels) {
-                        shouldEnable = true;
-                        break;
-                    }
-                }
-                dev->setEnabled(shouldEnable);
-            }
+            const auto withinDeviceInputs = [numInputChannels](int index) {
+                return index < numInputChannels;
+            };
+            enableDevicesForChannels(dm.getWaveInputDevices(), withinDeviceInputs);
 
             DBG("Reconfigured wave devices for " << currentDeviceName << " (" << numInputChannels
                                                  << " inputs)");
@@ -195,25 +190,12 @@ void TracktionEngineWrapper::setEnabledWaveChannels(bool input, const juce::BigI
     if (engine_ == nullptr)
         return;
 
-    const auto applyChannels = [&channels](const auto& devices) {
-        for (auto* device : devices) {
-            if (device == nullptr)
-                continue;
-            bool shouldEnable = false;
-            for (const auto& channel : device->getChannels()) {
-                if (channels[channel.indexInDevice]) {
-                    shouldEnable = true;
-                    break;
-                }
-            }
-            if (device->isEnabled() != shouldEnable)
-                device->setEnabled(shouldEnable);
-        }
-    };
+    const auto isSelected = [&channels](int index) { return channels[index]; };
+    auto& deviceManager = engine_->getDeviceManager();
     if (input)
-        applyChannels(engine_->getDeviceManager().getWaveInputDevices());
+        enableDevicesForChannels(deviceManager.getWaveInputDevices(), isSelected);
     else
-        applyChannels(engine_->getDeviceManager().getWaveOutputDevices());
+        enableDevicesForChannels(deviceManager.getWaveOutputDevices(), isSelected);
 }
 
 void TracktionEngineWrapper::rescanWaveDevices(bool enableInputs, bool enableOutputs) {

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -22,6 +22,7 @@
 #include "TempoLaneSync.hpp"
 #include "TracktionEngineWrapper.hpp"
 #include "TracktionTempoMap.hpp"
+#include "WaveDeviceChannels.hpp"
 
 namespace magda {
 
@@ -247,29 +248,17 @@ void TracktionEngineWrapper::configureAudioDevices() {
 
     // Apply saved channel preferences at the TE wave device level
     if (preferredInputs > 0) {
-        for (auto* dev : dm.getWaveInputDevices()) {
-            bool shouldEnable = false;
-            for (const auto& ch : dev->getChannels()) {
-                if (ch.indexInDevice < preferredInputs) {
-                    shouldEnable = true;
-                    break;
-                }
-            }
-            dev->setEnabled(shouldEnable);
-        }
+        const auto withinPreferredInputs = [preferredInputs](int index) {
+            return index < preferredInputs;
+        };
+        enableDevicesForChannels(dm.getWaveInputDevices(), withinPreferredInputs);
         DBG("Applied preferred input channel count: " << preferredInputs);
     }
     if (preferredOutputs > 0) {
-        for (auto* dev : dm.getWaveOutputDevices()) {
-            bool shouldEnable = false;
-            for (const auto& ch : dev->getChannels()) {
-                if (ch.indexInDevice < preferredOutputs) {
-                    shouldEnable = true;
-                    break;
-                }
-            }
-            dev->setEnabled(shouldEnable);
-        }
+        const auto withinPreferredOutputs = [preferredOutputs](int index) {
+            return index < preferredOutputs;
+        };
+        enableDevicesForChannels(dm.getWaveOutputDevices(), withinPreferredOutputs);
         DBG("Applied preferred output channel count: " << preferredOutputs);
     }
 

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -1,6 +1,8 @@
+#include <algorithm>
 #include <fstream>
 #include <map>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <thread>
@@ -622,7 +624,7 @@ std::vector<std::string> TracktionEngineWrapper::getSystemPluginSearchPaths() co
         const auto searchPaths = format->getDefaultLocationsToSearch();
         for (int j = 0; j < searchPaths.getNumPaths(); ++j) {
             auto path = searchPaths[j].getFullPathName().toStdString();
-            if (std::find(paths.begin(), paths.end(), path) == paths.end())
+            if (!std::ranges::contains(paths, path))
                 paths.push_back(std::move(path));
         }
     }
@@ -686,17 +688,14 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
         return result;
     }
 
-    juce::PluginDescription description;
-    bool found = false;
-    for (const auto& candidate : getKnownPluginTypes()) {
-        if (candidate.createIdentifierString() == pluginId) {
-            description = candidate;
-            found = true;
-            break;
-        }
-    }
-    if (!found)
+    const auto identifierOf = [](const juce::PluginDescription& candidate) {
+        return candidate.createIdentifierString();
+    };
+    const auto knownTypes = getKnownPluginTypes();
+    const auto match = std::ranges::find(knownTypes, pluginId, identifierOf);
+    if (match == knownTypes.end())
         return result;
+    const juce::PluginDescription description = *match;
 
     juce::String error;
     auto& formatManager = engine_->getPluginManager().pluginFormatManager;
@@ -749,15 +748,11 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
             for (const auto sample : samplePoints)
                 info.scanInput.displayTexts.push_back(parameter->getText(sample, 128));
 
-            bool allLabels = true;
-            for (const auto& text : info.scanInput.displayTexts) {
+            const auto startsWithALetter = [](const juce::String& text) {
                 const auto trimmed = text.trim();
-                if (trimmed.isEmpty() || !juce::CharacterFunctions::isLetter(trimmed[0])) {
-                    allLabels = false;
-                    break;
-                }
-            }
-            if (allLabels) {
+                return trimmed.isNotEmpty() && juce::CharacterFunctions::isLetter(trimmed[0]);
+            };
+            if (std::ranges::all_of(info.scanInput.displayTexts, startsWithALetter)) {
                 info.scanInput.displayTexts.clear();
                 for (int state = 0; state <= 1000; ++state) {
                     const auto text = parameter->getText(static_cast<float>(state) / 1000.0f, 128);

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 
 #include "../audio/AudioBridge.hpp"
 #include "../core/ClipManager.hpp"
@@ -469,12 +470,8 @@ bool TracktionEngineWrapper::isSessionSlotRecording(TrackId trackId, int sceneIn
 }
 
 bool TracktionEngineWrapper::hasActiveSessionSlotRecordings() const {
-    for (const auto& [trackId, target] : sessionSlotRecordingTargets_) {
-        juce::ignoreUnused(trackId);
-        if (target.active)
-            return true;
-    }
-    return false;
+    const auto isActive = [](const auto& target) { return target.active; };
+    return std::ranges::any_of(sessionSlotRecordingTargets_ | std::views::values, isActive);
 }
 
 void TracktionEngineWrapper::beginArmedSessionSlotRecordings() {

--- a/magda/daw/engine/TracktionEngineWrapperTracks.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTracks.cpp
@@ -1,3 +1,7 @@
+#include <algorithm>
+#include <iterator>
+#include <ranges>
+
 #include "../audio/AudioBridge.hpp"
 #include "TracktionEngineWrapper.hpp"
 
@@ -121,14 +125,12 @@ void TracktionEngineWrapper::setTrackColor(const std::string& track_id, int r, i
 std::vector<std::string> TracktionEngineWrapper::getAllTrackIds() const {
     std::vector<std::string> ids;
     ids.reserve(trackMap_.size());
-    for (const auto& pair : trackMap_) {
-        ids.push_back(pair.first);
-    }
+    std::ranges::copy(trackMap_ | std::views::keys, std::back_inserter(ids));
     return ids;
 }
 
 bool TracktionEngineWrapper::trackExists(const std::string& track_id) const {
-    return trackMap_.find(track_id) != trackMap_.end();
+    return trackMap_.contains(track_id);
 }
 
 void TracktionEngineWrapper::previewNoteOnTrack(const std::string& track_id, int noteNumber,

--- a/magda/daw/engine/WaveDeviceChannels.hpp
+++ b/magda/daw/engine/WaveDeviceChannels.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <algorithm>
+
+namespace magda {
+
+/** @brief Enable each wave device that carries a channel the predicate accepts.
+ *
+ *  A TE wave device owns a slice of the interface's channels, so it belongs in
+ *  the enabled set when any one of its channels does (#2148).
+ */
+void enableDevicesForChannels(const auto& devices, auto wantsChannel) {
+    for (auto* device : devices) {
+        if (device == nullptr)
+            continue;
+        const auto isWanted = [&wantsChannel](const auto& channel) {
+            return wantsChannel(channel.indexInDevice);
+        };
+        const bool shouldEnable = std::ranges::any_of(device->getChannels(), isWanted);
+        if (device->isEnabled() != shouldEnable)
+            device->setEnabled(shouldEnable);
+    }
+}
+
+}  // namespace magda

--- a/magda/daw/media_db/MediaDbIndexer.cpp
+++ b/magda/daw/media_db/MediaDbIndexer.cpp
@@ -234,7 +234,7 @@ std::vector<std::string> tagTokensFromText(const std::string& raw) {
     std::vector<std::string> out;
     std::string token;
     auto flush = [&]() {
-        if (!token.empty() && std::find(out.begin(), out.end(), token) == out.end()) {
+        if (!token.empty() && !std::ranges::contains(out, token)) {
             out.push_back(token);
         }
         token.clear();
@@ -255,9 +255,8 @@ void addTag(std::vector<std::pair<std::string, float>>& tags, const std::string&
     if (tag.empty()) {
         return;
     }
-    const auto exists =
-        std::any_of(tags.begin(), tags.end(), [&](const auto& t) { return t.first == tag; });
-    if (!exists) {
+    const auto tagNameOf = [](const auto& entry) { return entry.first; };
+    if (!std::ranges::contains(tags, tag, tagNameOf)) {
         tags.emplace_back(tag, 1.0F);
     }
 }

--- a/magda/daw/media_db/MediaDbMetadata.cpp
+++ b/magda/daw/media_db/MediaDbMetadata.cpp
@@ -1162,8 +1162,9 @@ int removeDuplicateFilePathRows(MediaDatabase& db) {
     if (removeIds.empty()) {
         return 0;
     }
-    std::sort(removeIds.begin(), removeIds.end());
-    removeIds.erase(std::unique(removeIds.begin(), removeIds.end()), removeIds.end());
+    std::ranges::sort(removeIds);
+    const auto duplicates = std::ranges::unique(removeIds);
+    removeIds.erase(duplicates.begin(), duplicates.end());
     return deleteMediaRows(db, removeIds);
 }
 

--- a/magda/daw/media_db/MediaDbQuery.cpp
+++ b/magda/daw/media_db/MediaDbQuery.cpp
@@ -682,8 +682,8 @@ std::vector<QueryResult> MediaDbQuery::search(const std::optional<std::string>& 
         }
         combined.emplace_back(weights.audio * a + weights.text * t, id);
     }
-    std::sort(combined.begin(), combined.end(),
-              [](const auto& a, const auto& b) { return a.first > b.first; });
+    const auto scoreOf = [](const auto& entry) { return entry.first; };
+    std::ranges::sort(combined, std::ranges::greater{}, scoreOf);
     if (sort.field != QuerySortField::Default) {
         auto sorted = hydrate(sql, combined);
         sortResults(sorted, sort);
@@ -763,8 +763,8 @@ std::vector<QueryResult> MediaDbQuery::similarTo(std::int64_t seedFileId,
         }
         ranked.emplace_back(s, id);
     }
-    std::sort(ranked.begin(), ranked.end(),
-              [](const auto& a, const auto& b) { return a.first > b.first; });
+    const auto similarityOf = [](const auto& entry) { return entry.first; };
+    std::ranges::sort(ranked, std::ranges::greater{}, similarityOf);
     if (sort.field != QuerySortField::Default) {
         auto sorted = hydrate(sql, ranked);
         sortResults(sorted, sort);

--- a/magda/daw/media_db/MediaDbZeroShotTags.cpp
+++ b/magda/daw/media_db/MediaDbZeroShotTags.cpp
@@ -237,8 +237,8 @@ std::vector<std::pair<std::string, float>> ZeroShotTagger::scoreEmbedding(
             hits.emplace_back(labels_[i], score);
         }
     }
-    std::sort(hits.begin(), hits.end(),
-              [](const auto& a, const auto& b) { return a.second > b.second; });
+    const auto scoreOf = [](const auto& hit) { return hit.second; };
+    std::ranges::sort(hits, std::ranges::greater{}, scoreOf);
     return hits;
 }
 

--- a/magda/daw/music/ChordCache.hpp
+++ b/magda/daw/music/ChordCache.hpp
@@ -60,7 +60,7 @@ class ChordCache {
         if (notes.empty())
             return "";
         std::vector<CacheNote> sortedNotes = notes;
-        std::sort(sortedNotes.begin(), sortedNotes.end());
+        std::ranges::sort(sortedNotes);
         std::ostringstream oss;
         for (size_t i = 0; i < sortedNotes.size(); ++i) {
             if (i > 0)

--- a/magda/daw/music/ChordEngine.cpp
+++ b/magda/daw/music/ChordEngine.cpp
@@ -90,8 +90,8 @@ ChordEngine::ChordEngine()
                   for (int& pitch : negativePitchClasses)
                       pitch = (pitch + 36) % 36;
 
-                  std::sort(positivePitchClasses.begin(), positivePitchClasses.end());
-                  std::sort(negativePitchClasses.begin(), negativePitchClasses.end());
+                  std::ranges::sort(positivePitchClasses);
+                  std::ranges::sort(negativePitchClasses);
 
                   allShapes.emplace(positivePitchClasses, ChordSpec(ChordRoot::C, quality, inv));
                   allShapes.emplace(negativePitchClasses, ChordSpec(ChordRoot::C, quality, inv));
@@ -122,14 +122,14 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
     std::vector<int> pitchClasses;
     for (const auto& note : heldNotes) {
         int pitchClass = note.noteNumber % 12;
-        if (std::find(pitchClasses.begin(), pitchClasses.end(), pitchClass) == pitchClasses.end())
+        if (!std::ranges::contains(pitchClasses, pitchClass))
             pitchClasses.push_back(pitchClass);
     }
 
     if (pitchClasses.size() < 2)
         return {"unknown"};
 
-    std::sort(pitchClasses.begin(), pitchClasses.end());
+    std::ranges::sort(pitchClasses);
 
     if (pitchClasses.size() == 2) {
         int a = pitchClasses[0];
@@ -169,19 +169,9 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
             chordPitches.reserve(intervals.size());
             for (int interval : intervals)
                 chordPitches.push_back((rootOffset + interval) % 12);
-            std::sort(chordPitches.begin(), chordPitches.end());
+            std::ranges::sort(chordPitches);
 
-            bool isExactMatch = false;
-            if (chordPitches.size() == pitchClasses.size()) {
-                bool matches = true;
-                for (size_t i = 0; i < chordPitches.size(); i++) {
-                    if (chordPitches[i] != pitchClasses[i]) {
-                        matches = false;
-                        break;
-                    }
-                }
-                isExactMatch = matches;
-            }
+            const bool isExactMatch = std::ranges::equal(chordPitches, pitchClasses);
 
             if (isExactMatch || !chordPitches.empty()) {
                 std::vector<int> intersection;
@@ -218,9 +208,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
                     } else {
                         for (size_t i = 0; i < intervals.size(); ++i) {
                             int chordTone = (rootOffset + intervals[i]) % 12;
-                            bool found = std::find(pitchClasses.begin(), pitchClasses.end(),
-                                                   chordTone) != pitchClasses.end();
-                            if (found) {
+                            if (std::ranges::contains(pitchClasses, chordTone)) {
                                 if (i == 0)
                                     weightedScore += 300;  // root
                                 else if (i == 1)
@@ -252,10 +240,7 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
         return chord;
     }
 
-    std::sort(candidates.begin(), candidates.end(),
-              [](const ChordCandidate& a, const ChordCandidate& b) {
-                  return a.matchScore > b.matchScore;
-              });
+    std::ranges::sort(candidates, std::ranges::greater{}, &ChordCandidate::matchScore);
 
     ChordCandidate best = candidates[0];
 
@@ -272,15 +257,13 @@ Chord ChordEngine::detect(const std::vector<ChordNote>& heldNotes) {
         for (int interval : intervals) {
             int chordTone = (rootOffset + interval) % 12;
             idealPitchClasses.push_back(chordTone);
-            if (std::find(pitchClasses.begin(), pitchClasses.end(), chordTone) ==
-                pitchClasses.end())
+            if (!std::ranges::contains(pitchClasses, chordTone))
                 chord.missingIntervals.push_back(interval);
         }
 
         // Which input notes are not in the ideal chord?
         for (int pc : pitchClasses) {
-            if (std::find(idealPitchClasses.begin(), idealPitchClasses.end(), pc) ==
-                idealPitchClasses.end())
+            if (!std::ranges::contains(idealPitchClasses, pc))
                 chord.extraPitchClasses.push_back(pc);
         }
     }
@@ -424,15 +407,11 @@ Chord ChordEngine::buildChordInversion(ChordRoot root, ChordQuality quality, int
 
     const int k = std::max(0, inversion);
     if (k > 0) {
-        std::sort(notes.begin(), notes.end(), [](const ChordNote& a, const ChordNote& b) {
-            return a.noteNumber < b.noteNumber;
-        });
+        std::ranges::sort(notes, {}, &ChordNote::noteNumber);
         const int limit = std::min(k, static_cast<int>(notes.size()) - 1);
         for (int i = 0; i < limit; ++i)
             notes[static_cast<size_t>(i)].noteNumber += 12;
-        std::sort(notes.begin(), notes.end(), [](const ChordNote& a, const ChordNote& b) {
-            return a.noteNumber < b.noteNumber;
-        });
+        std::ranges::sort(notes, {}, &ChordNote::noteNumber);
     }
 
     ChordSpec spec(root, quality, inversion);
@@ -472,7 +451,7 @@ std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
         return results;
 
     std::vector<int> sortedPitchClasses = pitchClasses;
-    std::sort(sortedPitchClasses.begin(), sortedPitchClasses.end());
+    std::ranges::sort(sortedPitchClasses);
 
     for (int rootOffset = 0; rootOffset < 12; rootOffset++) {
         std::vector<ChordQuality> qualities = {
@@ -488,7 +467,7 @@ std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
             chordPitches.reserve(intervals.size());
             for (int interval : intervals)
                 chordPitches.push_back((rootOffset + interval) % 12);
-            std::sort(chordPitches.begin(), chordPitches.end());
+            std::ranges::sort(chordPitches);
 
             std::vector<int> intersection;
             std::set_intersection(chordPitches.begin(), chordPitches.end(),
@@ -511,17 +490,14 @@ std::vector<std::pair<juce::String, float>> ChordEngine::findChordsFromNotes(
         }
     }
 
-    std::sort(results.begin(), results.end(),
-              [](const std::pair<juce::String, float>& a, const std::pair<juce::String, float>& b) {
-                  return a.second > b.second;
-              });
+    const auto similarityOf = [](const auto& result) { return result.second; };
+    std::ranges::sort(results, std::ranges::greater{}, similarityOf);
 
     return results;
 }
 
 void ChordEngine::finalizeChord(Chord& c) {
-    std::sort(c.notes.begin(), c.notes.end(),
-              [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+    std::ranges::sort(c.notes, {}, &ChordNote::noteNumber);
     if (c.notes.empty())
         return;
 

--- a/magda/daw/music/ChordSuggestionEngine.cpp
+++ b/magda/daw/music/ChordSuggestionEngine.cpp
@@ -433,8 +433,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::genera
     }
 
     // Apply priority boost (sort by score descending)
-    std::sort(filtered.begin(), filtered.end(),
-              [](const SuggestionItem& a, const SuggestionItem& b) { return a.score > b.score; });
+    std::ranges::sort(filtered, std::ranges::greater{}, &SuggestionItem::score);
     auto boostedCandidates = std::move(filtered);
 
     // Convert to final format with score decay by position and deduplicate by chord name
@@ -910,8 +909,7 @@ ChordSuggestionEngine::generateNonDiatonicCandidates(const juce::String& key,
                 notes.emplace_back(n, 100);
             for (int n : upperNotes)
                 notes.emplace_back(n, 100);
-            std::sort(notes.begin(), notes.end(),
-                      [](auto& a, auto& b) { return a.noteNumber < b.noteNumber; });
+            std::ranges::sort(notes, {}, &ChordNote::noteNumber);
 
             // Build chord object with base lower quality for compatibility; override names
             auto baseQuality = lowerMinor ? ChordQuality::Minor : ChordQuality::Major;
@@ -980,9 +978,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::mixCan
         }
 
         // Sort by priority (highest first)
-        std::sort(
-            prioritizedDiatonic.begin(), prioritizedDiatonic.end(),
-            [](const SuggestionItem& a, const SuggestionItem& b) { return a.score > b.score; });
+        std::ranges::sort(prioritizedDiatonic, std::ranges::greater{}, &SuggestionItem::score);
 
         // Take top candidates up to topK
         result.resize(std::min(topK, static_cast<int>(prioritizedDiatonic.size())));
@@ -999,8 +995,7 @@ std::vector<ChordSuggestionEngine::SuggestionItem> ChordSuggestionEngine::mixCan
 
     // Sort non-diatonic candidates by score (highest first) before taking
     std::vector<SuggestionItem> sortedNonDiatonic = nonDiatonic;
-    std::sort(sortedNonDiatonic.begin(), sortedNonDiatonic.end(),
-              [](const SuggestionItem& a, const SuggestionItem& b) { return a.score > b.score; });
+    std::ranges::sort(sortedNonDiatonic, std::ranges::greater{}, &SuggestionItem::score);
 
     // Ensure polychords are visible even at low novelty by reserving a couple of early slots
     std::vector<SuggestionItem> polyList;
@@ -1123,10 +1118,7 @@ Chord ChordSuggestionEngine::buildChordInRootPosition(const juce::String& root,
         if (midi >= 0)
             notes.emplace_back(midi, 100);
     };
-    auto ensureSorted = [&]() {
-        std::sort(notes.begin(), notes.end(),
-                  [](const auto& a, const auto& b) { return a.noteNumber < b.noteNumber; });
-    };
+    auto ensureSorted = [&]() { std::ranges::sort(notes, {}, &ChordNote::noteNumber); };
 
     // Handle slash chords: e.g., "maj/5", "maj/b7"
     if (quality.containsChar('/')) {
@@ -1386,9 +1378,7 @@ Chord ChordSuggestionEngine::optimizeVoicing(const Chord& chord, float inversion
     if (!result.notes.empty()) {
         // Sort notes to find the bass note
         auto sortedNotes = result.notes;
-        std::sort(
-            sortedNotes.begin(), sortedNotes.end(),
-            [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+        std::ranges::sort(sortedNotes, {}, &ChordNote::noteNumber);
 
         int bassNote = sortedNotes[0].noteNumber;
         int bassPitchClass = bassNote % 12;
@@ -1466,9 +1456,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
 
         // Sort notes to find the bass note
         auto sortedNotes = chord.notes;
-        std::sort(
-            sortedNotes.begin(), sortedNotes.end(),
-            [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+        std::ranges::sort(sortedNotes, {}, &ChordNote::noteNumber);
 
         int bassNote = sortedNotes[0].noteNumber;
         int bassPitchClass = bassNote % 12;
@@ -1531,8 +1519,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
 
     // Sort notes to find the bass note
     auto sortedNotes = canonicalRootPosition.notes;
-    std::sort(sortedNotes.begin(), sortedNotes.end(),
-              [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+    std::ranges::sort(sortedNotes, {}, &ChordNote::noteNumber);
 
     // Find the root pitch class from the chord name
     juce::String rootStr = chord.name.upToFirstOccurrenceOf(":", false, false);
@@ -1599,9 +1586,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
             }
 
             // Sort by pitch to ensure proper ordering
-            std::sort(
-                rearrangedNotes.begin(), rearrangedNotes.end(),
-                [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+            std::ranges::sort(rearrangedNotes, {}, &ChordNote::noteNumber);
 
             canonicalRootPosition.notes = rearrangedNotes;
             canonicalRootPosition.inversion = 0;
@@ -1614,9 +1599,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
         Chord inversion = canonicalRootPosition;
 
         // Sort notes by pitch
-        std::sort(
-            inversion.notes.begin(), inversion.notes.end(),
-            [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+        std::ranges::sort(inversion.notes, {}, &ChordNote::noteNumber);
 
         // Move the highest 'abs(inv)' notes down an octave
         int notesToMove = std::abs(inv);
@@ -1627,9 +1610,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
         }
 
         // Sort again to maintain order
-        std::sort(
-            inversion.notes.begin(), inversion.notes.end(),
-            [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+        std::ranges::sort(inversion.notes, {}, &ChordNote::noteNumber);
 
         // Now detect the actual inversion based on the bass note
         inversion.inversion = detectInversion(inversion);
@@ -1644,9 +1625,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
         Chord inversion = canonicalRootPosition;
 
         // Sort notes by pitch
-        std::sort(
-            inversion.notes.begin(), inversion.notes.end(),
-            [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+        std::ranges::sort(inversion.notes, {}, &ChordNote::noteNumber);
 
         // Move the lowest 'inv' notes up an octave
         for (int i = 0; i < inv && i < static_cast<int>(inversion.notes.size()); ++i) {
@@ -1654,9 +1633,7 @@ std::vector<Chord> ChordSuggestionEngine::generateInversions(const Chord& chord)
         }
 
         // Sort again to maintain order
-        std::sort(
-            inversion.notes.begin(), inversion.notes.end(),
-            [](const ChordNote& a, const ChordNote& b) { return a.noteNumber < b.noteNumber; });
+        std::ranges::sort(inversion.notes, {}, &ChordNote::noteNumber);
 
         // Now detect the actual inversion based on the bass note
         inversion.inversion = detectInversion(inversion);
@@ -1975,8 +1952,8 @@ juce::String ChordSuggestionEngine::getDetectedScalesString(float /*novelty*/) c
         }
 
         // Re-sort after reweighting
-        std::sort(detectedScales.begin(), detectedScales.end(),
-                  [](const auto& a, const auto& b) { return a.second.score > b.second.score; });
+        const auto scoreOf = [](const auto& entry) { return entry.second.score; };
+        std::ranges::sort(detectedScales, std::ranges::greater{}, scoreOf);
 
         if (detectedScales.empty()) {
             return "";
@@ -2103,8 +2080,8 @@ std::vector<std::pair<juce::String, juce::String>> ChordSuggestionEngine::getTop
         }
 
         // Re-sort after reweighting
-        std::sort(detectedScales.begin(), detectedScales.end(),
-                  [](const auto& a, const auto& b) { return a.second.score > b.second.score; });
+        const auto scoreOf = [](const auto& entry) { return entry.second.score; };
+        std::ranges::sort(detectedScales, std::ranges::greater{}, scoreOf);
 
         // Extract top scales with good confidence
         for (int i = 0; i < std::min(maxScales, static_cast<int>(detectedScales.size())); ++i) {

--- a/magda/daw/music/ChordTypes.hpp
+++ b/magda/daw/music/ChordTypes.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_core/juce_core.h>
 
+#include <algorithm>
 #include <vector>
 
 #include "ChordEnums.hpp"
@@ -89,8 +90,8 @@ struct Chord {
             a.push_back(n.noteNumber);
         for (const auto& n : other.notes)
             b.push_back(n.noteNumber);
-        std::sort(a.begin(), a.end());
-        std::sort(b.begin(), b.end());
+        std::ranges::sort(a);
+        std::ranges::sort(b);
         return a == b;
     }
 

--- a/magda/daw/music/ScaleDetector.hpp
+++ b/magda/daw/music/ScaleDetector.hpp
@@ -66,8 +66,8 @@ inline std::vector<std::pair<ScaleWithChords, MatchScore>> detectBestMatchingSca
         }
     }
 
-    std::sort(scored.begin(), scored.end(),
-              [](const auto& a, const auto& b) { return b.second.score < a.second.score; });
+    const auto scoreOf = [](const auto& entry) { return entry.second.score; };
+    std::ranges::sort(scored, std::ranges::greater{}, scoreOf);
 
     return scored;
 }
@@ -145,8 +145,8 @@ inline std::vector<std::pair<ScaleWithChords, NoteBasedMatchScore>> detectScales
         scored.emplace_back(scale, matchScore);
     }
 
-    std::sort(scored.begin(), scored.end(),
-              [](const auto& a, const auto& b) { return a.second.score > b.second.score; });
+    const auto scoreOf = [](const auto& entry) { return entry.second.score; };
+    std::ranges::sort(scored, std::ranges::greater{}, scoreOf);
 
     // Second pass: if a scale is a strict subset of a same-root scale that ranks
     // lower, promote the superset to sit directly above the subset.

--- a/magda/daw/project/MediaCollector.cpp
+++ b/magda/daw/project/MediaCollector.cpp
@@ -120,13 +120,11 @@ MediaCollector::Plan MediaCollector::scan() {
                 continue;
 
             auto& item = plan.items[static_cast<size_t>(idx)];
-            if (std::find(item.clipRefs.begin(), item.clipRefs.end(), clip.id) ==
-                item.clipRefs.end()) {
+            if (!std::ranges::contains(item.clipRefs, clip.id)) {
                 item.clipRefs.push_back(clip.id);
             }
             if (event.sourceId != INVALID_SOURCE_ID &&
-                std::find(item.sourceRefs.begin(), item.sourceRefs.end(), event.sourceId) ==
-                    item.sourceRefs.end()) {
+                !std::ranges::contains(item.sourceRefs, event.sourceId)) {
                 item.sourceRefs.push_back(event.sourceId);
             }
         }

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -841,7 +841,7 @@ void ProjectManager::refreshDirtyState() {
 void ProjectManager::addListener(ProjectManagerListener* listener) {
     if (listener != nullptr) {
         // Avoid adding the same listener multiple times
-        auto it = std::find(listeners_.begin(), listeners_.end(), listener);
+        auto it = std::ranges::find(listeners_, listener);
         if (it == listeners_.end()) {
             listeners_.push_back(listener);
         }

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <tuple>
 
 #include "../../core/Config.hpp"
 #include "../../core/ParameterUtils.hpp"
@@ -957,8 +958,7 @@ juce::String DawProjectXmlAdapter::toProjectXml(const ProjectDocument& document)
     // master track is actually present in the document (it isn't for partial
     // documents built outside a full capture).
     const bool hasMaster =
-        std::any_of(document.tracks.begin(), document.tracks.end(),
-                    [](const TrackInfo& t) { return t.type == TrackType::Master; });
+        std::ranges::contains(document.tracks, TrackType::Master, &TrackInfo::type);
 
     auto* structure = project.createNewChildElement("Structure");
     std::map<TrackId, const TrackInfo*> tracksById;
@@ -1407,7 +1407,10 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                     }
 
                     if (!lane.absolutePoints.empty()) {
-                        std::sort(lane.absolutePoints.begin(), lane.absolutePoints.end());
+                        const auto beatThenId = [](const AutomationPoint& point) {
+                            return std::tuple{point.beatPosition, point.id};
+                        };
+                        std::ranges::sort(lane.absolutePoints, {}, beatThenId);
                         document.automationLanes.push_back(std::move(lane));
                     }
                 }

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -1039,8 +1039,7 @@ juce::var ProjectSerializer::serializeClips() {
     // order every time - the file changes with nothing in the project changing,
     // and no diff of two saves means anything.
     auto clips = clipManager.getClips();
-    std::sort(clips.begin(), clips.end(),
-              [](const ClipInfo& a, const ClipInfo& b) { return a.id < b.id; });
+    std::ranges::sort(clips, {}, &ClipInfo::id);
 
     for (const auto& clip : clips) {
         clipsArray.add(serializeClipInfo(clip));

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -34,10 +34,11 @@ void migrateUtilityWidthToPercent(DeviceInfo& device) {
 }
 
 void enforcePostFxAnalysisDeviceOrder(std::vector<PostFxChainElement>& elements) {
-    auto findAnalysis = [&elements](int order) {
-        return std::find_if(elements.begin(), elements.end(), [order](const auto& element) {
-            return daw::audio::internalPostFxAnalysisOrder(element.device.pluginId) == order;
-        });
+    const auto analysisOrderOf = [](const PostFxChainElement& element) {
+        return daw::audio::internalPostFxAnalysisOrder(element.device.pluginId);
+    };
+    auto findAnalysis = [&elements, &analysisOrderOf](int order) {
+        return std::ranges::find(elements, order, analysisOrderOf);
     };
 
     auto osc = findAnalysis(0);

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -1,6 +1,7 @@
 #include "clip/ClipSnapshotCompiler.hpp"
 
 #include <algorithm>
+#include <tuple>
 #include <unordered_map>
 
 #include "clip/ClipStretcher.hpp"
@@ -370,13 +371,11 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
         // Sorted by where they start, ties by id: two compiles of one model
         // have to produce one snapshot, and a lane is held in whatever order
         // the model happens to keep it.
-        const auto byStart = [](const auto& a, const auto& b) {
-            if (a.span.beats.start != b.span.beats.start)
-                return a.span.beats.start < b.span.beats.start;
-            return a.clipId < b.clipId;
+        const auto startThenId = [](const auto& playback) {
+            return std::tuple{playback.span.beats.start, playback.clipId};
         };
-        std::sort(track.audio.begin(), track.audio.end(), byStart);
-        std::sort(track.midi.begin(), track.midi.end(), byStart);
+        std::ranges::sort(track.audio, {}, startThenId);
+        std::ranges::sort(track.midi, {}, startThenId);
 
         // The slots, each compiled as its own single-clip lane at the origin.
         //
@@ -453,9 +452,8 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                 continue;
             }
 
-            const auto found = std::find_if(
-                track.session.begin(), track.session.end(),
-                [scene](const SessionSlotPlayback& slot) { return slot.sceneIndex == scene; });
+            const auto found =
+                std::ranges::find(track.session, scene, &SessionSlotPlayback::sceneIndex);
 
             if (found != track.session.end()) {
                 // Already a target means the same scene was armed twice, which
@@ -470,10 +468,7 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
             track.session.push_back(SessionSlotPlayback{.sceneIndex = scene, .recordTarget = true});
         }
 
-        std::sort(track.session.begin(), track.session.end(),
-                  [](const SessionSlotPlayback& a, const SessionSlotPlayback& b) {
-                      return a.sceneIndex < b.sceneIndex;
-                  });
+        std::ranges::sort(track.session, {}, &SessionSlotPlayback::sceneIndex);
 
         // A track earns an entry by having something to play, in either view. A
         // session-only track is a real one: nothing is in its arrangement and
@@ -484,10 +479,7 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
     }
 
     // ClipSnapshot::find binary searches this.
-    std::sort(snapshot.tracks.begin(), snapshot.tracks.end(),
-              [](const TrackClipPlayback& a, const TrackClipPlayback& b) {
-                  return a.trackId < b.trackId;
-              });
+    std::ranges::sort(snapshot.tracks, {}, &TrackClipPlayback::trackId);
 
     return snapshot;
 }

--- a/magda/engine/clip/GrooveTemplate.cpp
+++ b/magda/engine/clip/GrooveTemplate.cpp
@@ -86,16 +86,14 @@ void GrooveTemplateSet::add(Entry entry) {
 }
 
 bool GrooveTemplateSet::contains(const std::string& name) const {
-    return std::any_of(entries_.begin(), entries_.end(),
-                       [&](const Entry& entry) { return entry.name == name; });
+    return std::ranges::contains(entries_, name, &Entry::name);
 }
 
 GrooveTemplate GrooveTemplateSet::compile(const std::string& name, float strength) const {
     if (name.empty())
         return {};
 
-    const auto found = std::find_if(entries_.begin(), entries_.end(),
-                                    [&](const Entry& entry) { return entry.name == name; });
+    const auto found = std::ranges::find(entries_, name, &Entry::name);
 
     if (found == entries_.end())
         return {};

--- a/magda/engine/clip/MidiClipCompiler.cpp
+++ b/magda/engine/clip/MidiClipCompiler.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <limits>
 #include <map>
+#include <tuple>
 
 #include "core/PitchExpressionCurve.hpp"
 
@@ -90,9 +91,7 @@ void densify(std::vector<EventType> sorted, int maxValue, double floorBeats, Emi
     if (sorted.empty())
         return;
 
-    std::stable_sort(sorted.begin(), sorted.end(), [](const EventType& a, const EventType& b) {
-        return a.beatPosition < b.beatPosition;
-    });
+    std::ranges::stable_sort(sorted, {}, &EventType::beatPosition);
 
     auto lastValue = std::numeric_limits<int>::min();
     auto lastBeat = -std::numeric_limits<double>::max();
@@ -239,12 +238,10 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
     // ---- Notes -------------------------------------------------------------
 
     auto notes = clip.midiNotes;
-    std::stable_sort(notes.begin(), notes.end(), [](const MidiNote& a, const MidiNote& b) {
-        return a.startBeat < b.startBeat;
-    });
+    std::ranges::stable_sort(notes, {}, &MidiNote::startBeat);
 
-    list.mpe = std::any_of(notes.begin(), notes.end(),
-                           [](const MidiNote& note) { return note.hasPitchExpression(); });
+    const auto hasPitchExpression = [](const MidiNote& note) { return note.hasPitchExpression(); };
+    list.mpe = std::ranges::any_of(notes, hasPitchExpression);
 
     std::array<MpeChannel, kMpeLastMemberChannel - kMpeFirstMemberChannel + 1> mpeChannels{};
     std::vector<int> channelOf(notes.size(), 1);
@@ -360,8 +357,8 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
         // which is where a coarse grid is heard most directly.
         if (list.mpe && note.hasPitchExpression()) {
             auto points = note.pitchExpression;
-            std::stable_sort(points.begin(), points.end(),
-                             [](const auto& a, const auto& b) { return a.beat < b.beat; });
+            const auto beatOf = [](const auto& point) { return point.beat; };
+            std::ranges::stable_sort(points, {}, beatOf);
 
             // Shape from core, so what compiles is what the piano roll drew
             // (#2198). The densification below is unchanged: it already walks
@@ -433,11 +430,10 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
 
     {
         const auto& bend = clip.midiPitchBendData;
-        const auto allAtRest =
-            !bend.empty() &&
-            std::all_of(bend.begin(), bend.end(), [](const MidiPitchBendData& event) {
-                return event.value == kPitchWheelRest;
-            });
+        const auto atRest = [](const MidiPitchBendData& event) {
+            return event.value == kPitchWheelRest;
+        };
+        const auto allAtRest = !bend.empty() && std::ranges::all_of(bend, atRest);
 
         if (!allAtRest) {
             densify(bend, 16383, curveFloorBeats, [&](double beat, int value) {
@@ -452,12 +448,10 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
 
     // ---- Sort, then pair the notes up again ---------------------------------
 
-    std::stable_sort(pending.begin(), pending.end(),
-                     [](const PendingEvent& a, const PendingEvent& b) {
-                         if (a.event.beat != b.event.beat)
-                             return a.event.beat < b.event.beat;
-                         return rankOf(a.event.status) < rankOf(b.event.status);
-                     });
+    const auto beatThenRank = [](const PendingEvent& pendingEvent) {
+        return std::tuple{pendingEvent.event.beat, rankOf(pendingEvent.event.status)};
+    };
+    std::ranges::stable_sort(pending, {}, beatThenRank);
 
     list.events.reserve(pending.size());
     for (const auto& entry : pending)
@@ -481,11 +475,10 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
                                 : kind == kChannelPressure ? MidiControllerStream::kChannelPressure
                                                            : static_cast<int>(event.data1);
 
-        auto found = std::find_if(list.controllers.begin(), list.controllers.end(),
-                                  [&](const MidiControllerStream& stream) {
-                                      return stream.channel == event.channel() &&
-                                             stream.controller == controller;
-                                  });
+        const auto isThisStream = [&](const MidiControllerStream& stream) {
+            return stream.channel == event.channel() && stream.controller == controller;
+        };
+        auto found = std::ranges::find_if(list.controllers, isThisStream);
 
         if (found == list.controllers.end()) {
             list.controllers.push_back(MidiControllerStream{event.channel(), controller, {}});

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -1004,12 +1004,8 @@ void PlanExecutor::feedNoteTriggers(std::size_t op, const juce::MidiBuffer& midi
     // A cross-track listener takes one trigger for the block rather than one
     // per note, which is what the fork's monitor does: it scans the buffer,
     // sets a flag, and fires triggerSidechain once.
-    bool anyNoteOn = false;
-    for (const auto metadata : midi)
-        if (metadata.getMessage().isNoteOn()) {
-            anyNoteOn = true;
-            break;
-        }
+    const auto isNoteOn = [](const auto& metadata) { return metadata.getMessage().isNoteOn(); };
+    const bool anyNoteOn = std::ranges::any_of(midi, isNoteOn);
 
     for (const auto index : modSourceForOp_[op]) {
         if (mods_.listensFor(index, *blockTable_) != ModListen::Midi)

--- a/magda/engine/exec/PlanLayout.cpp
+++ b/magda/engine/exec/PlanLayout.cpp
@@ -8,19 +8,6 @@
 namespace magda::engine {
 namespace {
 
-/// Producer ops an op waits on, each counted once however many slots it feeds.
-std::vector<OpId> distinctProducers(const PlanOp& op) {
-    std::vector<OpId> producers;
-    producers.reserve(op.inputs.size());
-    for (const auto& input : op.inputs) {
-        if (!input.valid())
-            continue;
-        if (std::ranges::find(producers, input.op) == producers.end())
-            producers.push_back(input.op);
-    }
-    return producers;
-}
-
 /// A set of ops, one bit each.
 class OpSet {
   public:

--- a/magda/engine/io/PrefetchThread.cpp
+++ b/magda/engine/io/PrefetchThread.cpp
@@ -19,7 +19,7 @@ PrefetchThread::~PrefetchThread() {
 void PrefetchThread::add(PrefetchStream& stream) {
     {
         const std::scoped_lock guard(lock_);
-        if (std::find(streams_.begin(), streams_.end(), &stream) == streams_.end())
+        if (!std::ranges::contains(streams_, &stream))
             streams_.push_back(&stream);
     }
 

--- a/magda/engine/io/RecordThread.cpp
+++ b/magda/engine/io/RecordThread.cpp
@@ -19,7 +19,7 @@ RecordThread::~RecordThread() {
 void RecordThread::add(RecordStream& stream) {
     {
         const std::scoped_lock guard(lock_);
-        if (std::find(streams_.begin(), streams_.end(), &stream) == streams_.end())
+        if (!std::ranges::contains(streams_, &stream))
             streams_.push_back(&stream);
     }
 

--- a/magda/engine/param/ModRuntime.cpp
+++ b/magda/engine/param/ModRuntime.cpp
@@ -186,7 +186,7 @@ void ModRuntime::buildListenerRouting(const ParamTable& table) {
         if (modifier.source == magda::INVALID_TRACK_ID)
             continue;
 
-        if (std::find(listened_.begin(), listened_.end(), modifier.source) == listened_.end())
+        if (!std::ranges::contains(listened_, modifier.source))
             listened_.push_back(modifier.source);
     }
 
@@ -207,7 +207,7 @@ void ModRuntime::buildListenerRouting(const ParamTable& table) {
 }
 
 std::span<const int> ModRuntime::listenersOf(magda::TrackId track) const {
-    const auto found = std::find(listened_.begin(), listened_.end(), track);
+    const auto found = std::ranges::find(listened_, track);
     if (found == listened_.end())
         return {};
 
@@ -342,7 +342,7 @@ ModState* ModRuntime::mutableState(int index) {
 }
 
 int ModRuntime::indexOf(const ParamKey& key) const {
-    const auto found = std::find(keys_.begin(), keys_.end(), key);
+    const auto found = std::ranges::find(keys_, key);
     return found == keys_.end() ? -1 : static_cast<int>(std::distance(keys_.begin(), found));
 }
 

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -253,19 +253,6 @@ bool isInputDelayRole(OpRole role) {
     }
 }
 
-/// Producer ops an op waits on, each counted once however many slots it feeds.
-std::vector<OpId> distinctProducers(const PlanOp& op) {
-    std::vector<OpId> producers;
-    producers.reserve(op.inputs.size());
-    for (const auto& input : op.inputs) {
-        if (!input.valid())
-            continue;
-        if (std::ranges::find(producers, input.op) == producers.end())
-            producers.push_back(input.op);
-    }
-    return producers;
-}
-
 }  // namespace
 
 PlanScheduling scheduleOf(const RenderPlan& plan) {

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -407,6 +408,17 @@ struct PlanOp {
     int padLevelParam = -1;
     int padPanParam = -1;
 };
+
+/** @brief Producer ops an op waits on, each counted once however many slots it feeds. */
+inline std::vector<OpId> distinctProducers(const PlanOp& op) {
+    std::vector<OpId> producers;
+    producers.reserve(op.inputs.size());
+    for (const auto& input : op.inputs) {
+        if (input.valid() && !std::ranges::contains(producers, input.op))
+            producers.push_back(input.op);
+    }
+    return producers;
+}
 
 /**
  * @brief A compiled, immutable render plan.

--- a/magda/engine/transport/TempoMap.cpp
+++ b/magda/engine/transport/TempoMap.cpp
@@ -111,10 +111,9 @@ TempoMap::TempoMap(std::vector<TempoChange> tempos, std::vector<TimeSignatureCha
     // Stable, so two changes at the same beat keep the order they arrived in:
     // that pair is how a step is written, and which of them wins is the whole
     // meaning of it.
-    std::stable_sort(tempos.begin(), tempos.end(),
-                     [](const auto& a, const auto& b) { return a.startBeat < b.startBeat; });
-    std::stable_sort(signatures.begin(), signatures.end(),
-                     [](const auto& a, const auto& b) { return a.startBeat < b.startBeat; });
+    const auto startBeatOf = [](const auto& change) { return change.startBeat; };
+    std::ranges::stable_sort(tempos, {}, startBeatOf);
+    std::ranges::stable_sort(signatures, {}, startBeatOf);
 
     // What precedes the first change is that change's own value, held. For the
     // tempo that means an extra change at the beginning rather than moving the
@@ -220,8 +219,9 @@ TempoMap::TempoMap(std::vector<TempoChange> tempos, std::vector<TimeSignatureCha
     for (const auto& region : regions)
         boundaries.push_back(region.startBeat);
 
-    std::sort(boundaries.begin(), boundaries.end());
-    boundaries.erase(std::unique(boundaries.begin(), boundaries.end()), boundaries.end());
+    std::ranges::sort(boundaries);
+    const auto duplicates = std::ranges::unique(boundaries);
+    boundaries.erase(duplicates.begin(), duplicates.end());
 
     sections_.reserve(boundaries.size());
 


### PR DESCRIPTION
Closes #2148, less the audio-path files the issue did not list.

## What the sweep exposed

- **`enableDevicesForChannels()`** (`engine/WaveDeviceChannels.hpp`) replaces four copies of "enable each wave device that owns a channel we want", spread over `TracktionEngineWrapperInit` and `TracktionEngineWrapperDevices`. Three of them wrote the flag unconditionally and the fourth guarded on `isEnabled()`; the guard is now what all four do, so a device that is already in the right state is not re-set.
- **`distinctProducers()`** was byte-identical in `plan/RenderPlan.cpp` and `exec/PlanLayout.cpp`. It is one `inline` in `RenderPlan.hpp`, and both `find == end()` guards are `!ranges::contains`.
- **`compact_parser`** had nine copies of "take `parts[n]`, then append the rest with spaces". `juce::StringArray::joinIntoString(" ", n)` already is that function, so the issue's proposed `joinFrom()` helper is not needed.
- **`ChordEngine`**'s exact-match walk over two pitch-class vectors is `ranges::equal`, and `TempoSequenceRippleMath::sameBeats()` is `ranges::equal` with a tolerance predicate and a projection on both sides.
- **`osc_feedback_live`**, **`remote_clients`**, **`remote_service`**, **`remote_api`**: repeated find-by-field lookups now pass a projection instead of a lambda.

The rest is the mechanical shape the loop sweeps never reach: iterator pairs to ranges, `find(...) != end()` to `contains`, and sorts to a projection or `ranges::greater`. Every predicate that survived as a lambda is named at the call site.

## Two types where `ranges::sort` is stricter than `std::sort`

`AutomationPoint` orders on `(beatPosition, id)` but compares equal on `id` alone, so it does not satisfy `totally_ordered` and the bare `ranges::sort` overload rejects it. `CurvePoint` has the same split. Both now sort through the projection that spells the intent out, which is also what their surrounding comments already claimed.

## Deliberately left raw

On the issue's own scoping — it lists `magda/engine` sites as "off the audio path":

- `ClipAudioSource`, `ClipMidiSource`, `ClipVoicePool`: the audio path.
- `ParamResolve`'s knot walk is a fold with two exits, not a search.
- `remote_http_auth`'s compare stays constant-time; only the origin allowlist next to it became `contains`.
- `PlanExecutor`'s note-on scan over a `MidiBuffer` is the one audio-thread conversion, which the issue calls out as identical codegen.
- The `juce::Array<var>` / `StringArray` collect loops in `project/serialization/*` and `remote_api.cpp`: `ranges::to` does not compile for them, and `toJuce<C>()` belongs to #2149.

## Verification

Debug build clean. Catch2: 3871 cases, 1944429 assertions, 0 failures. JUCE suite green, all nine real-project corpus cases through both engines.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi