### PR TITLE
Rewrite the UI collection queries as ranges pipelines

### DIFF
--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "KitRow.hpp"
 #include "MacroInfo.hpp"
@@ -465,6 +466,21 @@ struct DeviceInfo {
     }
     const ParameterInfo* findParameterByIndex(int paramIndex) const {
         return const_cast<DeviceInfo*>(this)->findParameterByIndex(paramIndex);
+    }
+
+    // Parameter names positioned at their own paramIndex, so a link picker can
+    // read a name back from the index a stored target carries. paramIndex is a
+    // TE slot rather than an array position, so gaps stay empty.
+    std::vector<juce::String> paramNamesByIndex() const {
+        std::vector<juce::String> names;
+        for (const auto& param : parameters) {
+            if (param.paramIndex < 0)
+                continue;
+            if (param.paramIndex >= static_cast<int>(names.size()))
+                names.resize(static_cast<size_t>(param.paramIndex) + 1);
+            names[static_cast<size_t>(param.paramIndex)] = param.name;
+        }
+        return names;
     }
 
     juce::String getFormatString() const {

--- a/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
+++ b/magda/daw/ui/components/automation/AutomationCurveEditor.cpp
@@ -7,6 +7,7 @@
 #include "AutomationLaneComponent.hpp"
 #include "core/AutomationCommands.hpp"
 #include "core/ParameterUtils.hpp"
+#include "core/RangesHelpers.hpp"
 #include "core/UndoManager.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -230,36 +231,37 @@ void AutomationCurveEditor::paintGrid(juce::Graphics& g) {
     auto paramInfo = getParameterInfoForTarget(lane->target);
 
     // Build list of normalized grid positions based on parameter type
+    const auto tickAt = [&paramInfo](double realValue) {
+        return static_cast<double>(
+            ParameterUtils::realToNormalized(static_cast<float>(realValue), paramInfo));
+    };
+
     std::vector<double> gridNorms;
 
     if (paramInfo.scale == ParameterScale::FaderDB) {
         // dB values that make sense for a fader
-        const double dbValues[] = {6.0, 3.0, 0.0, -6.0, -12.0, -18.0, -24.0, -36.0, -48.0, -60.0};
-        for (double db : dbValues) {
-            float norm = ParameterUtils::realToNormalized(static_cast<float>(db), paramInfo);
-            gridNorms.push_back(static_cast<double>(norm));
-        }
+        static constexpr double kDbTicks[] = {6.0,   3.0,   0.0,   -6.0,  -12.0,
+                                              -18.0, -24.0, -36.0, -48.0, -60.0};
+        gridNorms = kDbTicks | std::views::transform(tickAt) | toStd<std::vector<double>>();
     } else if (lane->target.kind == ControlTarget::Kind::TrackPan) {
         // Pan: fine divisions from -1 to +1
-        for (double pan = -1.0; pan <= 1.0; pan += 0.25) {
-            float norm = ParameterUtils::realToNormalized(static_cast<float>(pan), paramInfo);
-            gridNorms.push_back(static_cast<double>(norm));
-        }
+        const auto panAt = [&tickAt](int step) { return tickAt(-1.0 + step * 0.25); };
+        gridNorms =
+            std::views::iota(0, 9) | std::views::transform(panAt) | toStd<std::vector<double>>();
     } else if (paramInfo.isBipolar()) {
         // Symmetric real-value grid so 0 lands exactly at mid-lane.
         // Quarter + half divisions give a readable ±max, ±50%, 0 grid.
-        float absMax = std::max(std::abs(paramInfo.minValue), std::abs(paramInfo.maxValue));
-        const double frac[] = {-1.0, -0.5, 0.0, 0.5, 1.0};
-        for (double f : frac) {
-            float norm =
-                ParameterUtils::realToNormalized(static_cast<float>(f * absMax), paramInfo);
-            gridNorms.push_back(static_cast<double>(norm));
-        }
+        const float absMax = std::max(std::abs(paramInfo.minValue), std::abs(paramInfo.maxValue));
+        static constexpr double kFractions[] = {-1.0, -0.5, 0.0, 0.5, 1.0};
+        const auto scaledTickAt = [&tickAt, absMax](double fraction) {
+            return tickAt(fraction * absMax);
+        };
+        gridNorms = kFractions | std::views::transform(scaledTickAt) | toStd<std::vector<double>>();
     } else {
         // Generic: 10% increments
-        for (int i = 1; i < 10; ++i) {
-            gridNorms.push_back(i / 10.0);
-        }
+        const auto tenthStep = [](int step) { return step / 10.0; };
+        gridNorms = std::views::iota(1, 10) | std::views::transform(tenthStep) |
+                    toStd<std::vector<double>>();
     }
 
     auto bounds = getLocalBounds();

--- a/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
+++ b/magda/daw/ui/components/automation/AutomationLaneHeader.cpp
@@ -2,12 +2,14 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 #include <utility>
 #include <vector>
 
 #include "../../../core/AutomationCommands.hpp"
 #include "../../../core/AutomationManager.hpp"
 #include "../../../core/ParameterUtils.hpp"
+#include "../../../core/RangesHelpers.hpp"
 #include "../../../core/TrackManager.hpp"
 #include "../../../core/UndoManager.hpp"
 #include "../../state/TimelineController.hpp"
@@ -356,6 +358,144 @@ void layoutAutoLaneHeaderButtons(AutoLaneHeaderButtons& buttons, const Automatio
                                kModeBtnSize, kModeBtnSize);
 }
 
+std::vector<AutomationGridTick> automationGridTicks(const AutomationTarget& target,
+                                                    const ParameterInfo& paramInfo) {
+    const auto tickAt = [&paramInfo](double realValue) {
+        return static_cast<double>(
+            ParameterUtils::realToNormalized(static_cast<float>(realValue), paramInfo));
+    };
+    const auto asLabelledTick = [&tickAt](const auto& tick) {
+        return std::pair{tickAt(tick.first), juce::String(tick.second)};
+    };
+
+    static constexpr double kQuarterNorms[] = {0.0, 0.25, 0.5, 0.75, 1.0};
+
+    std::vector<AutomationGridTick> gridValues;
+    if (paramInfo.scale == ParameterScale::FaderDB) {
+        static constexpr std::pair<double, const char*> kDbTicks[] = {
+            {6.0, "6"},     {3.0, "3"},     {0.0, "0"},     {-6.0, "-6"},  {-12.0, "-12"},
+            {-18.0, "-18"}, {-24.0, "-24"}, {-36.0, "-36"}, {-48.0, "-48"}};
+        gridValues = kDbTicks | std::views::transform(asLabelledTick) |
+                     toStd<std::vector<AutomationGridTick>>();
+    } else if (target.kind == ControlTarget::Kind::TrackPan) {
+        static constexpr std::pair<double, const char*> kPanTicks[] = {
+            {1.0, "R"}, {0.5, "50R"}, {0.0, "C"}, {-0.5, "50L"}, {-1.0, "L"}};
+        gridValues = kPanTicks | std::views::transform(asLabelledTick) |
+                     toStd<std::vector<AutomationGridTick>>();
+    } else if (paramInfo.scale == ParameterScale::Boolean) {
+        // A switch has exactly two meaningful positions. Without
+        // this it falls through to the 10% grid at the bottom of
+        // the chain and reads as a continuous percentage.
+        gridValues.emplace_back(1.0, "On");
+        gridValues.emplace_back(0.0, "Off");
+    } else if (paramInfo.isBipolar()) {
+        // Bipolar params (EQ gain, pitch, etc): symmetric labels
+        // around zero so the 0 line lands mid-lane. Use the larger
+        // |bound| so extremes land on both ends regardless of
+        // asymmetry.
+        const float absMax = std::max(std::abs(paramInfo.minValue), std::abs(paramInfo.maxValue));
+        const double realTicks[] = {absMax, absMax * 0.5, 0.0, -absMax * 0.5, -absMax};
+        const auto asSignedTick = [&](double real) {
+            const int rounded = static_cast<int>(std::round(real));
+            const juce::String label =
+                rounded > 0 ? "+" + juce::String(rounded) : juce::String(rounded);
+            return std::pair{tickAt(real), label + paramInfo.unit};
+        };
+        gridValues = realTicks | std::views::transform(asSignedTick) |
+                     toStd<std::vector<AutomationGridTick>>();
+    } else if (paramInfo.scale == ParameterScale::Discrete && !paramInfo.choices.empty()) {
+        // Discrete: use the choices array as label source. Each
+        // index maps to a real value (0..N-1) — sample evenly so
+        // the lane shows musical labels (e.g. "1 Bar", "1/4",
+        // "1/8") instead of falling through to the 10% fallback.
+        // If the parameter curated a sparse labelTicks set (e.g.
+        // sync division skipping the triplet/dotted entries that
+        // snap on playback), use it directly so the thinner can't
+        // re-introduce the labels we deliberately excluded.
+        if (!paramInfo.labelTicks.empty()) {
+            gridValues = paramInfo.labelTicks | std::views::transform(asLabelledTick) |
+                         toStd<std::vector<AutomationGridTick>>();
+        } else {
+            const auto asChoiceTick = [&](int index) {
+                return std::pair{tickAt(index), paramInfo.choices[static_cast<size_t>(index)]};
+            };
+            gridValues = std::views::iota(0, static_cast<int>(paramInfo.choices.size())) |
+                         std::views::transform(asChoiceTick) |
+                         toStd<std::vector<AutomationGridTick>>();
+        }
+    } else if (paramInfo.unit.isNotEmpty()) {
+        // Unipolar with unit: evenly spaced in normalized space,
+        // labelled with the real value in the parameter's own unit.
+        const auto asUnitTick = [&](double norm) {
+            const float real =
+                ParameterUtils::normalizedToReal(static_cast<float>(norm), paramInfo);
+            return std::pair{norm,
+                             juce::String(static_cast<int>(std::round(real))) + paramInfo.unit};
+        };
+        gridValues = kQuarterNorms | std::views::transform(asUnitTick) |
+                     toStd<std::vector<AutomationGridTick>>();
+    } else if (paramInfo.displayText) {
+        // displayText wraps TE's valueToString, which expects a
+        // plugin-native value — NOT normalized [0,1]. Sample the
+        // REAL value at each visual position so any scaleAnchor
+        // skew is honoured, then project from info-range onto the
+        // TE-native range so the provider sees what it expects.
+        const float teSpan = paramInfo.teMaxValue - paramInfo.teMinValue;
+        const float infoSpan = paramInfo.maxValue - paramInfo.minValue;
+        const auto asDisplayTick = [&](double norm) {
+            float teRaw = NAN;
+            if (infoSpan > 0.0f) {
+                const float real =
+                    ParameterUtils::normalizedToReal(static_cast<float>(norm), paramInfo);
+                const float normInInfo = (real - paramInfo.minValue) / infoSpan;
+                teRaw = paramInfo.teMinValue + normInInfo * teSpan;
+            } else {
+                teRaw = paramInfo.teMinValue + static_cast<float>(norm) * teSpan;
+            }
+            const auto text = paramInfo.displayText->format(teRaw);
+            return std::pair{
+                norm, text.isNotEmpty() ? text : juce::String(static_cast<int>(norm * 100)) + "%"};
+        };
+        gridValues = kQuarterNorms | std::views::transform(asDisplayTick) |
+                     toStd<std::vector<AutomationGridTick>>();
+    } else if (!paramInfo.valueTable.empty()) {
+        const auto asTableTick = [&](double norm) {
+            const int idx = juce::jlimit(
+                0, static_cast<int>(paramInfo.valueTable.size()) - 1,
+                static_cast<int>(std::round(norm * (paramInfo.valueTable.size() - 1))));
+            return std::pair{norm, paramInfo.valueTable[static_cast<size_t>(idx)].trim()};
+        };
+        gridValues = kQuarterNorms | std::views::transform(asTableTick) |
+                     toStd<std::vector<AutomationGridTick>>();
+    } else {
+        const auto asPercentTick = [](int step) {
+            return std::pair{step / 10.0, juce::String(step * 10) + "%"};
+        };
+        gridValues = std::views::iota(1, 10) | std::views::transform(asPercentTick) |
+                     toStd<std::vector<AutomationGridTick>>();
+    }
+
+    return gridValues;
+}
+
+std::vector<AutomationGridTick> thinAutomationGridTicks(std::vector<AutomationGridTick> ticks,
+                                                        int maxLabels) {
+    if (maxLabels >= static_cast<int>(ticks.size()))
+        return ticks;
+    if (maxLabels == 1)
+        return {ticks[ticks.size() / 2]};
+
+    const auto srcMax = static_cast<double>(ticks.size() - 1);
+    const auto sampleAt = [&](int i) {
+        const auto srcIdx =
+            static_cast<size_t>(std::round(static_cast<double>(i) * srcMax / (maxLabels - 1)));
+        return ticks[srcIdx];
+    };
+
+    return std::views::iota(0, maxLabels) | std::views::transform(sampleAt) |
+           toStd<std::vector<AutomationGridTick>>();
+}
+
 void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane, int laneTopY,
                                int width, int laneHeight, int topInset) {
     const int y = laneTopY + topInset;
@@ -408,123 +548,7 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
         constexpr float tickLen = 5.0f;
 
         if (contentHeight > 20) {
-            auto paramInfo = getParameterInfoForTarget(lane.target);
-
-            // Build grid values: pairs of (normalized, label)
-            std::vector<std::pair<double, juce::String>> gridValues;
-            if (paramInfo.scale == ParameterScale::FaderDB) {
-                const std::pair<double, const char*> dbValues[] = {
-                    {6.0, "6"},     {3.0, "3"},     {0.0, "0"},     {-6.0, "-6"},  {-12.0, "-12"},
-                    {-18.0, "-18"}, {-24.0, "-24"}, {-36.0, "-36"}, {-48.0, "-48"}};
-                for (const auto& [db, label] : dbValues) {
-                    float norm =
-                        ParameterUtils::realToNormalized(static_cast<float>(db), paramInfo);
-                    gridValues.emplace_back(static_cast<double>(norm), label);
-                }
-            } else if (lane.target.kind == ControlTarget::Kind::TrackPan) {
-                gridValues.emplace_back(
-                    static_cast<double>(ParameterUtils::realToNormalized(1.0f, paramInfo)), "R");
-                gridValues.emplace_back(
-                    static_cast<double>(ParameterUtils::realToNormalized(0.5f, paramInfo)), "50R");
-                gridValues.emplace_back(
-                    static_cast<double>(ParameterUtils::realToNormalized(0.0f, paramInfo)), "C");
-                gridValues.emplace_back(
-                    static_cast<double>(ParameterUtils::realToNormalized(-0.5f, paramInfo)), "50L");
-                gridValues.emplace_back(
-                    static_cast<double>(ParameterUtils::realToNormalized(-1.0f, paramInfo)), "L");
-            } else if (paramInfo.scale == ParameterScale::Boolean) {
-                // A switch has exactly two meaningful positions. Without
-                // this it falls through to the 10% grid at the bottom of
-                // the chain and reads as a continuous percentage.
-                gridValues.emplace_back(1.0, "On");
-                gridValues.emplace_back(0.0, "Off");
-            } else if (paramInfo.isBipolar()) {
-                // Bipolar params (EQ gain, pitch, etc): symmetric labels
-                // around zero so the 0 line lands mid-lane. Use the larger
-                // |bound| so extremes land on both ends regardless of
-                // asymmetry.
-                float absMax = std::max(std::abs(paramInfo.minValue), std::abs(paramInfo.maxValue));
-                const double realTicks[] = {absMax, absMax * 0.5, 0.0, -absMax * 0.5, -absMax};
-                for (double real : realTicks) {
-                    float norm =
-                        ParameterUtils::realToNormalized(static_cast<float>(real), paramInfo);
-                    juce::String label;
-                    int rounded = static_cast<int>(std::round(real));
-                    if (rounded > 0)
-                        label = "+" + juce::String(rounded);
-                    else
-                        label = juce::String(rounded);
-                    label += paramInfo.unit;
-                    gridValues.emplace_back(static_cast<double>(norm), label);
-                }
-            } else if (paramInfo.scale == ParameterScale::Discrete && !paramInfo.choices.empty()) {
-                // Discrete: use the choices array as label source. Each
-                // index maps to a real value (0..N-1) — sample evenly so
-                // the lane shows musical labels (e.g. "1 Bar", "1/4",
-                // "1/8") instead of falling through to the 10% fallback.
-                // If the parameter curated a sparse labelTicks set (e.g.
-                // sync division skipping the triplet/dotted entries that
-                // snap on playback), use it directly so the thinner can't
-                // re-introduce the labels we deliberately excluded.
-                if (!paramInfo.labelTicks.empty()) {
-                    for (const auto& [realValue, label] : paramInfo.labelTicks) {
-                        float norm = ParameterUtils::realToNormalized(realValue, paramInfo);
-                        gridValues.emplace_back(static_cast<double>(norm), label);
-                    }
-                } else {
-                    int numChoices = static_cast<int>(paramInfo.choices.size());
-                    for (int i = 0; i < numChoices; ++i) {
-                        float norm =
-                            ParameterUtils::realToNormalized(static_cast<float>(i), paramInfo);
-                        gridValues.emplace_back(static_cast<double>(norm),
-                                                paramInfo.choices[static_cast<size_t>(i)]);
-                    }
-                }
-            } else if (paramInfo.unit.isNotEmpty()) {
-                // Unipolar with unit: evenly spaced in normalized space,
-                // labelled with the real value in the parameter's own unit.
-                for (double norm : {0.0, 0.25, 0.5, 0.75, 1.0}) {
-                    float real =
-                        ParameterUtils::normalizedToReal(static_cast<float>(norm), paramInfo);
-                    juce::String label =
-                        juce::String(static_cast<int>(std::round(real))) + paramInfo.unit;
-                    gridValues.emplace_back(norm, label);
-                }
-            } else if (paramInfo.displayText) {
-                // displayText wraps TE's valueToString, which expects a
-                // plugin-native value — NOT normalized [0,1]. Sample the
-                // REAL value at each visual position so any scaleAnchor
-                // skew is honoured, then project from info-range onto the
-                // TE-native range so the provider sees what it expects.
-                const float teSpan = paramInfo.teMaxValue - paramInfo.teMinValue;
-                const float infoSpan = paramInfo.maxValue - paramInfo.minValue;
-                for (double norm : {0.0, 0.25, 0.5, 0.75, 1.0}) {
-                    float teRaw = NAN;
-                    if (infoSpan > 0.0f) {
-                        float real =
-                            ParameterUtils::normalizedToReal(static_cast<float>(norm), paramInfo);
-                        float normInInfo = (real - paramInfo.minValue) / infoSpan;
-                        teRaw = paramInfo.teMinValue + normInInfo * teSpan;
-                    } else {
-                        teRaw = paramInfo.teMinValue + static_cast<float>(norm) * teSpan;
-                    }
-                    auto text = paramInfo.displayText->format(teRaw);
-                    gridValues.emplace_back(
-                        norm, text.isNotEmpty() ? text
-                                                : juce::String(static_cast<int>(norm * 100)) + "%");
-                }
-            } else if (!paramInfo.valueTable.empty()) {
-                for (double norm : {0.0, 0.25, 0.5, 0.75, 1.0}) {
-                    int idx = juce::jlimit(
-                        0, static_cast<int>(paramInfo.valueTable.size()) - 1,
-                        static_cast<int>(std::round(norm * (paramInfo.valueTable.size() - 1))));
-                    gridValues.emplace_back(norm,
-                                            paramInfo.valueTable[static_cast<size_t>(idx)].trim());
-                }
-            } else {
-                for (int i = 1; i < 10; ++i)
-                    gridValues.emplace_back(i / 10.0, juce::String(i * 10) + "%");
-            }
+            const auto paramInfo = getParameterInfoForTarget(lane.target);
 
             g.setFont(FontManager::getInstance().getUIFont(8.0f));
             constexpr int labelH = 10;
@@ -533,22 +557,10 @@ void paintAutomationLaneHeader(juce::Graphics& g, const AutomationLaneInfo& lane
             // across the range (endpoints included whenever at least two labels
             // fit), while tall lanes show every sample.
             constexpr int labelSpacing = labelH + 6;
-            int maxLabels = juce::jmax(1, contentHeight / labelSpacing);
-            if (maxLabels < static_cast<int>(gridValues.size())) {
-                std::vector<std::pair<double, juce::String>> thinned;
-                thinned.reserve(static_cast<size_t>(maxLabels));
-                if (maxLabels == 1) {
-                    thinned.push_back(gridValues[gridValues.size() / 2]);
-                } else {
-                    const auto srcMax = static_cast<double>(gridValues.size() - 1);
-                    for (int i = 0; i < maxLabels; ++i) {
-                        int srcIdx = static_cast<int>(
-                            std::round(static_cast<double>(i) * srcMax / (maxLabels - 1)));
-                        thinned.push_back(gridValues[static_cast<size_t>(srcIdx)]);
-                    }
-                }
-                gridValues = std::move(thinned);
-            }
+            const int maxLabels = juce::jmax(1, contentHeight / labelSpacing);
+            const auto gridValues =
+                thinAutomationGridTicks(automationGridTicks(lane.target, paramInfo), maxLabels);
+
             for (const auto& [norm, label] : gridValues) {
                 int tickY = contentTop + static_cast<int>((1.0 - norm) * contentHeight);
                 // Tick

--- a/magda/daw/ui/components/automation/AutomationLaneHeader.hpp
+++ b/magda/daw/ui/components/automation/AutomationLaneHeader.hpp
@@ -3,6 +3,8 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "AutomationInfo.hpp"
 #include "TypeIds.hpp"
@@ -53,6 +55,27 @@ void syncAutoLaneHeaderButtonStates(AutoLaneHeaderButtons& buttons, const Automa
  */
 void layoutAutoLaneHeaderButtons(AutoLaneHeaderButtons& buttons, const AutomationLaneInfo& lane,
                                  int laneTopY, int headerWidth, int topInset = 0);
+
+/// One tick on a lane's value axis: where it sits in [0, 1], and what it reads.
+using AutomationGridTick = std::pair<double, juce::String>;
+
+/**
+ * @brief The ticks a lane's value axis shows, chosen by what the parameter is.
+ *
+ * @p target only decides the pan case, whose ticks are L/C/R rather than the
+ * numbers its range would give.
+ */
+std::vector<AutomationGridTick> automationGridTicks(const AutomationTarget& target,
+                                                    const ParameterInfo& paramInfo);
+
+/**
+ * @brief The ticks that fit when @p maxLabels is fewer than there are.
+ *
+ * Evenly spaced samples with both endpoints kept, or the middle tick alone
+ * when only one label fits. More slots than ticks changes nothing.
+ */
+std::vector<AutomationGridTick> thinAutomationGridTicks(std::vector<AutomationGridTick> ticks,
+                                                        int maxLabels);
 
 /**
  * @brief Paint a single automation lane header: background, parameter name, and

--- a/magda/daw/ui/components/automation/MasterAutomationLanes.cpp
+++ b/magda/daw/ui/components/automation/MasterAutomationLanes.cpp
@@ -2,10 +2,14 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
+#include <iterator>
 #include <memory>
+#include <ranges>
 
 #include "AutomationLaneComponent.hpp"
 #include "core/AutomationInfo.hpp"
+#include "core/RangesHelpers.hpp"
 
 namespace magda {
 
@@ -32,29 +36,30 @@ std::vector<AutomationLaneId> visibleMasterAutomationLanes() {
     // per-track lanes, so the toggle affects the master band too.
     if (!manager.isGlobalLaneVisibilityEnabled())
         return result;
+
+    const auto isVisible = [&manager](AutomationLaneId laneId) {
+        const auto* lane = manager.getLane(laneId);
+        return lane != nullptr && lane->visible;
+    };
+
     // Edit-scoped lanes (Tempo) are project-global concerns and live at the top
     // of the master band rather than in a separate pinned block.
-    for (auto laneId : manager.getEditScopedLanes()) {
-        const auto* lane = manager.getLane(laneId);
-        if (lane && lane->visible)
-            result.push_back(laneId);
-    }
-    for (auto laneId : manager.getLanesForTrack(MASTER_TRACK_ID)) {
-        const auto* lane = manager.getLane(laneId);
-        if (lane && lane->visible)
-            result.push_back(laneId);
-    }
+    const auto editScoped = manager.getEditScopedLanes();
+    const auto onMaster = manager.getLanesForTrack(MASTER_TRACK_ID);
+    std::ranges::copy(editScoped | std::views::filter(isVisible), std::back_inserter(result));
+    std::ranges::copy(onMaster | std::views::filter(isVisible), std::back_inserter(result));
     return result;
 }
 
 int masterAutomationBandHeight(double verticalZoom) {
     auto& manager = AutomationManager::getInstance();
-    int total = 0;
-    for (auto laneId : visibleMasterAutomationLanes()) {
-        if (const auto* lane = manager.getLane(laneId))
-            total += laneHeightPx(*lane, verticalZoom);
-    }
-    return total;
+    const auto heightOf = [&manager, verticalZoom](AutomationLaneId laneId) {
+        const auto* lane = manager.getLane(laneId);
+        return lane == nullptr ? 0 : laneHeightPx(*lane, verticalZoom);
+    };
+
+    return std::ranges::fold_left(visibleMasterAutomationLanes() | std::views::transform(heightOf),
+                                  0, std::plus{});
 }
 
 // ============================================================================

--- a/magda/daw/ui/components/chain/ChainPanel.cpp
+++ b/magda/daw/ui/components/chain/ChainPanel.cpp
@@ -1,7 +1,9 @@
 #include "ChainPanel.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <iterator>
+#include <ranges>
 
 #include "ChainNodePathDrag.hpp"
 #include "DeviceSlotComponent.hpp"
@@ -14,6 +16,7 @@
 #include "core/GestureRouter.hpp"
 #include "core/MacroInfo.hpp"
 #include "core/ModInfo.hpp"
+#include "core/RangesHelpers.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackCommands.hpp"
 #include "core/UndoManager.hpp"
@@ -405,16 +408,9 @@ void ChainPanel::resizedContent(juce::Rectangle<int> contentArea) {
 }
 
 int ChainPanel::calculateTotalContentWidth() const {
-    // Add left padding during drag/drop to show insertion indicator before first element
-    bool isDraggingOrDropping = dragOriginalIndex_ >= 0 || dropInsertIndex_ >= 0;
-    int totalWidth = isDraggingOrDropping ? DRAG_LEFT_PADDING : 0;
-
-    int scaledArrowWidth = getScaledWidth(ARROW_WIDTH);
-    for (const auto& slot : elementSlots_) {
-        totalWidth += getScaledWidth(slot->getPreferredWidth()) + scaledArrowWidth;
-    }
-    totalWidth += getScaledWidth(APPEND_ZONE_WIDTH);
-    return totalWidth;
+    // The append zone sits past the last slot, where calculateAppendZoneX()
+    // already ends.
+    return calculateAppendZoneX() + getScaledWidth(APPEND_ZONE_WIDTH);
 }
 
 int ChainPanel::getContentWidth() const {
@@ -908,15 +904,16 @@ int ChainPanel::calculateIndicatorX(int index) const {
 }
 
 int ChainPanel::calculateAppendZoneX() const {
-    bool isDraggingOrDropping = dragOriginalIndex_ >= 0 || dropInsertIndex_ >= 0;
-    int x = isDraggingOrDropping ? DRAG_LEFT_PADDING : 0;
-    int scaledArrowWidth = getScaledWidth(ARROW_WIDTH);
+    // Drag/drop adds left padding, so the insertion indicator has room before
+    // the first element.
+    const bool isDraggingOrDropping = dragOriginalIndex_ >= 0 || dropInsertIndex_ >= 0;
+    const int scaledArrowWidth = getScaledWidth(ARROW_WIDTH);
+    const auto slotAndArrowWidth = [this, scaledArrowWidth](const auto& slot) {
+        return getScaledWidth(slot->getPreferredWidth()) + scaledArrowWidth;
+    };
 
-    for (const auto& slot : elementSlots_) {
-        x += getScaledWidth(slot->getPreferredWidth()) + scaledArrowWidth;
-    }
-
-    return x;
+    return std::ranges::fold_left(elementSlots_ | std::views::transform(slotAndArrowWidth),
+                                  isDraggingOrDropping ? DRAG_LEFT_PADDING : 0, std::plus{});
 }
 
 void ChainPanel::timerCallback() {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -1327,15 +1327,8 @@ std::vector<std::pair<magda::DeviceId, juce::String>> DeviceSlotComponent::getAv
 
 std::map<magda::DeviceId, std::vector<juce::String>> DeviceSlotComponent::getDeviceParamNames()
     const {
-    std::vector<juce::String> names;
-    for (const auto& param : device_.parameters) {
-        if (param.paramIndex < 0)
-            continue;
-        if (param.paramIndex >= static_cast<int>(names.size()))
-            names.resize(static_cast<size_t>(param.paramIndex) + 1);
-        names[static_cast<size_t>(param.paramIndex)] = param.name;
-    }
-    std::map<magda::DeviceId, std::vector<juce::String>> result = {{device_.id, std::move(names)}};
+    std::map<magda::DeviceId, std::vector<juce::String>> result = {
+        {device_.id, device_.paramNamesByIndex()}};
     drum_grid_slot::appendDeviceParamNames(customUI_.getDrumGridUI(), result);
     return result;
 }

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -2,6 +2,7 @@
 
 #include <BinaryData.h>
 
+#include <ranges>
 #include <utility>
 
 #include "../../utils/SelectionPolicy.hpp"
@@ -10,6 +11,7 @@
 #include "core/AutomationInfo.hpp"
 #include "core/GestureRouter.hpp"
 #include "core/LinkModeManager.hpp"
+#include "core/RangesHelpers.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackManager.hpp"
 #include "core/controllers/ControllerActivation.hpp"
@@ -24,6 +26,26 @@
 namespace magda::daw::ui {
 
 namespace {
+/// The raw pointers a fade timer takes, out of a container that owns them.
+std::vector<juce::Component*> fadeTargets(const auto& owned) {
+    const auto rawPointer = [](const auto& item) -> juce::Component* { return item.get(); };
+    return owned | std::views::transform(rawPointer) | toStd<std::vector<juce::Component*>>();
+}
+
+/// The modifiers a link picker can offer: the enabled ones, by id and name.
+std::vector<std::pair<magda::ModId, juce::String>> enabledModifiers(const magda::ModArray* mods) {
+    if (mods == nullptr)
+        return {};
+
+    const auto isEnabled = [](const magda::ModInfo& mod) { return mod.enabled; };
+    const auto asEntry = [](const magda::ModInfo& mod) {
+        return std::pair{mod.id, magda::getModDisplayName(mod)};
+    };
+
+    return *mods | std::views::filter(isEnabled) | std::views::transform(asEntry) |
+           toStd<std::vector<std::pair<magda::ModId, juce::String>>>();
+}
+
 juce::Image createChainNodeDragImage(const juce::String& label, int itemCount) {
     constexpr int width = 188;
     constexpr int height = 42;
@@ -1802,14 +1824,7 @@ void NodeComponent::updateModsPanel() {
     // Same-scope modifiers — each knob's "Link to Modulator" submenu
     // can target another mod's rate. Skip the knob's own ModId is done
     // inside the knob (it knows its own currentMod_.id).
-    std::vector<std::pair<magda::ModId, juce::String>> modList;
-    if (mods) {
-        modList.reserve(mods->size());
-        for (const auto& m : *mods)
-            if (m.enabled)
-                modList.emplace_back(m.id, magda::getModDisplayName(m));
-    }
-    modsPanel_->setAvailableModifiers(modList);
+    modsPanel_->setAvailableModifiers(enabledModifiers(mods));
 }
 
 void NodeComponent::updateMacroValueDisplay(int macroIndex, float value) {
@@ -1831,11 +1846,7 @@ void NodeComponent::fadeInParamPanelContent() {
         return;
     }
 
-    std::vector<juce::Component*> targets;
-    targets.reserve(paramKnobs_.size());
-    for (auto& knob : paramKnobs_)
-        targets.push_back(knob.get());
-    paramPanelFadeTimer_->fadeIn(targets, SIDE_PANEL_FADE_IN_MS, repaintPanel);
+    paramPanelFadeTimer_->fadeIn(fadeTargets(paramKnobs_), SIDE_PANEL_FADE_IN_MS, repaintPanel);
 }
 
 void NodeComponent::cancelParamPanelContentFade() {
@@ -1843,14 +1854,8 @@ void NodeComponent::cancelParamPanelContentFade() {
 }
 
 void NodeComponent::fadeOutParamPanelContent() {
-    std::vector<juce::Component*> targets;
-    if (macroPanel_) {
-        targets.push_back(macroPanel_.get());
-    } else {
-        targets.reserve(paramKnobs_.size());
-        for (auto& knob : paramKnobs_)
-            targets.push_back(knob.get());
-    }
+    const auto targets =
+        macroPanel_ ? std::vector<juce::Component*>{macroPanel_.get()} : fadeTargets(paramKnobs_);
 
     auto safeThis = juce::Component::SafePointer<NodeComponent>(this);
     paramPanelFadeTimer_->fadeOut(
@@ -1887,11 +1892,7 @@ void NodeComponent::fadeInModPanelContent() {
         return;
     }
 
-    std::vector<juce::Component*> targets;
-    targets.reserve(3);
-    for (auto& button : modSlotButtons_)
-        targets.push_back(button.get());
-    modPanelFadeTimer_->fadeIn(targets, SIDE_PANEL_FADE_IN_MS, repaintPanel);
+    modPanelFadeTimer_->fadeIn(fadeTargets(modSlotButtons_), SIDE_PANEL_FADE_IN_MS, repaintPanel);
 }
 
 void NodeComponent::cancelModPanelContentFade() {
@@ -1899,14 +1900,8 @@ void NodeComponent::cancelModPanelContentFade() {
 }
 
 void NodeComponent::fadeOutModPanelContent() {
-    std::vector<juce::Component*> targets;
-    if (modsPanel_) {
-        targets.push_back(modsPanel_.get());
-    } else {
-        targets.reserve(3);
-        for (auto& button : modSlotButtons_)
-            targets.push_back(button.get());
-    }
+    const auto targets =
+        modsPanel_ ? std::vector<juce::Component*>{modsPanel_.get()} : fadeTargets(modSlotButtons_);
 
     auto safeThis = juce::Component::SafePointer<NodeComponent>(this);
     modPanelFadeTimer_->fadeOut(
@@ -1955,14 +1950,7 @@ void NodeComponent::updateMacroPanel() {
 
     // Same-scope modifiers — let the macro link picker offer "Modulators →
     // <mod> → Rate" entries that resolve to the LFO's rate / rateType param.
-    std::vector<std::pair<magda::ModId, juce::String>> mods;
-    if (const auto* modsData = getModsData()) {
-        mods.reserve(modsData->size());
-        for (const auto& m : *modsData)
-            if (m.enabled)
-                mods.emplace_back(m.id, magda::getModDisplayName(m));
-    }
-    macroPanel_->setAvailableModifiers(mods);
+    macroPanel_->setAvailableModifiers(enabledModifiers(getModsData()));
 }
 
 // === Modulator Editor Panel ===

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -2,11 +2,16 @@
 
 #include <BinaryData.h>
 
+#include <algorithm>
+#include <functional>
+#include <ranges>
+
 #include "ChainPanel.hpp"
 #include "ChainRowComponent.hpp"
 #include "audio/AudioBridge.hpp"
 #include "core/Config.hpp"
 #include "core/PresetManager.hpp"
+#include "core/RangesHelpers.hpp"
 #include "core/TrackCommands.hpp"
 #include "engine/AudioEngine.hpp"
 #include "layout/NodeHeaderStyles.hpp"
@@ -363,11 +368,7 @@ void RackComponent::resizedContent(juce::Rectangle<int> contentArea) {
     chainViewport_.setBounds(contentArea);
 
     // Calculate total height for chain rows container
-    int totalHeight = 0;
-    for (const auto& row : chainRows_) {
-        totalHeight += row->getPreferredHeight() + 2;
-    }
-    totalHeight = juce::jmax(totalHeight, contentArea.getHeight());
+    const int totalHeight = juce::jmax(stackedChainRowsHeight(), contentArea.getHeight());
 
     // Set container size and layout rows inside it
     chainRowsContainer_.setSize(
@@ -423,11 +424,15 @@ void RackComponent::resizedCollapsed(juce::Rectangle<int>& area) {
     deltaButton_->setVisible(true);
 }
 
+int RackComponent::stackedChainRowsHeight() const {
+    const auto rowAndGapHeight = [](const auto& row) { return row->getPreferredHeight() + 2; };
+
+    return std::ranges::fold_left(chainRows_ | std::views::transform(rowAndGapHeight), 0,
+                                  std::plus{});
+}
+
 int RackComponent::getPreferredHeight() const {
-    int height = HEADER_HEIGHT + CHAINS_LABEL_HEIGHT + 8;
-    for (const auto& row : chainRows_) {
-        height += row->getPreferredHeight() + 2;
-    }
+    const int height = HEADER_HEIGHT + CHAINS_LABEL_HEIGHT + 8 + stackedChainRowsHeight();
     return juce::jmax(height, HEADER_HEIGHT + CHAINS_LABEL_HEIGHT + MIN_CONTENT_HEIGHT);
 }
 
@@ -735,20 +740,14 @@ std::map<magda::DeviceId, std::vector<juce::String>> RackComponent::getDevicePar
     const auto* rack = magda::TrackManager::getInstance().getRackByPath(rackPath_);
     if (rack == nullptr)
         return result;
+    // One level, the same devices getAvailableDevices() offers: a nested rack's
+    // devices are picked from that rack's own component.
     for (const auto& chain : rack->chains) {
         for (const auto& element : chain.elements) {
             if (!magda::isDevice(element))
                 continue;
             const auto& device = magda::getDevice(element);
-            std::vector<juce::String> names;
-            for (const auto& param : device.parameters) {
-                if (param.paramIndex < 0)
-                    continue;
-                if (param.paramIndex >= static_cast<int>(names.size()))
-                    names.resize(static_cast<size_t>(param.paramIndex) + 1);
-                names[static_cast<size_t>(param.paramIndex)] = param.name;
-            }
-            result[device.id] = std::move(names);
+            result[device.id] = device.paramNamesByIndex();
         }
     }
     return result;

--- a/magda/daw/ui/components/chain/RackComponent.hpp
+++ b/magda/daw/ui/components/chain/RackComponent.hpp
@@ -89,6 +89,9 @@ class RackComponent : public NodeComponent, public juce::Timer {
     }
 
   private:
+    /// Every chain row stacked, each with the 2px gap that follows it.
+    int stackedChainRowsHeight() const;
+
     void initializeCommon(const magda::RackInfo& rack);
     void onAddChainClicked();
     void openMacroPanelForSelectionIfNeeded();

--- a/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
@@ -2,9 +2,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 
 #include "BinaryData.h"
 #include "audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
+#include "core/RangesHelpers.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
@@ -548,11 +550,9 @@ void PolySynthUI::updateFromParameters(const std::vector<magda::ParameterInfo>& 
 }
 
 std::vector<LinkableTextSlider*> PolySynthUI::getLinkableSliders() {
-    std::vector<LinkableTextSlider*> sliders;
-    sliders.reserve(kNumParams);
-    for (auto& c : controls_)
-        sliders.push_back(c.slider.get());
-    return sliders;
+    const auto sliderOf = [](const auto& control) { return control.slider.get(); };
+
+    return controls_ | std::views::transform(sliderOf) | toStd<std::vector<LinkableTextSlider*>>();
 }
 
 void PolySynthUI::layoutOscSection() {

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <ranges>
 
 #include "../../interaction/ClipDragTargets.hpp"
 #include "../../interaction/ClipNudge.hpp"
@@ -11,6 +12,7 @@
 #include "core/ClipCommands.hpp"
 #include "core/ClipPlacementPolicy.hpp"
 #include "core/GestureRouter.hpp"
+#include "core/RangesHelpers.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TempoUtils.hpp"
 #include "core/UndoManager.hpp"
@@ -579,14 +581,14 @@ namespace {
 // clips live in a scene grid, not on the timeline, and are left alone even
 // when a session view put them in the same selection.
 std::vector<ClipId> selectedArrangementClips() {
-    std::vector<ClipId> clips;
     auto& clipManager = ClipManager::getInstance();
-    for (ClipId clipId : SelectionManager::getInstance().getSelectedClips()) {
+    const auto isOnTimeline = [&clipManager](ClipId clipId) {
         const auto* clip = clipManager.getClip(clipId);
-        if (clip != nullptr && clip->view == ClipView::Arrangement)
-            clips.push_back(clipId);
-    }
-    return clips;
+        return clip != nullptr && clip->view == ClipView::Arrangement;
+    };
+
+    const auto& selected = SelectionManager::getInstance().getSelectedClips();
+    return selected | std::views::filter(isOnTimeline) | toStd<std::vector<ClipId>>();
 }
 
 // Frozen tracks are rendered to audio, so their clips must not move out from

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -727,6 +727,10 @@ target_sources(magda_juce_tests PRIVATE
     ui/test_timeline_extreme_zoom_paint_juce.cpp
     ui/test_repaint_invariance_juce.cpp
     ui/test_arrange_beat_native_juce.cpp
+    # The lane header's value axis: eight label sources picked by scale and
+    # target, and nothing else in either suite paints a lane header.
+    automation/test_automation_grid_ticks_juce.cpp
+    ../magda/daw/ui/components/automation/AutomationLaneHeader.cpp
     automation/test_tempo_map_juce.cpp
     automation/test_tempo_lane_bridge_juce.cpp
     automation/test_tempo_lane_sync_juce.cpp

--- a/tests/automation/test_automation_grid_ticks_juce.cpp
+++ b/tests/automation/test_automation_grid_ticks_juce.cpp
@@ -1,0 +1,178 @@
+// The value axis an automation lane header paints: which ticks a parameter
+// gets, and which of them survive a lane too short to label them all.
+//
+// The builder is a chain of eight cases picked by scale, target and which
+// label source the parameter carries, and nothing in either suite paints a
+// lane header, so a wrong branch would ship as silently wrong labels.
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <ranges>
+#include <vector>
+
+#include "magda/daw/core/RangesHelpers.hpp"
+#include "magda/daw/ui/components/automation/AutomationLaneHeader.hpp"
+
+namespace {
+
+using magda::AutomationGridTick;
+
+std::vector<juce::String> labelsOf(const std::vector<AutomationGridTick>& ticks) {
+    const auto labelOf = [](const AutomationGridTick& tick) { return tick.second; };
+    return ticks | std::views::transform(labelOf) | magda::toStd<std::vector<juce::String>>();
+}
+
+magda::ParameterInfo linearParam(float minValue, float maxValue, const juce::String& unit) {
+    magda::ParameterInfo param;
+    param.scale = magda::ParameterScale::Linear;
+    param.minValue = minValue;
+    param.maxValue = maxValue;
+    param.teMinValue = minValue;
+    param.teMaxValue = maxValue;
+    param.unit = unit;
+    return param;
+}
+
+magda::AutomationTarget targetOfKind(magda::ControlTarget::Kind kind) {
+    magda::AutomationTarget target;
+    target.kind = kind;
+    return target;
+}
+
+std::vector<AutomationGridTick> ticksFor(const magda::ParameterInfo& param) {
+    return magda::automationGridTicks(targetOfKind(magda::ControlTarget::Kind::PluginParam), param);
+}
+
+}  // namespace
+
+class AutomationGridTicksTest final : public juce::UnitTest {
+  public:
+    AutomationGridTicksTest() : juce::UnitTest("Automation Grid Ticks Tests", "magda") {}
+
+    void runTest() override {
+        beginTest("A pan lane is labelled L to R, whatever its range says");
+        {
+            const auto ticks = magda::automationGridTicks(
+                targetOfKind(magda::ControlTarget::Kind::TrackPan), linearParam(-1.0f, 1.0f, ""));
+
+            expect(labelsOf(ticks) == std::vector<juce::String>{"R", "50R", "C", "50L", "L"},
+                   "The pan lane reads top-down R, 50R, C, 50L, L");
+        }
+
+        beginTest("A switch gets two positions, not a percentage grid");
+        {
+            magda::ParameterInfo param;
+            param.scale = magda::ParameterScale::Boolean;
+            param.minValue = 0.0f;
+            param.maxValue = 1.0f;
+
+            const auto ticks = ticksFor(param);
+
+            expect(labelsOf(ticks) == std::vector<juce::String>{"On", "Off"});
+        }
+
+        beginTest("A fader is labelled in dB, loudest first");
+        {
+            magda::ParameterInfo param;
+            param.scale = magda::ParameterScale::FaderDB;
+            param.minValue = -60.0f;
+            param.maxValue = 6.0f;
+            param.teMinValue = -60.0f;
+            param.teMaxValue = 6.0f;
+
+            const auto ticks = ticksFor(param);
+
+            expectEquals(static_cast<int>(ticks.size()), 9);
+            expectEquals(ticks.front().second, juce::String("6"));
+            expectEquals(ticks.back().second, juce::String("-48"));
+        }
+
+        beginTest("A bipolar parameter signs its labels and carries its unit");
+        {
+            auto param = linearParam(-12.0f, 12.0f, "dB");
+
+            const auto ticks = ticksFor(param);
+
+            expect(labelsOf(ticks) ==
+                       std::vector<juce::String>{"+12dB", "+6dB", "0dB", "-6dB", "-12dB"},
+                   "Bipolar ticks run +max, +half, 0, -half, -max");
+            expectWithinAbsoluteError(ticks[2].first, 0.5, 1.0e-6);
+        }
+
+        beginTest("A discrete parameter uses its choices, one tick each");
+        {
+            magda::ParameterInfo param;
+            param.scale = magda::ParameterScale::Discrete;
+            param.choices = {"6 dB", "12 dB", "24 dB"};
+            param.minValue = 0.0f;
+            param.maxValue = 2.0f;
+            param.teMinValue = 0.0f;
+            param.teMaxValue = 2.0f;
+
+            const auto ticks = ticksFor(param);
+
+            expect(labelsOf(ticks) == std::vector<juce::String>{"6 dB", "12 dB", "24 dB"});
+        }
+
+        beginTest("Curated labelTicks win over the choices behind them");
+        {
+            magda::ParameterInfo param;
+            param.scale = magda::ParameterScale::Discrete;
+            param.choices = {"1/4", "1/4T", "1/8", "1/8T"};
+            param.labelTicks = {{0.0f, "1/4"}, {2.0f, "1/8"}};
+            param.minValue = 0.0f;
+            param.maxValue = 3.0f;
+            param.teMinValue = 0.0f;
+            param.teMaxValue = 3.0f;
+
+            const auto ticks = ticksFor(param);
+
+            expect(labelsOf(ticks) == std::vector<juce::String>{"1/4", "1/8"},
+                   "The triplet entries the parameter left out must stay out");
+        }
+
+        beginTest("A unipolar parameter with a unit is labelled in that unit");
+        {
+            const auto ticks = ticksFor(linearParam(0.0f, 100.0f, "%"));
+
+            expect(labelsOf(ticks) == std::vector<juce::String>{"0%", "25%", "50%", "75%", "100%"});
+        }
+
+        beginTest("A parameter with nothing to label falls back to percentages");
+        {
+            const auto ticks = ticksFor(linearParam(0.0f, 1.0f, ""));
+
+            expectEquals(static_cast<int>(ticks.size()), 9);
+            expectEquals(ticks.front().second, juce::String("10%"));
+            expectEquals(ticks.back().second, juce::String("90%"));
+        }
+
+        beginTest("A lane with room for every label keeps them all");
+        {
+            const auto ticks = ticksFor(linearParam(0.0f, 100.0f, "%"));
+
+            expect(magda::thinAutomationGridTicks(ticks, 5) == ticks);
+            expect(magda::thinAutomationGridTicks(ticks, 99) == ticks);
+        }
+
+        beginTest("Thinning keeps both endpoints and spaces the rest");
+        {
+            const auto ticks = ticksFor(linearParam(0.0f, 100.0f, "%"));
+
+            const auto thinned = magda::thinAutomationGridTicks(ticks, 3);
+
+            expect(labelsOf(thinned) == std::vector<juce::String>{"0%", "50%", "100%"});
+        }
+
+        beginTest("One slot shows the middle label, not an edge");
+        {
+            const auto ticks = ticksFor(linearParam(0.0f, 100.0f, "%"));
+
+            const auto thinned = magda::thinAutomationGridTicks(ticks, 1);
+
+            expect(labelsOf(thinned) == std::vector<juce::String>{"50%"});
+        }
+    }
+};
+
+static AutomationGridTicksTest automationGridTicksTest;


### PR DESCRIPTION
Closes #2149. The `daw/ui` half of the sweep, after #2562 did core and audio.

## The lane header's value axis

The grid builder comes out of `paintAutomationLaneHeader()` as two free
functions, `automationGridTicks()` and `thinAutomationGridTicks()`, with 11
tests behind them in the JUCE suite. It is a chain of eight label sources
picked by scale, target and what the parameter carries, and nothing in either
suite painted a lane header, so a wrong branch would have shipped as silently
wrong labels rather than a red test.

The issue asked for one builder shared with `AutomationCurveEditor`. Having
read both: they are not the same grid, and merging them would change what is
drawn.

| | header | curve editor |
|---|---|---|
| dB ticks | down to -48 | down to -60 |
| pan | 5 ticks, `L`/`50L`/`C`/`50R`/`R` | 9 ticks at 0.25 steps |
| bipolar | +max first | -max first |
| labels | yes | none, it draws lines |

Each is a pipeline in place instead.

## Dedupes

- the fade-timer target list, 4 copies in `NodeComponent` -> `fadeTargets()`
- the enabled-modifier picker entries, 2 copies -> `enabledModifiers()`
- the slot width sum behind `ChainPanel`'s total width and its append-zone x
- the chain-row height sum behind `RackComponent`'s layout and preferred height
- the name-by-TE-slot scatter, 2 byte-identical copies in `RackComponent` and
  `DeviceSlotComponent` -> `DeviceInfo::paramNamesByIndex()`

That last one stays a loop rather than becoming a pipeline: `paramIndex` is a
TE slot, not an array position, so it is a sparse scatter into index positions.
Its outer walk stays one level deep too, rather than going through
`chain_walk::forEachDevice`, which recurses: `getAvailableDevices()` directly
above it walks one level, and a name map wider than the picker would be a
silent mismatch.

## Verification

- `make debug` clean
- Catch2: 3880 passed, 13 skipped, 0 failed
- `magda_juce_tests`: all passed, including the 11 new grid-tick cases

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi