### PR TITLE
Rewrite the core and audio collection queries as ranges pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ See [Issues](https://github.com/Conceptual-Machines/magda-core/issues) for known
 
 - C++23 compiler **and standard library**: GCC 13+, Clang 16+ with libc++,
   AppleClang 16+, or MSVC 19.36+ (VS 2022 17.6). The floor is the library, not
-  the language: `std::views::zip` and `std::ranges::contains` are in use, and
-  libstdc++ only gained `views::zip` in GCC 13.1, so a GCC 12 build fails even
-  though CMake will select C++23 for it.
+  the language: `std::views::zip`, `std::views::chunk_by`,
+  `std::ranges::fold_left` and `std::ranges::contains` are in use, and libstdc++
+  only gained them in GCC 13.1, so a GCC 12 build fails even though CMake will
+  select C++23 for it. `std::ranges::to` is *not* used: libstdc++ only has it
+  from GCC 14, so collecting goes through `toStd<C>()` / `toJuce<C>()` in
+  `magda/daw/core/RangesHelpers.hpp`.
   (CI builds with GCC 13.3, AppleClang 16.0 and MSVC 19.50.)
 - CMake 3.24+
 - [Git LFS](https://git-lfs.com/) — required to fetch bundled binary assets

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -6,8 +6,10 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <ranges>
 #include <utility>
 
+#include "../core/RangesHelpers.hpp"
 #include "../engine/AudioEngine.hpp"
 #include "../project/ProjectManager.hpp"
 #include "../ui/state/TimelineController.hpp"
@@ -1664,11 +1666,8 @@ void DeleteTimeSelectionCommand::undo() {
     // Re-trimmed/kept clips keep their engine mapping, so forceNotifyClipsChanged
     // (topology only) won't restore their length/position. Push every restored
     // clip's placement back to the engine; unchanged clips are cheap no-ops.
-    std::vector<ClipId> restoredIds;
-    restoredIds.reserve(snapshot_.size());
-    for (const auto& clip : snapshot_)
-        restoredIds.push_back(clip.id);
-    clipManager.forceNotifyMultipleClipPropertiesChanged(restoredIds);
+    clipManager.forceNotifyMultipleClipPropertiesChanged(
+        snapshot_ | std::views::transform(&ClipInfo::id) | toStd<std::vector<ClipId>>());
     executed_ = false;
 }
 
@@ -1780,11 +1779,8 @@ void InsertTimeCommand::undo() {
     clipManager.forceNotifyClipsChanged();
     // Push every restored placement back to the engine so shifted/split clips
     // return to their pre-insert positions; unchanged clips are cheap no-ops.
-    std::vector<ClipId> restoredIds;
-    restoredIds.reserve(snapshot_.size());
-    for (const auto& clip : snapshot_)
-        restoredIds.push_back(clip.id);
-    clipManager.forceNotifyMultipleClipPropertiesChanged(restoredIds);
+    clipManager.forceNotifyMultipleClipPropertiesChanged(
+        snapshot_ | std::views::transform(&ClipInfo::id) | toStd<std::vector<ClipId>>());
     executed_ = false;
 }
 
@@ -1853,11 +1849,8 @@ void SplitClipsAtBeatCommand::undo() {
     clipManager.forceNotifyClipsChanged();
     // Re-merged clips keep their engine mapping, so push every restored
     // placement back to the engine; unchanged clips are cheap no-ops.
-    std::vector<ClipId> restoredIds;
-    restoredIds.reserve(snapshot_.size());
-    for (const auto& clip : snapshot_)
-        restoredIds.push_back(clip.id);
-    clipManager.forceNotifyMultipleClipPropertiesChanged(restoredIds);
+    clipManager.forceNotifyMultipleClipPropertiesChanged(
+        snapshot_ | std::views::transform(&ClipInfo::id) | toStd<std::vector<ClipId>>());
     createdClipIds_.clear();
     executed_ = false;
 }
@@ -2013,11 +2006,8 @@ void RippleDeleteRangeCommand::undo() {
     }
 
     clipManager.forceNotifyClipsChanged();
-    std::vector<ClipId> restoredIds;
-    restoredIds.reserve(snapshot_.size());
-    for (const auto& clip : snapshot_)
-        restoredIds.push_back(clip.id);
-    clipManager.forceNotifyMultipleClipPropertiesChanged(restoredIds);
+    clipManager.forceNotifyMultipleClipPropertiesChanged(
+        snapshot_ | std::views::transform(&ClipInfo::id) | toStd<std::vector<ClipId>>());
     executed_ = false;
 }
 

--- a/magda/daw/audio/CompService.cpp
+++ b/magda/daw/audio/CompService.cpp
@@ -2,11 +2,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 #include <set>
 #include <vector>
 
 #include "core/ClipManager.hpp"
 #include "core/CompSectionMath.hpp"
+#include "core/RangesHelpers.hpp"
 #include "project/ProjectManager.hpp"
 
 namespace magda {
@@ -17,10 +19,9 @@ constexpr double kCrossfadeSeconds = 0.012;  // 12 ms equal-power crossfade at b
 
 // Longest take defines the comp timeline extent.
 double compLengthSeconds(const AudioClipModel& audio) {
-    double len = 0.0;
-    for (const auto& t : audio.takes)
-        len = std::max(len, t.durationSeconds);
-    return len;
+    if (audio.takes.empty())
+        return 0.0;
+    return std::ranges::max(audio.takes | std::views::transform(&AudioTake::durationSeconds));
 }
 
 // Rebuild the comp section list so [a, b) plays `take`, splitting/merging as
@@ -28,18 +29,16 @@ double compLengthSeconds(const AudioClipModel& audio) {
 // the shared (domain-neutral) algorithm; CompSection (seconds) <-> CompSpan.
 std::vector<CompSection> assignSection(const std::vector<CompSection>& existing, double compLen,
                                        int baseTake, double a, double b, int take) {
-    std::vector<CompSpan> spans;
-    spans.reserve(existing.size());
-    for (const auto& s : existing)
-        spans.push_back({s.startSeconds, s.endSeconds, s.takeIndex});
+    const auto asSpan = [](const CompSection& section) {
+        return CompSpan{section.startSeconds, section.endSeconds, section.takeIndex};
+    };
+    const auto asSection = [](const CompSpan& span) {
+        return CompSection{span.start, span.end, span.takeIndex};
+    };
 
-    const auto out = assignCompSections(spans, compLen, baseTake, a, b, take);
-
-    std::vector<CompSection> result;
-    result.reserve(out.size());
-    for (const auto& s : out)
-        result.push_back({s.start, s.end, s.takeIndex});
-    return result;
+    const auto spans = existing | std::views::transform(asSpan) | toStd<std::vector<CompSpan>>();
+    return assignCompSections(spans, compLen, baseTake, a, b, take) |
+           std::views::transform(asSection) | toStd<std::vector<CompSection>>();
 }
 
 // Equal-power gains across a fade position p in [0, 1].
@@ -90,9 +89,8 @@ double stitchComp(const CompSnapshot& snap) {
     if (sampleRate <= 0.0 || numChannels <= 0 || snap.sections.empty())
         return 0.0;
 
-    double compLen = 0.0;
-    for (const auto& s : snap.sections)
-        compLen = std::max(compLen, s.endSeconds);
+    const double compLen =
+        std::ranges::max(snap.sections | std::views::transform(&CompSection::endSeconds));
     const int total = static_cast<int>(std::round(compLen * sampleRate));
     if (total <= 0)
         return 0.0;

--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -1,5 +1,11 @@
 #include "MidiBridge.hpp"
 
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <ranges>
+
+#include "../core/RangesHelpers.hpp"
 #include "../core/TrackManager.hpp"
 #include "AudioBridge.hpp"
 
@@ -60,54 +66,52 @@ void MidiBridge::stopAllInputs() {
         juce::Thread::sleep(1);
 }
 
+namespace {
+
+// Output enable state is not tracked the way input enable state is, so both
+// physical lists come back disabled.
+MidiDeviceInfo asPhysicalDevice(const juce::MidiDeviceInfo& device) {
+    MidiDeviceInfo info;
+    info.id = device.identifier;
+    info.name = device.name;
+    info.isEnabled = false;
+    info.isAvailable = true;
+    return info;
+}
+
+}  // namespace
+
 std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiInputs() const {
-    std::vector<MidiDeviceInfo> devices;
-
-    // Use JUCE's MidiInput::getAvailableDevices() for physical MIDI devices
-    auto midiInputs = juce::MidiInput::getAvailableDevices();
-
-    for (const auto& device : midiInputs) {
-        MidiDeviceInfo info;
-        info.id = device.identifier;
-        info.name = device.name;
-        info.isEnabled = false;
-        info.isAvailable = true;
-        devices.push_back(info);
-    }
+    const auto midiInputs = juce::MidiInput::getAvailableDevices();
+    auto devices =
+        midiInputs | std::views::transform(asPhysicalDevice) | toStd<std::vector<MidiDeviceInfo>>();
 
     // Include TE virtual MIDI devices only when enabled. The routing
     // selectors refresh via onMidiDeviceListChanged when the device
     // state changes, so the filter is effective.
-    for (auto& dev : engine_.getDeviceManager().getMidiInDevices()) {
-        if (dynamic_cast<te::VirtualMidiInputDevice*>(dev.get()) && dev->isEnabled()) {
-            MidiDeviceInfo info;
-            info.id = dev->getDeviceID();
-            info.name = dev->getName();
-            info.isEnabled = dev->isEnabled();
-            info.isAvailable = true;
-            devices.push_back(info);
-        }
-    }
+    const auto isEnabledVirtualInput = [](const std::shared_ptr<te::MidiInputDevice>& dev) {
+        return dynamic_cast<te::VirtualMidiInputDevice*>(dev.get()) != nullptr && dev->isEnabled();
+    };
+    const auto asVirtualDevice = [](const std::shared_ptr<te::MidiInputDevice>& dev) {
+        MidiDeviceInfo info;
+        info.id = dev->getDeviceID();
+        info.name = dev->getName();
+        info.isEnabled = dev->isEnabled();
+        info.isAvailable = true;
+        return info;
+    };
 
+    const auto teDevices = engine_.getDeviceManager().getMidiInDevices();
+    std::ranges::copy(teDevices | std::views::filter(isEnabledVirtualInput) |
+                          std::views::transform(asVirtualDevice),
+                      std::back_inserter(devices));
     return devices;
 }
 
 std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiOutputs() {
-    std::vector<MidiDeviceInfo> devices;
-
-    auto midiOutputs = juce::MidiOutput::getAvailableDevices();
-
-    for (const auto& device : midiOutputs) {
-        MidiDeviceInfo info;
-        info.id = device.identifier;
-        info.name = device.name;
-        info.isEnabled = false;  // Output enable state not tracked same way
-        info.isAvailable = true;
-
-        devices.push_back(info);
-    }
-
-    return devices;
+    const auto midiOutputs = juce::MidiOutput::getAvailableDevices();
+    return midiOutputs | std::views::transform(asPhysicalDevice) |
+           toStd<std::vector<MidiDeviceInfo>>();
 }
 
 bool MidiBridge::sendMidi(const juce::String& deviceNameOrId, const juce::MidiMessage& msg) {

--- a/magda/daw/audio/TrackController.cpp
+++ b/magda/daw/audio/TrackController.cpp
@@ -1,5 +1,8 @@
 #include "TrackController.hpp"
 
+#include <ranges>
+
+#include "../core/RangesHelpers.hpp"
 #include "../core/TrackManager.hpp"
 
 namespace magda {
@@ -573,12 +576,7 @@ juce::String TrackController::getTrackAudioInput(TrackId trackId) const {
 
 std::vector<TrackId> TrackController::getAllTrackIds() const {
     juce::ScopedLock lock(trackLock_);
-    std::vector<TrackId> trackIds;
-    trackIds.reserve(trackMapping_.size());
-    for (const auto& [trackId, track] : trackMapping_) {
-        trackIds.push_back(trackId);
-    }
-    return trackIds;
+    return trackMapping_ | std::views::keys | toStd<std::vector<TrackId>>();
 }
 
 void TrackController::clearAllMappings() {

--- a/magda/daw/audio/analysis/OfflineMixAnalysis.cpp
+++ b/magda/daw/audio/analysis/OfflineMixAnalysis.cpp
@@ -5,7 +5,9 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <ranges>
 
+#include "../../core/RangesHelpers.hpp"
 #include "../../core/StringTable.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../core/UserAlert.hpp"
@@ -248,17 +250,22 @@ class AnalysisJob : public juce::Thread {
         // Resolve the track set up front (Deep) so the total pass count -- and
         // therefore the progress estimate -- is known before rendering starts:
         // one master pass plus one pass per track.
+        const auto isAnalysable = [](const TrackInfo& track) {
+            return track.type != TrackType::Chord;
+        };
+        const auto stillExists = [](TrackId id) {
+            return TrackManager::getInstance().getTrack(id) != nullptr;
+        };
+
         std::vector<TrackId> trackIds;
         if (deep) {
-            if (request_.trackSet.empty()) {
-                for (const auto& track : TrackManager::getInstance().getTracks())
-                    if (track.type != TrackType::Chord)
-                        trackIds.push_back(track.id);
-            } else {
-                for (auto id : request_.trackSet)
-                    if (TrackManager::getInstance().getTrack(id) != nullptr)
-                        trackIds.push_back(id);
-            }
+            const auto& tracks = TrackManager::getInstance().getTracks();
+            trackIds = request_.trackSet.empty()
+                           ? tracks | std::views::filter(isAnalysable) |
+                                 std::views::transform(&TrackInfo::id) |
+                                 toStd<std::vector<TrackId>>()
+                           : request_.trackSet | std::views::filter(stillExists) |
+                                 toStd<std::vector<TrackId>>();
         }
         const int totalPasses = deep ? 1 + static_cast<int>(trackIds.size()) : 1;
 
@@ -394,12 +401,11 @@ class AnalysisJob : public juce::Thread {
             // Annotate each track with its type (audio/MIDI) + effect chain. build()
             // preserves source order, so measurements.tracks[i] matches sourceTrackIds[i].
             auto& tmgr = magda::TrackManager::getInstance();
-            for (size_t i = 0; i < measurements.tracks.size() && i < sourceTrackIds.size(); ++i) {
-                const auto tid = sourceTrackIds[i];
+            for (auto&& [measured, tid] : std::views::zip(measurements.tracks, sourceTrackIds)) {
                 if (tid == magda::INVALID_TRACK_ID)
                     continue;
-                measurements.tracks[i].role = tmgr.getPrimaryInstrument(tid) ? "MIDI" : "audio";
-                measurements.tracks[i].chain = tmgr.getChainSummary(tid);
+                measured.role = tmgr.getPrimaryInstrument(tid) ? "MIDI" : "audio";
+                measured.chain = tmgr.getChainSummary(tid);
             }
 
             if (skipped > 0)

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <map>
+#include <ranges>
 #include <set>
 #include <unordered_set>
 #include <utility>
@@ -8,6 +9,7 @@
 #include "../../core/ChainRoutingModel.hpp"
 #include "../../core/PluginCapabilities.hpp"
 #include "../../core/RackInfo.hpp"
+#include "../../core/RangesHelpers.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../core/aliases/AutoAliasGenerator.hpp"
 #include "../../profiling/PerformanceProfiler.hpp"
@@ -44,6 +46,18 @@
 namespace magda {
 
 namespace {
+/// Every synced plugin on a track: the scope a modifier or macro teardown
+/// walks. The caller holds pluginLock_.
+std::vector<te::Plugin*> scopePluginsForTrack(const auto& syncedDevices, TrackId trackId) {
+    const auto onTrackWithPlugin = [trackId](const auto& entry) {
+        return entry.second.trackId == trackId && entry.second.plugin != nullptr;
+    };
+    const auto pluginOf = [](const auto& entry) { return entry.second.plugin.get(); };
+
+    return syncedDevices | std::views::filter(onTrackWithPlugin) | std::views::transform(pluginOf) |
+           toStd<std::vector<te::Plugin*>>();
+}
+
 void clearAutomationCurve(te::AutomatableParameter* param) {
     if (!param)
         return;
@@ -358,11 +372,8 @@ void PluginManager::syncAllPlugins() {
             for (auto it = syncedDevices_.begin(); it != syncedDevices_.end();) {
                 if (validDevicePaths.find(it->first) == validDevicePaths.end() &&
                     !isDrumGridPadPathLocked(it->first)) {
-                    std::vector<te::Plugin*> scopePlugins;
-                    for (const auto& [_deviceId, sd] : syncedDevices_) {
-                        if (sd.trackId == it->second.trackId && sd.plugin)
-                            scopePlugins.push_back(sd.plugin.get());
-                    }
+                    const auto scopePlugins =
+                        scopePluginsForTrack(syncedDevices_, it->second.trackId);
                     auto* teTrack = trackController_.getAudioTrack(it->second.trackId);
                     auto* modifierList = teTrack ? teTrack->getModifierList() : nullptr;
                     if (!modifierList && it->second.trackId == MASTER_TRACK_ID) {
@@ -520,11 +531,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
 
         // Remove from mappings while under lock
         deferredHolders_.clear();  // Drain previous cycle's deferred holders
-        std::vector<te::Plugin*> scopePlugins;
-        for (const auto& [_deviceId, sd] : syncedDevices_) {
-            if (sd.trackId == trackId && sd.plugin)
-                scopePlugins.push_back(sd.plugin.get());
-        }
+        const auto scopePlugins = scopePluginsForTrack(syncedDevices_, trackId);
         auto* modifierList = teTrack ? teTrack->getModifierList() : nullptr;
         auto* macroList = teTrack ? &teTrack->getMacroParameterListForWriting() : nullptr;
         for (const auto& devicePath : toRemove) {
@@ -958,12 +965,7 @@ void PluginManager::cleanupTrackPlugins(TrackId trackId) {
                 midiPluginsToDelete.push_back(sd.midiRestorePlugin.get());
         }
 
-        std::vector<te::Plugin*> scopePlugins;
-        scopePlugins.reserve(devicePaths.size());
-        for (const auto& [deviceId, sd] : syncedDevices_) {
-            if (sd.trackId == trackId && sd.plugin)
-                scopePlugins.push_back(sd.plugin.get());
-        }
+        const auto scopePlugins = scopePluginsForTrack(syncedDevices_, trackId);
 
         auto* modifierList = teTrack ? teTrack->getModifierList() : nullptr;
         auto* macroList = teTrack ? &teTrack->getMacroParameterListForWriting() : nullptr;

--- a/magda/daw/audio/plugins/MidiStrumPlugin.cpp
+++ b/magda/daw/audio/plugins/MidiStrumPlugin.cpp
@@ -1,6 +1,9 @@
 #include "plugins/MidiStrumPlugin.hpp"
 
 #include <algorithm>
+#include <ranges>
+
+#include "core/RangesHelpers.hpp"
 
 namespace magda::daw::audio {
 
@@ -105,9 +108,9 @@ ParameterInfo slotInfo(int index) {
             break;
 
         case MidiStrumPlugin::kShape: {
-            std::vector<juce::String> names;
-            for (const auto& shape : shapes())
-                names.emplace_back(shape.name);
+            const auto nameOf = [](const auto& shape) { return juce::String(shape.name); };
+            auto names =
+                shapes() | std::views::transform(nameOf) | toStd<std::vector<juce::String>>();
             discrete("shape", "Shape", 1.0f, std::move(names));  // Ease In
             break;
         }
@@ -465,20 +468,20 @@ void MidiStrumPlugin::process(DeviceProcessContext& context) {
 }
 
 std::vector<float> MidiStrumPlugin::curveOnsetPreview(int shapeIndex, int cyclesIndex, int count) {
-    std::vector<float> out;
     if (count <= 0)
-        return out;
+        return {};
 
     std::array<float, 1024> lut{};
     buildLut(shapeIndex, lut);
     const int cyc = juce::jlimit(0, 7, cyclesIndex) + 1;  // index 0..7 -> 1..8
 
-    out.reserve(static_cast<size_t>(count));
-    for (int i = 0; i < count; ++i) {
+    const auto onsetAt = [&lut, count, cyc](int i) {
         const float u = (count == 1) ? 0.0f : static_cast<float>(i) / static_cast<float>(count - 1);
-        out.push_back(juce::jlimit(0.0f, 1.0f, sampleCycled(lut, u, cyc)));
-    }
-    return out;
+        return juce::jlimit(0.0f, 1.0f, sampleCycled(lut, u, cyc));
+    };
+
+    return std::views::iota(0, count) | std::views::transform(onsetAt) |
+           toStd<std::vector<float>>();
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -1,10 +1,12 @@
 #include "racks/RackSyncManager.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 #include "../../core/DrumGridPads.hpp"
 #include "TracktionHelpers.hpp"
 #include "core/ChainRoutingModel.hpp"
+#include "core/RangesHelpers.hpp"
 #include "core/TrackManager.hpp"
 #include "modifiers/CurveSnapshot.hpp"
 #include "modifiers/ModifierHelpers.hpp"
@@ -298,44 +300,30 @@ void RackSyncManager::removeRackInternal(RackId rackId, bool clearDeviceState) {
 }
 
 void RackSyncManager::removeRacksForTrack(TrackId trackId) {
-    std::vector<RackId> toRemove;
-    for (const auto& [rackId, synced] : syncedRacks_) {
-        if (synced.trackId == trackId)
-            toRemove.push_back(rackId);
-    }
-    for (auto rackId : toRemove) {
+    // Collected first: removeRack() erases from the map being walked.
+    for (auto rackId : getSyncedRackIdsForTrack(trackId))
         removeRack(rackId);
-    }
 }
 
 std::vector<RackId> RackSyncManager::getSyncedRackIds() const {
-    std::vector<RackId> ids;
-    ids.reserve(syncedRacks_.size());
-    for (const auto& [rackId, _] : syncedRacks_) {
-        ids.push_back(rackId);
-    }
-    return ids;
+    return syncedRacks_ | std::views::keys | toStd<std::vector<RackId>>();
 }
 
 std::vector<RackId> RackSyncManager::getSyncedRackIdsForTrack(TrackId trackId) const {
-    std::vector<RackId> ids;
-    for (const auto& [rackId, synced] : syncedRacks_) {
-        if (synced.trackId == trackId)
-            ids.push_back(rackId);
-    }
-    return ids;
+    const auto onTrack = [trackId](const auto& entry) { return entry.second.trackId == trackId; };
+
+    return syncedRacks_ | std::views::filter(onTrack) | std::views::keys |
+           toStd<std::vector<RackId>>();
 }
 
 std::vector<DeviceId> RackSyncManager::getInnerDeviceIdsForTrack(TrackId trackId) const {
-    std::vector<DeviceId> ids;
-    for (const auto& [rackId, synced] : syncedRacks_) {
-        if (synced.trackId != trackId)
-            continue;
-        for (const auto& [deviceId, plugin] : synced.innerPlugins) {
-            ids.push_back(deviceId);
-        }
-    }
-    return ids;
+    const auto onTrack = [trackId](const auto& entry) { return entry.second.trackId == trackId; };
+    const auto innerPluginsOf = [](const auto& entry) -> const auto& {
+        return entry.second.innerPlugins;
+    };
+
+    return syncedRacks_ | std::views::filter(onTrack) | std::views::transform(innerPluginsOf) |
+           std::views::join | std::views::keys | toStd<std::vector<DeviceId>>();
 }
 
 std::unordered_map<TrackId, RackSyncManager::TrackMeteringInfo> RackSyncManager::getMeteringMap()

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -3,12 +3,14 @@
 #include <algorithm>
 #include <cmath>
 #include <iterator>
+#include <ranges>
 
 #include "AutomationCurve.hpp"
 #include "ClipLaneFlattener.hpp"
 #include "GridDivision.hpp"
 #include "ParameterInfo.hpp"
 #include "ParameterUtils.hpp"
+#include "RangesHelpers.hpp"
 #include "TrackManager.hpp"
 #include "audio/AudioBridge.hpp"
 #include "audio/automation/ControlTargetResolver.hpp"
@@ -17,6 +19,19 @@
 namespace magda {
 
 namespace {
+
+/// The highest id in a range, or 0 when it is empty: ids count from 1, so the
+/// counters below still land on 1 for a project with nothing in it.
+int highestId(std::ranges::input_range auto&& ids) {
+    const auto larger = [](int a, int b) { return std::max(a, b); };
+    return std::ranges::fold_left(ids, 0, larger);
+}
+
+auto baselineFor(const AutomationTarget& target) {
+    return [&target](const std::pair<AutomationTarget, double>& entry) {
+        return entry.first == target;
+    };
+}
 
 bool isPostFxAutomationTarget(const AutomationTarget& target) {
     switch (target.kind) {
@@ -417,32 +432,29 @@ const AutomationLaneInfo* AutomationManager::getLane(AutomationLaneId laneId) co
 }
 
 std::vector<AutomationLaneId> AutomationManager::getLanesForTrack(TrackId trackId) const {
-    std::vector<AutomationLaneId> result;
-    for (const auto& lane : lanes_) {
-        if (lane.target.devicePath.trackId == trackId) {
-            result.push_back(lane.id);
-        }
-    }
-    return result;
+    const auto onTrack = [trackId](const AutomationLaneInfo& lane) {
+        return lane.target.devicePath.trackId == trackId;
+    };
+
+    return lanes_ | std::views::filter(onTrack) | std::views::transform(&AutomationLaneInfo::id) |
+           toStd<std::vector<AutomationLaneId>>();
 }
 
 std::vector<AutomationLaneId> AutomationManager::getEditScopedLanes() const {
-    std::vector<AutomationLaneId> result;
-    for (const auto& lane : lanes_) {
-        if (lane.target.isEditScoped()) {
-            result.push_back(lane.id);
-        }
-    }
-    return result;
+    const auto isEditScoped = [](const AutomationLaneInfo& lane) {
+        return lane.target.isEditScoped();
+    };
+
+    return lanes_ | std::views::filter(isEditScoped) |
+           std::views::transform(&AutomationLaneInfo::id) | toStd<std::vector<AutomationLaneId>>();
 }
 
 AutomationLaneId AutomationManager::getLaneForTarget(const AutomationTarget& target) const {
-    for (const auto& lane : lanes_) {
-        if (lane.target == target) {
-            return lane.id;
-        }
-    }
-    return INVALID_AUTOMATION_LANE_ID;
+    const auto hasTarget = [&target](const AutomationLaneInfo& lane) {
+        return lane.target == target;
+    };
+    const auto found = std::ranges::find_if(lanes_, hasTarget);
+    return found == lanes_.end() ? INVALID_AUTOMATION_LANE_ID : found->id;
 }
 
 // ============================================================================
@@ -518,26 +530,22 @@ std::vector<AutomationTarget> AutomationManager::getUserTouchedTargets() const {
 }
 
 void AutomationManager::setTouchBaseline(const AutomationTarget& target, double normalizedValue) {
-    for (auto& entry : touchBaselines_) {
-        if (entry.first == target) {
-            entry.second = normalizedValue;
-            return;
-        }
-    }
-    touchBaselines_.emplace_back(target, normalizedValue);
+    const auto found = std::ranges::find_if(touchBaselines_, baselineFor(target));
+    if (found == touchBaselines_.end())
+        touchBaselines_.emplace_back(target, normalizedValue);
+    else
+        found->second = normalizedValue;
 }
 
 std::optional<double> AutomationManager::getTouchBaseline(const AutomationTarget& target) const {
-    for (const auto& entry : touchBaselines_) {
-        if (entry.first == target)
-            return entry.second;
-    }
-    return std::nullopt;
+    const auto found = std::ranges::find_if(touchBaselines_, baselineFor(target));
+    if (found == touchBaselines_.end())
+        return std::nullopt;
+    return found->second;
 }
 
 void AutomationManager::clearTouchBaseline(const AutomationTarget& target) {
-    std::erase_if(touchBaselines_,
-                  [&](const std::pair<AutomationTarget, double>& e) { return e.first == target; });
+    std::erase_if(touchBaselines_, baselineFor(target));
 }
 
 AutomationVisualState AutomationManager::getVisualState(const AutomationTarget& target) const {
@@ -579,11 +587,14 @@ std::optional<double> AutomationManager::getCurrentTargetValue(const AutomationT
 }
 
 void AutomationManager::resetRuntimeAuthorityStates() {
-    std::vector<AutomationLaneId> runtimeLanes;
-    for (const auto& lane : lanes_) {
-        if (isAutomationGestureActive(lane.authorityState))
-            runtimeLanes.push_back(lane.id);
-    }
+    const auto isGesturing = [](const AutomationLaneInfo& lane) {
+        return isAutomationGestureActive(lane.authorityState);
+    };
+
+    // Collected first: dispatching moves lanes through their authority states.
+    const auto runtimeLanes = lanes_ | std::views::filter(isGesturing) |
+                              std::views::transform(&AutomationLaneInfo::id) |
+                              toStd<std::vector<AutomationLaneId>>();
     for (const auto laneId : runtimeLanes)
         dispatchAuthorityEvent(laneId, AutomationAuthorityEvent::ResetRuntime);
 }
@@ -1206,33 +1217,18 @@ void AutomationManager::restoreClip(AutomationClipInfo& clip) {
 }
 
 void AutomationManager::refreshIdCountersFromLanes() {
-    int maxLaneId = 0;
-    int maxClipId = 0;
-    int maxPointId = 0;
+    auto laneIds = lanes_ | std::views::transform(&AutomationLaneInfo::id);
+    auto lanePointIds = lanes_ | std::views::transform(&AutomationLaneInfo::absolutePoints) |
+                        std::views::join | std::views::transform(&AutomationPoint::id);
+    auto laneClipIds =
+        lanes_ | std::views::transform(&AutomationLaneInfo::clipIds) | std::views::join;
+    auto clipIds = clips_ | std::views::transform(&AutomationClipInfo::id);
+    auto clipPointIds = clips_ | std::views::transform(&AutomationClipInfo::points) |
+                        std::views::join | std::views::transform(&AutomationPoint::id);
 
-    for (const auto& lane : lanes_) {
-        maxLaneId = std::max(maxLaneId, lane.id);
-
-        for (const auto& point : lane.absolutePoints) {
-            maxPointId = std::max(maxPointId, point.id);
-        }
-
-        for (auto clipId : lane.clipIds) {
-            maxClipId = std::max(maxClipId, clipId);
-        }
-    }
-
-    for (const auto& clip : clips_) {
-        maxClipId = std::max(maxClipId, clip.id);
-
-        for (const auto& point : clip.points) {
-            maxPointId = std::max(maxPointId, point.id);
-        }
-    }
-
-    nextLaneId_ = maxLaneId + 1;
-    nextClipId_ = maxClipId + 1;
-    nextPointId_ = maxPointId + 1;
+    nextLaneId_ = highestId(laneIds) + 1;
+    nextClipId_ = std::max(highestId(laneClipIds), highestId(clipIds)) + 1;
+    nextPointId_ = std::max(highestId(lanePointIds), highestId(clipPointIds)) + 1;
 }
 
 // ============================================================================

--- a/magda/daw/core/ClipFades.cpp
+++ b/magda/daw/core/ClipFades.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 
 #include "ClipOcclusion.hpp"
+#include "RangesHelpers.hpp"
 #include "TempoUtils.hpp"
 
 namespace magda {
@@ -14,12 +16,24 @@ namespace {
 // has to be a real case, not a float coincidence.
 constexpr double kBeatTol = 1e-6;
 
+const ClipInfo* addressOf(const ClipInfo& clip) {
+    return &clip;
+}
+
+double startBeatOf(const ClipInfo* clip) {
+    return clip->placement.startBeat;
+}
+
+double endBeatOf(const ClipInfo* clip) {
+    return clip->placement.endBeat();
+}
+
 std::vector<const ClipInfo*> laneView(const std::vector<ClipInfo>& clips) {
-    std::vector<const ClipInfo*> lane;
-    lane.reserve(clips.size());
-    for (const auto& clip : clips)
-        lane.push_back(&clip);
-    return lane;
+    return clips | std::views::transform(addressOf) | toStd<std::vector<const ClipInfo*>>();
+}
+
+auto clipWithId(ClipId clipId) {
+    return [clipId](const ClipInfo& clip) { return clip.id == clipId; };
 }
 
 }  // namespace
@@ -41,28 +55,24 @@ std::optional<CrossfadeInfo> crossfadeAtStartOf(const ClipInfo& clip,
     // about its own edge, so a clip fades into a neighbour that hard-cuts just
     // the same. What IS asked for is that the overlap plays both - fading into
     // a clip that has been silenced under this one is a dip, not a fade.
-    const ClipInfo* best = nullptr;
-    for (const auto* other : lane) {
+    const auto startsFirstAndReachesOver = [&](const ClipInfo* other) {
         if (other->id == clip.id || other->view != ClipView::Arrangement ||
             other->trackId != clip.trackId || !other->isAudio() ||
-            !overlapPlaysThrough(clip, *other))
-            continue;
-        const double oStart = other->placement.startBeat;
-        const double oEnd = other->placement.endBeat();
-        if (!(oEnd > startB))
-            continue;
+            !overlapPlaysThrough(clip, *other) || !(other->placement.endBeat() > startB))
+            return false;
         // Starts before this one - or on the very same beat, where the clip on
         // top is the one arriving.
-        const bool startsFirst =
-            oStart < startB - kBeatTol ||
-            (std::abs(oStart - startB) <= kBeatTol && clipSitsBelow(*other, clip));
-        if (startsFirst) {
-            if (!best || oEnd > best->placement.endBeat())
-                best = other;
-        }
-    }
-    if (!best)
+        const double oStart = other->placement.startBeat;
+        return oStart < startB - kBeatTol ||
+               (std::abs(oStart - startB) <= kBeatTol && clipSitsBelow(*other, clip));
+    };
+
+    auto arriving = lane | std::views::filter(startsFirstAndReachesOver);
+    const auto longestTail = std::ranges::max_element(arriving, {}, endBeatOf);
+    if (longestTail == std::ranges::end(arriving))
         return std::nullopt;
+
+    const ClipInfo* best = *longestTail;
     return CrossfadeInfo{best->id, clip.id, startB, std::min(best->placement.endBeat(), endB)};
 }
 
@@ -78,43 +88,41 @@ std::optional<CrossfadeInfo> crossfadeAtEndOf(const ClipInfo& clip,
     // this clip is the one leaving and draws the fade OUT. A clip that swallows
     // another is not on its right - it started first - so a swallowed clip
     // fades in and holds, rather than fading in and back out of itself.
-    const ClipInfo* best = nullptr;
-    for (const auto* other : lane) {
+    const auto arrivesOverEnd = [&](const ClipInfo* other) {
         if (other->id == clip.id || other->view != ClipView::Arrangement ||
             other->trackId != clip.trackId || !other->isAudio() ||
             !overlapPlaysThrough(clip, *other))
-            continue;
+            return false;
         const double oStart = other->placement.startBeat;
-        const double oEnd = other->placement.endBeat();
         if (!(oStart < endB) ||
             (oStart <= startB + kBeatTol &&
              (std::abs(oStart - startB) > kBeatTol || !clipSitsBelow(clip, *other))))
-            continue;
+            return false;
         // Runs past this clip's end, or ends on the very same beat.
-        if (oEnd > endB - kBeatTol) {
-            if (!best || oStart < best->placement.startBeat)
-                best = other;
-        }
-    }
-    if (!best)
+        return other->placement.endBeat() > endB - kBeatTol;
+    };
+
+    auto leaving = lane | std::views::filter(arrivesOverEnd);
+    const auto earliestStart = std::ranges::min_element(leaving, {}, startBeatOf);
+    if (earliestStart == std::ranges::end(leaving))
         return std::nullopt;
+
+    const ClipInfo* best = *earliestStart;
     return CrossfadeInfo{clip.id, best->id, std::max(best->placement.startBeat, startB), endB};
 }
 
 std::optional<CrossfadeInfo> crossfadeAtStartIn(const std::vector<ClipInfo>& lane, ClipId clipId) {
-    for (const auto& clip : lane) {
-        if (clip.id == clipId)
-            return crossfadeAtStartOf(clip, laneView(lane));
-    }
-    return std::nullopt;
+    const auto found = std::ranges::find_if(lane, clipWithId(clipId));
+    if (found == lane.end())
+        return std::nullopt;
+    return crossfadeAtStartOf(*found, laneView(lane));
 }
 
 std::optional<CrossfadeInfo> crossfadeAtEndIn(const std::vector<ClipInfo>& lane, ClipId clipId) {
-    for (const auto& clip : lane) {
-        if (clip.id == clipId)
-            return crossfadeAtEndOf(clip, laneView(lane));
-    }
-    return std::nullopt;
+    const auto found = std::ranges::find_if(lane, clipWithId(clipId));
+    if (found == lane.end())
+        return std::nullopt;
+    return crossfadeAtEndOf(*found, laneView(lane));
 }
 
 EffectiveFades effectiveFadesOf(const ClipInfo& clip, const std::vector<const ClipInfo*>& lane,
@@ -153,11 +161,8 @@ EffectiveFades effectiveFadesOf(const ClipInfo& clip, const std::vector<const Cl
 }
 
 EffectiveFades effectiveFadesIn(const std::vector<ClipInfo>& lane, ClipId clipId, double bpm) {
-    for (const auto& clip : lane) {
-        if (clip.id == clipId)
-            return effectiveFadesOf(clip, laneView(lane), bpm);
-    }
-    return {};
+    const auto found = std::ranges::find_if(lane, clipWithId(clipId));
+    return found == lane.end() ? EffectiveFades{} : effectiveFadesOf(*found, laneView(lane), bpm);
 }
 
 }  // namespace magda

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -4,7 +4,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
+#include <iterator>
 #include <limits>
+#include <ranges>
 #include <unordered_map>
 
 #include "../project/ProjectManager.hpp"
@@ -13,6 +16,7 @@
 #include "Config.hpp"
 #include "GridDivision.hpp"
 #include "MidiFileWriter.hpp"
+#include "RangesHelpers.hpp"
 #include "TempoUtils.hpp"
 #include "TimeStretchModes.hpp"
 #include "TrackManager.hpp"
@@ -763,6 +767,17 @@ void ClipManager::setAudioClipCurrentTake(ClipId clipId, int takeIndex) {
 }
 
 namespace {
+// Append the events of one take that land in a comp section [start, end).
+template <std::ranges::input_range R, class Beat>
+void appendEventsInSection(const R& events, Beat beatOf, const MidiCompSection& section,
+                           std::vector<std::ranges::range_value_t<R>>& out) {
+    const auto insideSection = [&](const auto& event) {
+        const double beat = std::invoke(beatOf, event);
+        return beat >= section.startBeat && beat < section.endBeat;
+    };
+    std::ranges::copy(events | std::views::filter(insideSection), std::back_inserter(out));
+}
+
 // Assemble a clip's active event vectors from its comp sections + take note
 // sets: each section [startBeat, endBeat) contributes the events of its take
 // whose start beat falls in that range.
@@ -773,19 +788,15 @@ void rebuildMidiComp(ClipInfo& clip) {
     std::vector<MidiPitchBendData> pb;
 
     const int numTakes = static_cast<int>(midi.takes.size());
-    for (const auto& sec : midi.comp) {
-        if (sec.takeIndex < 0 || sec.takeIndex >= numTakes)
-            continue;
-        const auto& take = midi.takes[static_cast<size_t>(sec.takeIndex)];
-        for (const auto& n : take.notes)
-            if (n.startBeat >= sec.startBeat && n.startBeat < sec.endBeat)
-                notes.push_back(n);
-        for (const auto& c : take.cc)
-            if (c.beatPosition >= sec.startBeat && c.beatPosition < sec.endBeat)
-                cc.push_back(c);
-        for (const auto& p : take.pitchBend)
-            if (p.beatPosition >= sec.startBeat && p.beatPosition < sec.endBeat)
-                pb.push_back(p);
+    const auto namesATake = [numTakes](const MidiCompSection& section) {
+        return section.takeIndex >= 0 && section.takeIndex < numTakes;
+    };
+
+    for (const auto& section : midi.comp | std::views::filter(namesATake)) {
+        const auto& take = midi.takes[static_cast<size_t>(section.takeIndex)];
+        appendEventsInSection(take.notes, &MidiNote::startBeat, section, notes);
+        appendEventsInSection(take.cc, &MidiCCData::beatPosition, section, cc);
+        appendEventsInSection(take.pitchBend, &MidiPitchBendData::beatPosition, section, pb);
     }
 
     clip.midiNotes = std::move(notes);
@@ -829,17 +840,18 @@ void ClipManager::setMidiCompSection(ClipId clipId, double startBeat, double end
         return;
 
     ClipInfo before = *clip;
-    std::vector<CompSpan> spans;
-    spans.reserve(midi.comp.size());
-    for (const auto& s : midi.comp)
-        spans.push_back({s.startBeat, s.endBeat, s.takeIndex});
+    const auto asSpan = [](const MidiCompSection& section) {
+        return CompSpan{section.startBeat, section.endBeat, section.takeIndex};
+    };
+    const auto asSection = [](const CompSpan& span) {
+        return MidiCompSection{span.start, span.end, span.takeIndex};
+    };
 
+    const auto spans = midi.comp | std::views::transform(asSpan) | toStd<std::vector<CompSpan>>();
     const auto out =
         assignCompSections(spans, compLen, midi.currentTakeIndex, startBeat, endBeat, takeIndex);
 
-    midi.comp.clear();
-    for (const auto& s : out)
-        midi.comp.push_back({s.start, s.end, s.takeIndex});
+    midi.comp = out | std::views::transform(asSection) | toStd<std::vector<MidiCompSection>>();
     midi.compActive = true;
 
     rebuildMidiComp(*clip);
@@ -2336,6 +2348,29 @@ void ClipManager::setLaunchFadeSamples(ClipId clipId, int samples) {
 // clip, so an overlap can never degenerate into full containment.
 static constexpr double kCrossfadeEdgeGuardBeats = 1e-3;
 
+namespace {
+
+const ClipInfo* addressOf(const ClipInfo& clip) {
+    return &clip;
+}
+
+bool isFound(const ClipInfo* clip) {
+    return clip != nullptr;
+}
+
+const ClipInfo& derefClip(const ClipInfo* clip) {
+    return *clip;
+}
+
+/// The crossfade rules take a lane of pointers and filter it themselves, so
+/// what they are handed is every clip in the project.
+std::vector<const ClipInfo*> everyClipAsLane(const std::unordered_map<ClipId, ClipInfo>& clips) {
+    return clips | std::views::values | std::views::transform(addressOf) |
+           toStd<std::vector<const ClipInfo*>>();
+}
+
+}  // namespace
+
 std::optional<ClipManager::CrossfadeInfo> ClipManager::crossfadeAtStartIn(
     const std::vector<ClipInfo>& lane, ClipId clipId) {
     return ::magda::crossfadeAtStartIn(lane, clipId);
@@ -2347,12 +2382,11 @@ std::optional<ClipManager::CrossfadeInfo> ClipManager::crossfadeAtEndIn(
 }
 
 std::vector<ClipInfo> ClipManager::arrangementLane(TrackId trackId) const {
-    std::vector<ClipInfo> lane;
-    for (ClipId id : getClipsOnTrack(trackId, ClipView::Arrangement)) {
-        if (const auto* clip = getClip(id))
-            lane.push_back(*clip);
-    }
-    return lane;
+    const auto clipIds = getClipsOnTrack(trackId, ClipView::Arrangement);
+    const auto clipFor = [this](ClipId id) { return getClip(id); };
+
+    return clipIds | std::views::transform(clipFor) | std::views::filter(isFound) |
+           std::views::transform(derefClip) | toStd<std::vector<ClipInfo>>();
 }
 
 ClipManager::EffectiveFades ClipManager::effectiveFadesIn(const std::vector<ClipInfo>& lane,
@@ -2365,11 +2399,7 @@ ClipManager::EffectiveFades ClipManager::getEffectiveFades(ClipId clipId, double
     if (clip == nullptr)
         return {};
 
-    std::vector<const ClipInfo*> lane;
-    lane.reserve(clips_.size());
-    for (const auto& [cid, other] : clips_)
-        lane.push_back(&other);
-    return effectiveFadesOf(*clip, lane, bpm);
+    return effectiveFadesOf(*clip, everyClipAsLane(clips_), bpm);
 }
 
 std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtStart(ClipId clipId) const {
@@ -2377,11 +2407,7 @@ std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtStart(ClipI
     if (!clip)
         return std::nullopt;
 
-    std::vector<const ClipInfo*> lane;
-    lane.reserve(clips_.size());
-    for (const auto& [cid, other] : clips_)
-        lane.push_back(&other);
-    return crossfadeAtStartOf(*clip, lane);
+    return crossfadeAtStartOf(*clip, everyClipAsLane(clips_));
 }
 
 std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtEnd(ClipId clipId) const {
@@ -2389,11 +2415,7 @@ std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtEnd(ClipId 
     if (!clip)
         return std::nullopt;
 
-    std::vector<const ClipInfo*> lane;
-    lane.reserve(clips_.size());
-    for (const auto& [cid, other] : clips_)
-        lane.push_back(&other);
-    return crossfadeAtEndOf(*clip, lane);
+    return crossfadeAtEndOf(*clip, everyClipAsLane(clips_));
 }
 
 ClipId ClipManager::findCrossfadeNeighbour(ClipId clipId, bool atStart) const {
@@ -2755,6 +2777,18 @@ void ClipManager::clearChordAnnotations(ClipId clipId) {
 // Access
 // ============================================================================
 
+namespace {
+
+bool isArrangementClip(const ClipInfo& clip) {
+    return clip.view == ClipView::Arrangement;
+}
+
+bool isSessionClip(const ClipInfo& clip) {
+    return clip.view == ClipView::Session;
+}
+
+}  // namespace
+
 ClipInfo* ClipManager::getClip(ClipId clipId) {
     auto it = clips_.find(clipId);
     return (it != clips_.end()) ? &it->second : nullptr;
@@ -2766,63 +2800,48 @@ const ClipInfo* ClipManager::getClip(ClipId clipId) const {
 }
 
 std::vector<ClipInfo> ClipManager::getArrangementClips() const {
-    std::vector<ClipInfo> result;
-    result.reserve(clips_.size());
-    for (const auto& [id, clip] : clips_) {
-        if (clip.view == ClipView::Arrangement)
-            result.push_back(clip);
-    }
-    return result;
+    return clips_ | std::views::values | std::views::filter(isArrangementClip) |
+           toStd<std::vector<ClipInfo>>();
 }
 
 std::vector<ClipInfo> ClipManager::getSessionClips() const {
-    std::vector<ClipInfo> result;
-    result.reserve(clips_.size());
-    for (const auto& [id, clip] : clips_) {
-        if (clip.view == ClipView::Session)
-            result.push_back(clip);
-    }
-    return result;
+    return clips_ | std::views::values | std::views::filter(isSessionClip) |
+           toStd<std::vector<ClipInfo>>();
 }
 
 std::vector<ClipInfo> ClipManager::getClips() const {
-    std::vector<ClipInfo> result;
-    result.reserve(clips_.size());
-    for (const auto& [id, clip] : clips_)
-        result.push_back(clip);
-    return result;
+    return clips_ | std::views::values | toStd<std::vector<ClipInfo>>();
 }
 
 std::vector<ClipId> ClipManager::getClipsOnTrack(TrackId trackId) const {
-    std::vector<ClipId> result;
-    for (const auto& [id, clip] : clips_) {
-        if (clip.trackId == trackId)
-            result.push_back(clip.id);
-    }
-    std::sort(result.begin(), result.end(), [this](ClipId a, ClipId b) {
-        const auto* clipA = getClip(a);
-        const auto* clipB = getClip(b);
-        const double bpm = currentProjectTempoOrDefault();
-        return clipA && clipB && clipA->getTimelineStart(bpm) < clipB->getTimelineStart(bpm);
-    });
+    const auto onTrack = [trackId](const ClipInfo& clip) { return clip.trackId == trackId; };
+
+    auto result = clips_ | std::views::values | std::views::filter(onTrack) |
+                  std::views::transform(&ClipInfo::id) | toStd<std::vector<ClipId>>();
+    sortByTimelineStart(result);
     return result;
 }
 
 std::vector<ClipId> ClipManager::getClipsOnTrack(TrackId trackId, ClipView view) const {
-    std::vector<ClipId> result;
-    for (const auto& [id, clip] : clips_) {
-        if (clip.trackId == trackId && clip.view == view)
-            result.push_back(clip.id);
-    }
-    if (view == ClipView::Arrangement) {
-        std::sort(result.begin(), result.end(), [this](ClipId a, ClipId b) {
-            const auto* clipA = getClip(a);
-            const auto* clipB = getClip(b);
-            const double bpm = currentProjectTempoOrDefault();
-            return clipA && clipB && clipA->getTimelineStart(bpm) < clipB->getTimelineStart(bpm);
-        });
-    }
+    const auto onTrackInView = [trackId, view](const ClipInfo& clip) {
+        return clip.trackId == trackId && clip.view == view;
+    };
+
+    auto result = clips_ | std::views::values | std::views::filter(onTrackInView) |
+                  std::views::transform(&ClipInfo::id) | toStd<std::vector<ClipId>>();
+    if (view == ClipView::Arrangement)
+        sortByTimelineStart(result);
     return result;
+}
+
+void ClipManager::sortByTimelineStart(std::vector<ClipId>& clipIds) const {
+    const double bpm = currentProjectTempoOrDefault();
+    const auto startsEarlier = [this, bpm](ClipId a, ClipId b) {
+        const auto* clipA = getClip(a);
+        const auto* clipB = getClip(b);
+        return clipA && clipB && clipA->getTimelineStart(bpm) < clipB->getTimelineStart(bpm);
+    };
+    std::ranges::sort(clipIds, startsEarlier);
 }
 
 ClipId ClipManager::getClipAtPosition(TrackId trackId, double time) const {
@@ -2840,17 +2859,14 @@ ClipId ClipManager::getClipAtPosition(TrackId trackId, double time) const {
 
 std::vector<ClipId> ClipManager::getClipsInRange(TrackId trackId, double startTime,
                                                  double endTime) const {
-    std::vector<ClipId> result;
     const double bpm = currentProjectTempoOrDefault();
-    for (const auto& [id, clip] : clips_) {
-        const double clipStart = clip.getTimelineStart(bpm);
-        const double clipEnd = clip.getTimelineEnd(bpm);
-        if (clip.view == ClipView::Arrangement && clip.trackId == trackId && clipStart < endTime &&
-            clipEnd > startTime) {
-            result.push_back(clip.id);
-        }
-    }
-    return result;
+    const auto overlapsRange = [&](const ClipInfo& clip) {
+        return isArrangementClip(clip) && clip.trackId == trackId &&
+               clip.getTimelineStart(bpm) < endTime && clip.getTimelineEnd(bpm) > startTime;
+    };
+
+    return clips_ | std::views::values | std::views::filter(overlapsRange) |
+           std::views::transform(&ClipInfo::id) | toStd<std::vector<ClipId>>();
 }
 
 // ============================================================================
@@ -2947,7 +2963,7 @@ void ClipManager::addListener(ClipManagerListener* listener) {
 }
 
 void ClipManager::removeListener(ClipManagerListener* listener) {
-    listeners_.erase(std::remove(listeners_.begin(), listeners_.end(), listener), listeners_.end());
+    std::erase(listeners_, listener);
 }
 
 // ============================================================================

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -943,6 +943,10 @@ class ClipManager {
     double findNonOverlappingStartBeats(TrackId trackId, double desiredStartBeats,
                                         double lengthBeats, ClipView view) const;
 
+    /// Arrangement order: a lane reads left to right, so its ids come back
+    /// that way. Ids with no clip behind them sort as equivalent.
+    void sortByTimelineStart(std::vector<ClipId>& clipIds) const;
+
     // How far (in timeline beats) an audio clip's edge can extend before it
     // runs out of source material. Left = earlier than its current start
     // (bounded by the source read offset), right = past its current end

--- a/magda/daw/core/ClipOcclusion.cpp
+++ b/magda/daw/core/ClipOcclusion.cpp
@@ -1,7 +1,10 @@
 #include "ClipOcclusion.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <ranges>
+
+#include "RangesHelpers.hpp"
 
 namespace magda {
 
@@ -19,17 +22,38 @@ bool overlaps(const ClipInfo& a, const ClipInfo& b) {
 
 /// The clip this one is looking for in the lane, or nullptr.
 const ClipInfo* findClip(const std::vector<ClipInfo>& trackClips, ClipId clipId) {
-    for (const auto& candidate : trackClips)
-        if (candidate.id == clipId)
-            return &candidate;
-    return nullptr;
+    const auto hasId = [clipId](const ClipInfo& candidate) { return candidate.id == clipId; };
+    const auto found = std::ranges::find_if(trackClips, hasId);
+    return found == trackClips.end() ? nullptr : &*found;
+}
+
+const ClipInfo* addressOf(const ClipInfo& clip) {
+    return &clip;
+}
+
+bool stacksBelow(const ClipInfo* a, const ClipInfo* b) {
+    return clipSitsBelow(*a, *b);
+}
+
+double rangeStart(const BeatRange& range) {
+    return range.start.value;
+}
+
+bool isNonEmptyRange(const BeatRange& range) {
+    return range.end.value > range.start.value + kTolBeats;
+}
+
+/// Another clip's span clamped into [start, end): what the pair share.
+BeatRange overlapRange(const ClipInfo& other, double start, double end) {
+    const auto& placement = other.placement;
+    return {BeatPosition{std::max(placement.startBeat, start)},
+            BeatPosition{std::min(placement.startBeat + placement.lengthBeats, end)}};
 }
 
 /// Sorted, non-overlapping covers, so trimming and hole-finding can walk them
 /// once. Touching ranges merge: two clips butted together cover as one.
 std::vector<BeatRange> mergeRanges(std::vector<BeatRange> ranges) {
-    std::sort(ranges.begin(), ranges.end(),
-              [](const BeatRange& a, const BeatRange& b) { return a.start.value < b.start.value; });
+    std::ranges::sort(ranges, {}, rangeStart);
 
     std::vector<BeatRange> merged;
     for (const auto& range : ranges) {
@@ -61,12 +85,9 @@ std::unordered_map<ClipId, AudibleSpan> computeAudibleSpans(
     std::unordered_map<ClipId, AudibleSpan> spans;
     spans.reserve(trackClips.size());
 
-    std::vector<const ClipInfo*> ordered;
-    ordered.reserve(trackClips.size());
-    for (const auto& clip : trackClips)
-        ordered.push_back(&clip);
-    std::sort(ordered.begin(), ordered.end(),
-              [](const ClipInfo* a, const ClipInfo* b) { return clipSitsBelow(*a, *b); });
+    auto ordered =
+        trackClips | std::views::transform(addressOf) | toStd<std::vector<const ClipInfo*>>();
+    std::ranges::sort(ordered, stacksBelow);
 
     for (size_t i = 0; i < ordered.size(); ++i) {
         const ClipInfo& clip = *ordered[i];
@@ -84,34 +105,28 @@ std::unordered_map<ClipId, AudibleSpan> computeAudibleSpans(
         const double clipStart = span.startBeat;
         const double clipEnd = span.endBeat();
 
-        // Only the clips above this one can cover it.
-        std::vector<BeatRange> covers;
-        for (size_t j = i + 1; j < ordered.size(); ++j) {
-            const ClipInfo& upper = *ordered[j];
-
+        const auto silencesThisClip = [&clip](const ClipInfo* upper) {
             // A clip nobody can hear covers nothing: letting a hand-disabled
             // clip (#1736) occlude would silence the clip below on behalf of
             // silence.
-            if (!upper.enabled)
-                continue;
+            if (!upper->enabled)
+                return false;
             // The one switch: either clip asking makes the overlap play both,
             // and nothing else does. Ticking it on the clip that had gone
             // silent — the one you would reach for, and the only one with
             // anything to gain — used to do nothing at all (#2003).
-            if (upper.overlapPlaysBoth || clip.overlapPlaysBoth)
-                continue;
+            if (upper->overlapPlaysBoth || clip.overlapPlaysBoth)
+                return false;
+            return upper->placement.lengthBeats > 0.0;
+        };
+        const auto clampedToClip = [&](const ClipInfo* upper) {
+            return overlapRange(*upper, clipStart, clipEnd);
+        };
 
-            const double uStart = upper.placement.startBeat;
-            const double uEnd = uStart + upper.placement.lengthBeats;
-            if (!(uEnd > uStart))
-                continue;
-
-            const double from = std::max(uStart, clipStart);
-            const double to = std::min(uEnd, clipEnd);
-            if (to > from + kTolBeats)
-                covers.push_back({BeatPosition{from}, BeatPosition{to}});
-        }
-
+        // Only the clips above this one can cover it.
+        auto covers = ordered | std::views::drop(static_cast<std::ptrdiff_t>(i) + 1) |
+                      std::views::filter(silencesThisClip) | std::views::transform(clampedToClip) |
+                      std::views::filter(isNonEmptyRange) | toStd<std::vector<BeatRange>>();
         covers = mergeRanges(std::move(covers));
 
         // Covers touching an edge pull that edge in — that is a shorter clip,
@@ -164,18 +179,16 @@ std::vector<BeatRange> computeBothPlayRanges(const std::vector<ClipInfo>& trackC
 
     // Above and below alike: both clips of a pair that sounds together mark it
     // (#2003).
-    std::vector<BeatRange> shared;
-    for (const auto& other : trackClips) {
-        if (other.id == clipId || !overlapPlaysThrough(*clip, other))
-            continue;
+    const auto soundsWithClip = [&](const ClipInfo& other) {
+        return other.id != clipId && overlapPlaysThrough(*clip, other);
+    };
+    const auto clampedToClip = [&](const ClipInfo& other) {
+        return overlapRange(other, start, end);
+    };
 
-        const double from = std::max(other.placement.startBeat, start);
-        const double to = std::min(other.placement.startBeat + other.placement.lengthBeats, end);
-        if (to > from + kTolBeats)
-            shared.push_back({BeatPosition{from}, BeatPosition{to}});
-    }
-
-    return mergeRanges(std::move(shared));
+    return mergeRanges(trackClips | std::views::filter(soundsWithClip) |
+                       std::views::transform(clampedToClip) | std::views::filter(isNonEmptyRange) |
+                       toStd<std::vector<BeatRange>>());
 }
 
 std::vector<BeatRange> computeShowThroughRanges(const std::vector<ClipInfo>& trackClips,
@@ -189,21 +202,18 @@ std::vector<BeatRange> computeShowThroughRanges(const std::vector<ClipInfo>& tra
     if (!(end > start))
         return {};
 
-    std::vector<BeatRange> showing;
-    for (const auto& other : trackClips) {
-        if (other.id == clipId || !clipSitsBelow(other, *clip))
-            continue;
+    const auto showsThroughClip = [&](const ClipInfo& other) {
         // A cover has nothing left to show: it silences what is under it.
-        if (!overlapPlaysThrough(*clip, other))
-            continue;
+        return other.id != clipId && clipSitsBelow(other, *clip) &&
+               overlapPlaysThrough(*clip, other);
+    };
+    const auto clampedToClip = [&](const ClipInfo& other) {
+        return overlapRange(other, start, end);
+    };
 
-        const double from = std::max(other.placement.startBeat, start);
-        const double to = std::min(other.placement.startBeat + other.placement.lengthBeats, end);
-        if (to > from + kTolBeats)
-            showing.push_back({BeatPosition{from}, BeatPosition{to}});
-    }
-
-    return mergeRanges(std::move(showing));
+    return mergeRanges(trackClips | std::views::filter(showsThroughClip) |
+                       std::views::transform(clampedToClip) | std::views::filter(isNonEmptyRange) |
+                       toStd<std::vector<BeatRange>>());
 }
 
 }  // namespace magda

--- a/magda/daw/core/MixerStripOrder.cpp
+++ b/magda/daw/core/MixerStripOrder.cpp
@@ -1,14 +1,23 @@
 #include "MixerStripOrder.hpp"
 
+#include <algorithm>
+#include <iterator>
+#include <ranges>
+
+#include "RangesHelpers.hpp"
+
 namespace magda {
 
 namespace {
 
 const TrackInfo* findTrack(const std::vector<TrackInfo>& tracks, TrackId id) {
-    for (const auto& track : tracks)
-        if (track.id == id)
-            return &track;
-    return nullptr;
+    const auto hasId = [id](const TrackInfo& track) { return track.id == id; };
+    const auto found = std::ranges::find_if(tracks, hasId);
+    return found == tracks.end() ? nullptr : &*found;
+}
+
+auto isStripIn(const std::vector<TrackInfo>& tracks, ViewMode mode) {
+    return [&tracks, mode](const TrackInfo& track) { return isMixerStrip(track, tracks, mode); };
 }
 
 }  // namespace
@@ -32,26 +41,18 @@ bool isMixerStrip(const TrackInfo& track, const std::vector<TrackInfo>& tracks, 
 }
 
 std::vector<TrackId> mixerStripOrder(const std::vector<TrackInfo>& tracks, ViewMode mode) {
-    std::vector<TrackId> order;
-    order.reserve(tracks.size());
-    for (const auto& track : tracks)
-        if (isMixerStrip(track, tracks, mode))
-            order.push_back(track.id);
-    return order;
+    return tracks | std::views::filter(isStripIn(tracks, mode)) |
+           std::views::transform(&TrackInfo::id) | toStd<std::vector<TrackId>>();
 }
 
 TrackId mixerStripAtPosition(const std::vector<TrackInfo>& tracks, ViewMode mode, int position) {
     if (position < 1)
         return INVALID_TRACK_ID;
 
-    int seen = 0;
-    for (const auto& track : tracks) {
-        if (!isMixerStrip(track, tracks, mode))
-            continue;
-        if (++seen == position)
-            return track.id;
-    }
-    return INVALID_TRACK_ID;
+    // Positions count from 1: the strip at N is the (N - 1)th one along.
+    auto strips = tracks | std::views::filter(isStripIn(tracks, mode));
+    const auto found = std::ranges::next(strips.begin(), position - 1, strips.end());
+    return found == strips.end() ? INVALID_TRACK_ID : found->id;
 }
 
 }  // namespace magda

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -1,9 +1,13 @@
 #include "ParameterUtils.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <functional>
 #include <limits>
+#include <ranges>
 
+#include "RangesHelpers.hpp"
 #include "TechnicalText.hpp"
 #include "TempoUtils.hpp"
 
@@ -329,13 +333,14 @@ float applyModulation(float baseNormalized, float modValue, float amount, bool b
 
 float applyModulations(float baseNormalized,
                        const std::vector<std::pair<float, float>>& modsAndAmounts, bool bipolar) {
-    float result = baseNormalized;
+    const auto offsetOf = [bipolar](const std::pair<float, float>& mod) {
+        return modulationOffset(mod.first, mod.second, bipolar);
+    };
 
-    for (const auto& [modValue, amount] : modsAndAmounts) {
-        result += modulationOffset(modValue, amount, bipolar);
-    }
-
-    return juce::jlimit(0.0f, 1.0f, result);
+    // Left fold: the sum keeps the order the mods were stacked in.
+    return juce::jlimit(0.0f, 1.0f,
+                        std::ranges::fold_left(modsAndAmounts | std::views::transform(offsetOf),
+                                               baseNormalized, std::plus{}));
 }
 
 namespace {
@@ -742,6 +747,15 @@ double snapNormalizedToGrid(double normalized, const ParameterInfo& info) {
     // Build the set of "natural" grid values in normalized space for this
     // parameter, then snap to the closest one. Values mirror what the
     // curve editor and track header paint as grid lines.
+    const auto normalizedTick = [&info](double realValue) {
+        return static_cast<double>(realToNormalized(static_cast<float>(realValue), info));
+    };
+    const auto tenthStep = [](int step) { return step / 10.0; };
+    const auto tenPercentSteps = [&tenthStep] {
+        return std::views::iota(0, 11) | std::views::transform(tenthStep) |
+               toStd<std::vector<double>>();
+    };
+
     std::vector<double> gridNorms;
 
     switch (info.scale) {
@@ -749,10 +763,8 @@ double snapNormalizedToGrid(double normalized, const ParameterInfo& info) {
             // dB ticks — same set the paint code uses.
             static constexpr double kDbTicks[] = {6.0,   3.0,   0.0,   -6.0,  -12.0,
                                                   -18.0, -24.0, -36.0, -48.0, -60.0};
-            for (double db : kDbTicks) {
-                float n = realToNormalized(static_cast<float>(db), info);
-                gridNorms.push_back(static_cast<double>(n));
-            }
+            gridNorms =
+                kDbTicks | std::views::transform(normalizedTick) | toStd<std::vector<double>>();
             // Always include the endpoints so snap can reach max/min.
             gridNorms.push_back(0.0);
             gridNorms.push_back(1.0);
@@ -760,12 +772,15 @@ double snapNormalizedToGrid(double normalized, const ParameterInfo& info) {
         }
 
         case ParameterScale::Discrete: {
-            if (info.choices.empty())
+            // One choice has nowhere to snap to, and its step would be 0/0.
+            const int count = static_cast<int>(info.choices.size());
+            if (count < 2)
                 return normalized;
-            int count = static_cast<int>(info.choices.size());
-            for (int i = 0; i < count; ++i) {
-                gridNorms.push_back(static_cast<double>(i) / (count - 1));
-            }
+            const auto evenStep = [count](int index) {
+                return static_cast<double>(index) / (count - 1);
+            };
+            gridNorms = std::views::iota(0, count) | std::views::transform(evenStep) |
+                        toStd<std::vector<double>>();
             break;
         }
 
@@ -777,38 +792,28 @@ double snapNormalizedToGrid(double normalized, const ParameterInfo& info) {
             // Detect by range; otherwise fall through to 10% steps.
             if (info.minValue == -1.0f && info.maxValue == 1.0f) {
                 static constexpr double kPanTicks[] = {-1.0, -0.5, 0.0, 0.5, 1.0};
-                for (double p : kPanTicks) {
-                    float n = realToNormalized(static_cast<float>(p), info);
-                    gridNorms.push_back(static_cast<double>(n));
-                }
+                gridNorms = kPanTicks | std::views::transform(normalizedTick) |
+                            toStd<std::vector<double>>();
                 break;
             }
             // Generic linear (e.g., percent): 10% steps.
-            for (int i = 0; i <= 10; ++i)
-                gridNorms.push_back(i / 10.0);
+            gridNorms = tenPercentSteps();
             break;
         }
 
         default:
             // Generic fallback: 10% steps in normalized space.
-            for (int i = 0; i <= 10; ++i)
-                gridNorms.push_back(i / 10.0);
+            gridNorms = tenPercentSteps();
             break;
     }
 
     if (gridNorms.empty())
         return normalized;
 
-    double best = gridNorms.front();
-    double bestDist = std::abs(normalized - best);
-    for (double g : gridNorms) {
-        double d = std::abs(normalized - g);
-        if (d < bestDist) {
-            bestDist = d;
-            best = g;
-        }
-    }
-    return best;
+    const auto distanceFromValue = [normalized](double grid) {
+        return std::abs(normalized - grid);
+    };
+    return *std::ranges::min_element(gridNorms, {}, distanceFromValue);
 }
 
 juce::String getChoiceString(int index, const ParameterInfo& info) {

--- a/magda/daw/core/RangesHelpers.hpp
+++ b/magda/daw/core/RangesHelpers.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_data_structures/juce_data_structures.h>
 
+#include <cstddef>
 #include <ranges>
 #include <utility>
 
@@ -42,6 +43,45 @@ template <class C, std::ranges::input_range R> C toJuce(R&& range) {
     for (auto&& value : range)
         out.add(std::forward<decltype(value)>(value));
     return out;
+}
+
+/** @brief Collect a range into a std container (#2149).
+ *
+ *  std::ranges::to is libstdc++ 14, and Linux CI builds with GCC 13.3, which is
+ *  the floor the README documents.
+ */
+template <class C, std::ranges::input_range R> C toStd(R&& range) {
+    C out;
+    if constexpr (std::ranges::sized_range<R> && requires { out.reserve(std::size_t{}); })
+        out.reserve(static_cast<std::size_t>(std::ranges::size(range)));
+    for (auto&& value : range)
+        out.insert(out.end(), std::forward<decltype(value)>(value));
+    return out;
+}
+
+namespace detail {
+
+template <class C> struct ToJuceClosure {
+    template <std::ranges::input_range R> friend C operator|(R&& range, ToJuceClosure) {
+        return toJuce<C>(std::forward<R>(range));
+    }
+};
+
+template <class C> struct ToStdClosure {
+    template <std::ranges::input_range R> friend C operator|(R&& range, ToStdClosure) {
+        return toStd<C>(std::forward<R>(range));
+    }
+};
+
+}  // namespace detail
+
+/** @brief The pipe forms, so a pipeline ends where it reads: `| toStd<V>()`. */
+template <class C> auto toJuce() {
+    return detail::ToJuceClosure<C>{};
+}
+
+template <class C> auto toStd() {
+    return detail::ToStdClosure<C>{};
 }
 
 }  // namespace magda

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -10,6 +10,7 @@
 #include "../engine/AudioEngine.hpp"
 #include "../project/ProjectManager.hpp"
 #include "ClipManager.hpp"
+#include "RangesHelpers.hpp"
 #include "TempoUtils.hpp"
 
 namespace magda {
@@ -20,12 +21,24 @@ ChainNodePath parentChainOf(const ChainNodePath& path) {
 }
 
 std::vector<ChainElement> deepCopyChainElements(const std::vector<ChainElement>& elements) {
-    std::vector<ChainElement> copied;
-    copied.reserve(elements.size());
-    for (const auto& element : elements)
-        copied.push_back(deepCopyElement(element));
-    return copied;
+    return elements | std::views::transform(deepCopyElement) | toStd<std::vector<ChainElement>>();
 }
+
+/// Container order for the move records: same parent chain first, then the
+/// index each element sat at inside it.
+const auto byParentThenIndex = [](const auto& a, const auto& b) {
+    const auto& parentA = a.originalParentPath;
+    const auto& parentB = b.originalParentPath;
+    if (parentA == parentB)
+        return a.originalIndex < b.originalIndex;
+    if (parentA.trackId != parentB.trackId)
+        return parentA.trackId < parentB.trackId;
+    return parentA.toString() < parentB.toString();
+};
+
+const auto sameParent = [](const auto& a, const auto& b) {
+    return a.originalParentPath == b.originalParentPath;
+};
 
 ChainNodePath findChainElementPathRecursive(const ChainNodePath& parentPath,
                                             const std::vector<ChainElement>& elements,
@@ -477,25 +490,16 @@ void MoveChainElementsCommand::execute() {
         if (index < 0)
             continue;
 
-        const bool alreadyRecorded =
-            std::any_of(records.begin(), records.end(), [type, id](const auto& record) {
-                return record.type == type && record.id == id;
-            });
-        if (alreadyRecorded)
+        const auto namesSameElement = [type, id](const auto& record) {
+            return record.type == type && record.id == id;
+        };
+        if (std::ranges::any_of(records, namesSameElement))
             continue;
 
         records.push_back({path, parentPath, index, type, id});
     }
 
-    std::stable_sort(records.begin(), records.end(), [](const auto& a, const auto& b) {
-        const auto& parentA = a.originalParentPath;
-        const auto& parentB = b.originalParentPath;
-        if (parentA == parentB)
-            return a.originalIndex < b.originalIndex;
-        if (parentA.trackId != parentB.trackId)
-            return parentA.trackId < parentB.trackId;
-        return parentA.toString() < parentB.toString();
-    });
+    std::ranges::stable_sort(records, byParentThenIndex);
 
     commands_.clear();
     commands_.reserve(records.size());
@@ -523,13 +527,7 @@ void MoveChainElementsCommand::undo() {
 
     auto& tm = TrackManager::getInstance();
     auto records = movedElements_;
-    std::stable_sort(records.begin(), records.end(), [](const auto& a, const auto& b) {
-        if (a.originalParentPath == b.originalParentPath)
-            return a.originalIndex < b.originalIndex;
-        if (a.originalParentPath.trackId != b.originalParentPath.trackId)
-            return a.originalParentPath.trackId < b.originalParentPath.trackId;
-        return a.originalParentPath.toString() < b.originalParentPath.toString();
-    });
+    std::ranges::stable_sort(records, byParentThenIndex);
 
     auto restoreRecord = [&tm](const auto& record) {
         auto currentPath = findChainElementPath(tm, record.type, record.id);
@@ -545,21 +543,15 @@ void MoveChainElementsCommand::undo() {
             dropIndexForHome(tm, currentPath, record.originalParentPath, record.originalIndex));
     };
 
-    auto begin = records.begin();
-    while (begin != records.end()) {
-        auto end = std::find_if(begin, records.end(), [&](const auto& record) {
-            return record.originalParentPath != begin->originalParentPath;
-        });
+    for (auto chunk : records | std::views::chunk_by(sameParent)) {
+        const auto originalIndexOf = [](const auto& record) { return record.originalIndex; };
+        const auto lowestOriginal = std::ranges::min_element(chunk, {}, originalIndexOf);
 
-        const auto minOriginalIt = std::min_element(begin, end, [](const auto& a, const auto& b) {
-            return a.originalIndex < b.originalIndex;
-        });
         int minCurrentIndex = std::numeric_limits<int>::max();
         bool allStillInOriginalContainer = true;
-
-        for (auto it = begin; it != end; ++it) {
-            const auto currentPath = findChainElementPath(tm, it->type, it->id);
-            if (!currentPath.isValid() || parentChainOf(currentPath) != it->originalParentPath) {
+        for (const auto& record : chunk) {
+            const auto currentPath = findChainElementPath(tm, record.type, record.id);
+            if (!currentPath.isValid() || parentChainOf(currentPath) != record.originalParentPath) {
                 allStillInOriginalContainer = false;
                 break;
             }
@@ -569,17 +561,18 @@ void MoveChainElementsCommand::undo() {
                 minCurrentIndex = std::min(minCurrentIndex, currentIndex);
         }
 
-        if (allStillInOriginalContainer && minOriginalIt != end &&
-            minCurrentIndex < minOriginalIt->originalIndex) {
-            for (auto it = std::make_reverse_iterator(end); it != std::make_reverse_iterator(begin);
-                 ++it)
-                restoreRecord(*it);
+        // The chunk sits earlier than it started, so restoring front-first
+        // would push each element past the one before it.
+        const bool restoreFromBack = allStillInOriginalContainer &&
+                                     lowestOriginal != std::ranges::end(chunk) &&
+                                     minCurrentIndex < lowestOriginal->originalIndex;
+        if (restoreFromBack) {
+            for (const auto& record : chunk | std::views::reverse)
+                restoreRecord(record);
         } else {
-            for (auto it = begin; it != end; ++it)
-                restoreRecord(*it);
+            for (const auto& record : chunk)
+                restoreRecord(record);
         }
-
-        begin = end;
     }
 }
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <map>
+#include <ranges>
 #include <set>
 #include <unordered_set>
 
@@ -1358,13 +1359,8 @@ std::vector<TrackId> TrackManager::getChildTracks(TrackId groupId) const {
 }
 
 std::vector<TrackId> TrackManager::getTopLevelTracks() const {
-    std::vector<TrackId> result;
-    for (const auto& track : tracks_) {
-        if (track.isTopLevel()) {
-            result.push_back(track.id);
-        }
-    }
-    return result;
+    return tracks_ | std::views::filter(&TrackInfo::isTopLevel) |
+           std::views::transform(&TrackInfo::id) | toStd<std::vector<TrackId>>();
 }
 
 std::vector<TrackId> TrackManager::getAllDescendants(TrackId trackId) const {
@@ -3164,23 +3160,19 @@ void TrackManager::setTrackHeight(TrackId trackId, ViewMode mode, int height) {
 // ============================================================================
 
 std::vector<TrackId> TrackManager::getVisibleTracks(ViewMode mode) const {
-    std::vector<TrackId> result;
-    for (const auto& track : tracks_) {
-        if (track.isVisibleIn(mode)) {
-            result.push_back(track.id);
-        }
-    }
-    return result;
+    const auto isVisible = [mode](const TrackInfo& track) { return track.isVisibleIn(mode); };
+
+    return tracks_ | std::views::filter(isVisible) | std::views::transform(&TrackInfo::id) |
+           toStd<std::vector<TrackId>>();
 }
 
 std::vector<TrackId> TrackManager::getVisibleTopLevelTracks(ViewMode mode) const {
-    std::vector<TrackId> result;
-    for (const auto& track : tracks_) {
-        if (track.isTopLevel() && track.isVisibleIn(mode)) {
-            result.push_back(track.id);
-        }
-    }
-    return result;
+    const auto isVisibleAtTopLevel = [mode](const TrackInfo& track) {
+        return track.isTopLevel() && track.isVisibleIn(mode);
+    };
+
+    return tracks_ | std::views::filter(isVisibleAtTopLevel) |
+           std::views::transform(&TrackInfo::id) | toStd<std::vector<TrackId>>();
 }
 
 // ============================================================================

--- a/magda/daw/ui/components/chain/params/ParamLinkResolver.cpp
+++ b/magda/daw/ui/components/chain/params/ParamLinkResolver.cpp
@@ -1,8 +1,38 @@
 #include "params/ParamLinkResolver.hpp"
 
 #include <algorithm>
+#include <functional>
+#include <ranges>
+
+#include "core/ParameterUtils.hpp"
+#include "core/RangesHelpers.hpp"
 
 namespace magda::daw::ui {
+
+namespace {
+
+constexpr auto linkIsEnabled = [](const auto& link) { return link.enabled; };
+constexpr auto everyLink = [](const auto&) { return true; };
+
+/// What one level's sources add to a parameter. Left fold: the sum keeps the
+/// order the sources are stacked in.
+template <class Sources, class LinkCounts>
+float sumLinkedOffsets(const Sources* sources, const magda::ControlTarget& target,
+                       LinkCounts counts) {
+    if (sources == nullptr)
+        return 0.0f;
+
+    const auto offsetOf = [&](const auto& source) {
+        const auto* link = source.getLink(target);
+        if (link == nullptr || !counts(*link))
+            return 0.0f;
+        return magda::ParameterUtils::modulationOffset(source.value, link->amount, link->bipolar);
+    };
+
+    return std::ranges::fold_left(*sources | std::views::transform(offsetOf), 0.0f, std::plus{});
+}
+
+}  // namespace
 
 std::vector<ResolvedModLink> getLinkedMods(const ParamLinkContext& ctx) {
     std::vector<ResolvedModLink> linked;
@@ -127,93 +157,28 @@ bool hasActiveLinks(const ParamLinkContext& ctx) {
 }
 
 float computeTotalModModulation(const ParamLinkContext& ctx) {
-    float total = 0.0f;
-    if (ctx.deviceId == magda::INVALID_DEVICE_ID) {
-        return total;
-    }
+    if (ctx.deviceId == magda::INVALID_DEVICE_ID)
+        return 0.0f;
 
-    magda::ControlTarget modTarget =
-        magda::ControlTarget::pluginParam(ctx.devicePath, ctx.paramIndex);
+    const auto modTarget = magda::ControlTarget::pluginParam(ctx.devicePath, ctx.paramIndex);
 
-    // Device-level mods
-    if (ctx.deviceMods) {
-        for (const auto& mod : *ctx.deviceMods) {
-            if (const auto* link = mod.getLink(modTarget)) {
-                if (!link->enabled)
-                    continue;
-                float modOffset = link->bipolar ? (mod.value * 2.0f - 1.0f) : mod.value;
-                total += modOffset * link->amount;
-            }
-        }
-    }
-
-    // Rack-level mods
-    if (ctx.rackMods) {
-        for (const auto& mod : *ctx.rackMods) {
-            if (const auto* link = mod.getLink(modTarget)) {
-                if (!link->enabled)
-                    continue;
-                float modOffset = link->bipolar ? (mod.value * 2.0f - 1.0f) : mod.value;
-                total += modOffset * link->amount;
-            }
-        }
-    }
-
-    // Track-level mods
-    if (ctx.trackMods) {
-        for (const auto& mod : *ctx.trackMods) {
-            if (const auto* link = mod.getLink(modTarget)) {
-                if (!link->enabled)
-                    continue;
-                float modOffset = link->bipolar ? (mod.value * 2.0f - 1.0f) : mod.value;
-                total += modOffset * link->amount;
-            }
-        }
-    }
-
-    return total;
+    // A mod link that is switched off contributes nothing; device, rack and
+    // track levels all stack onto the same parameter.
+    return sumLinkedOffsets(ctx.deviceMods, modTarget, linkIsEnabled) +
+           sumLinkedOffsets(ctx.rackMods, modTarget, linkIsEnabled) +
+           sumLinkedOffsets(ctx.trackMods, modTarget, linkIsEnabled);
 }
 
 float computeTotalMacroModulation(const ParamLinkContext& ctx) {
-    float total = 0.0f;
-    if (ctx.deviceId == magda::INVALID_DEVICE_ID) {
-        return total;
-    }
+    if (ctx.deviceId == magda::INVALID_DEVICE_ID)
+        return 0.0f;
 
-    magda::ControlTarget macroTarget =
-        magda::ControlTarget::pluginParam(ctx.devicePath, ctx.paramIndex);
+    const auto macroTarget = magda::ControlTarget::pluginParam(ctx.devicePath, ctx.paramIndex);
 
-    // Device-level macros
-    if (ctx.deviceMacros) {
-        for (const auto& macro : *ctx.deviceMacros) {
-            if (const auto* link = macro.getLink(macroTarget)) {
-                float macroOffset = link->bipolar ? (macro.value * 2.0f - 1.0f) : macro.value;
-                total += macroOffset * link->amount;
-            }
-        }
-    }
-
-    // Rack-level macros
-    if (ctx.rackMacros) {
-        for (const auto& macro : *ctx.rackMacros) {
-            if (const auto* link = macro.getLink(macroTarget)) {
-                float macroOffset = link->bipolar ? (macro.value * 2.0f - 1.0f) : macro.value;
-                total += macroOffset * link->amount;
-            }
-        }
-    }
-
-    // Track-level macros
-    if (ctx.trackMacros) {
-        for (const auto& macro : *ctx.trackMacros) {
-            if (const auto* link = macro.getLink(macroTarget)) {
-                float macroOffset = link->bipolar ? (macro.value * 2.0f - 1.0f) : macro.value;
-                total += macroOffset * link->amount;
-            }
-        }
-    }
-
-    return total;
+    // A macro link has no switch of its own: linking one is the switch.
+    return sumLinkedOffsets(ctx.deviceMacros, macroTarget, everyLink) +
+           sumLinkedOffsets(ctx.rackMacros, macroTarget, everyLink) +
+           sumLinkedOffsets(ctx.trackMacros, macroTarget, everyLink);
 }
 
 const magda::ModInfo* resolveModPtr(const magda::ModSelection& sel,

--- a/tests/core/test_ranges_helpers.cpp
+++ b/tests/core/test_ranges_helpers.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <ranges>
+#include <set>
 #include <vector>
 
 #include "magda/daw/core/RangesHelpers.hpp"
@@ -83,4 +85,60 @@ TEST_CASE("removeChildrenWithType() leaves nested children of that type alone",
     magda::removeChildrenWithType(tree, juce::Identifier("STEP"));
 
     CHECK(tree.getChild(0).getNumChildren() == 1);
+}
+
+// The two collect helpers (#2144, #2149). std::ranges::to rejects juce::Array
+// and StringArray, and is libstdc++ 14, past the GCC 13 floor in the README.
+
+TEST_CASE("toStd() collects a pipeline into a vector", "[ranges][collect]") {
+    const std::vector<int> source{1, 2, 3, 4, 5};
+    const auto isOdd = [](int n) { return n % 2 != 0; };
+    const auto doubled = [](int n) { return n * 2; };
+
+    CHECK(magda::toStd<std::vector<int>>(source | std::views::filter(isOdd) |
+                                         std::views::transform(doubled)) ==
+          std::vector<int>{2, 6, 10});
+}
+
+TEST_CASE("toStd() reads as the last stage of the pipe", "[ranges][collect]") {
+    const std::vector<int> source{1, 2, 3};
+    const auto negated = [](int n) { return -n; };
+
+    CHECK((source | std::views::transform(negated) | magda::toStd<std::vector<int>>()) ==
+          std::vector<int>{-1, -2, -3});
+}
+
+TEST_CASE("toStd() fills a node container through insert()", "[ranges][collect]") {
+    const std::vector<int> source{3, 1, 3, 2};
+
+    CHECK((source | magda::toStd<std::set<int>>()) == std::set<int>{1, 2, 3});
+}
+
+TEST_CASE("toStd() of an empty pipeline is empty", "[ranges][collect]") {
+    const std::vector<int> source{1, 3, 5};
+    const auto isEven = [](int n) { return n % 2 == 0; };
+
+    CHECK((source | std::views::filter(isEven) | magda::toStd<std::vector<int>>()).empty());
+}
+
+TEST_CASE("toStd() collects move-only elements", "[ranges][collect]") {
+    const std::vector<int> source{1, 2, 3};
+    const auto boxed = [](int n) { return std::make_unique<int>(n); };
+
+    const auto boxes =
+        source | std::views::transform(boxed) | magda::toStd<std::vector<std::unique_ptr<int>>>();
+
+    REQUIRE(boxes.size() == 3);
+    CHECK(*boxes[1] == 2);
+}
+
+TEST_CASE("toJuce() collects into a JUCE container", "[ranges][collect]") {
+    const std::vector<int> source{1, 2, 3};
+    const auto asString = [](int n) { return juce::String(n); };
+
+    const auto names =
+        source | std::views::transform(asString) | magda::toJuce<juce::StringArray>();
+
+    REQUIRE(names.size() == 3);
+    CHECK(names[2] == "3");
 }


### PR DESCRIPTION
Part of #2149. The query blocks that build a vector by hand become
`filter | transform | collect`, with the predicate named at the call site
rather than written inline.

## The collect helper

`std::ranges::to` is libstdc++ 14, and Linux CI builds with GCC 13.3,
which is the floor the README documents. So collecting goes through a new
`toStd<C>()` beside `toJuce<C>()` in `RangesHelpers.hpp`. Both gain a pipe
form, so a pipeline ends where it reads:

```cpp
return clips_ | std::views::values | std::views::filter(isArrangementClip) |
       toStd<std::vector<ClipInfo>>();
```

Covered in `tests/core/test_ranges_helpers.cpp`, including the move-only
and node-container cases.

## Dedupes

Shapes that turned up more than once, collapsed to one:

- every clip as a pointer lane, 3 copies in `ClipManager`
- the take/section event walk in `rebuildMidiComp`, 3 near-identical loops
- the arrangement id ordering behind both `getClipsOnTrack` overloads
- the touch-baseline lookup in `AutomationManager`, 3 copies
- the move-record container order in `TrackCommands`, 2 copies, and its
  hand-rolled run walk is now `views::chunk_by(sameParent)`
- the scope plugins for a track, 3 copies in `PluginManagerSync`
- the restored-id notify, 4 copies in `ClipCommands`
- the six bipolar offset sums in `ParamLinkResolver`, which now reuse
  `ParameterUtils::modulationOffset` instead of re-inlining the rule

## One bug

`snapNormalizedToGrid` returned NaN for a Discrete parameter with exactly
one choice: the step is `index / (count - 1)`, so `0/0`. It now returns the
value unsnapped, as it already did for no choices at all.

## Library floor

`fold_left` and `chunk_by` join `zip` and `contains` in the README's list of
C++23 library features in use. All four are libstdc++ 13.1, so the GCC 13
floor is unchanged. Both new ones were checked against AppleClang 16.0, the
compiler the macOS runners use, before being used.

## Still open on #2149

The `daw/ui` block: the shared (norm, label) grid builder duplicated between
`AutomationLaneHeader` and `AutomationCurveEditor`, `NodeComponent`'s pointer
vectors, the `ChainPanel` / `RackComponent` width sums, and three smaller
sites. That grid-builder extraction is surgery in paint code that neither
suite covers, so it gets its own PR.

## Verification

- `make debug` clean
- Catch2: 3880 passed, 13 skipped, 0 failed
- `magda_juce_tests`: all passed

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi