### PR TITLE
Move the block reductions onto FloatVectorOperations

### DIFF
--- a/magda/daw/audio/BlockMath.hpp
+++ b/magda/daw/audio/BlockMath.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+namespace magda {
+
+/** @brief Highest absolute sample in a block (#2151).
+ *
+ *  The scalar `peak = max(peak, fabs(x))` form does not vectorise: reassociating
+ *  a float reduction needs -ffast-math, which the release build does not set.
+ *  juce::AudioBuffer::getMagnitude() is this for a buffer; this is the same
+ *  reduction for a bare pointer, which is what a sidechain port and the follower
+ *  scratch are.
+ */
+inline float peakMagnitude(const float* samples, int numSamples) noexcept {
+    if (samples == nullptr || numSamples <= 0)
+        return 0.0f;
+
+    const auto range = juce::FloatVectorOperations::findMinAndMax(samples, numSamples);
+    return juce::jmax(range.getStart(), -range.getStart(), range.getEnd(), -range.getEnd());
+}
+
+}  // namespace magda

--- a/magda/daw/audio/BlockMath.hpp
+++ b/magda/daw/audio/BlockMath.hpp
@@ -2,22 +2,44 @@
 
 #include <juce_audio_basics/juce_audio_basics.h>
 
+#include <algorithm>
+#include <cmath>
+
 namespace magda {
 
-/** @brief Highest absolute sample in a block (#2151).
+/** @brief Highest absolute sample in a block, ignoring NaN (#2151).
  *
  *  The scalar `peak = max(peak, fabs(x))` form does not vectorise: reassociating
  *  a float reduction needs -ffast-math, which the release build does not set.
- *  juce::AudioBuffer::getMagnitude() is this for a buffer; this is the same
- *  reduction for a bare pointer, which is what a sidechain port and the follower
- *  scratch are.
+ *  It also ignores NaN, because the compare against it fails, while still
+ *  counting an infinity. Both are kept here.
+ *
+ *  findMinAndMax cannot be handed a NaN: its SIMD min/max differ by
+ *  architecture, and on the lane that met the NaN the running extreme is
+ *  dropped, so a real peak can go missing without the result being NaN at all.
+ *  The block is screened first, which is an integer reduction over a compare and
+ *  vectorises where the float one will not.
  */
 inline float peakMagnitude(const float* samples, int numSamples) noexcept {
     if (samples == nullptr || numSamples <= 0)
         return 0.0f;
 
-    const auto range = juce::FloatVectorOperations::findMinAndMax(samples, numSamples);
-    return juce::jmax(range.getStart(), -range.getStart(), range.getEnd(), -range.getEnd());
+    int nanCount = 0;
+    for (int i = 0; i < numSamples; ++i)
+        nanCount += static_cast<int>(samples[i] != samples[i]);
+
+    if (nanCount == 0) {
+        const auto range = juce::FloatVectorOperations::findMinAndMax(samples, numSamples);
+        return juce::jmax(range.getStart(), -range.getStart(), range.getEnd(), -range.getEnd());
+    }
+
+    // A NaN in the block is an upstream bug, so this path is not the one worth
+    // making fast: it is the loop this function replaces, which walks past a
+    // NaN and reports the loudest real sample around it.
+    float peak = 0.0f;
+    for (int i = 0; i < numSamples; ++i)
+        peak = std::max(peak, std::fabs(samples[i]));
+    return peak;
 }
 
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
@@ -9,6 +9,7 @@
 #include "../../core/TrackManager.hpp"
 #include "../../core/aliases/AutoAliasGenerator.hpp"
 #include "../../profiling/PerformanceProfiler.hpp"
+#include "../BlockMath.hpp"
 #include "../PluginWindowBridge.hpp"
 #include "../TrackController.hpp"
 #include "../TracktionHelpers.hpp"
@@ -511,9 +512,7 @@ void PluginManager::pushFollowerSourceBuffer(TrackId sourceTrackId, const float*
     // (so each can track a different part of the spectrum), then take the peak
     // and stream it to the follower's envelope DSP.
     const int n = std::min(numSamples, static_cast<int>(followerScratch_.size()));
-    float rawPeak = 0.0f;
-    for (int s = 0; s < n; ++s)
-        rawPeak = std::max(rawPeak, std::abs(mono[s]));
+    const float rawPeak = peakMagnitude(mono, n);
 
     static std::atomic<int> pushLogThrottle{0};
     const bool logThisBlock = (pushLogThrottle.fetch_add(1, std::memory_order_relaxed) % 100) == 0;
@@ -534,16 +533,15 @@ void PluginManager::pushFollowerSourceBuffer(TrackId sourceTrackId, const float*
 
         float peak = 0.0f;
         if (!slot.hpEnabled && !slot.lpEnabled) {
-            for (int s = 0; s < n; ++s)
-                peak = std::max(peak, std::abs(mono[s] * slot.gain));
+            // Scaling by a constant is monotone in magnitude, so the peak of
+            // the scaled block is the scaled peak: no second pass.
+            peak = rawPeak * std::abs(slot.gain);
         } else {
             float* work = followerScratch_.data();
-            if (slot.gain == 1.0f) {
+            if (slot.gain == 1.0f)
                 std::copy(mono, mono + n, work);
-            } else {
-                for (int s = 0; s < n; ++s)
-                    work[s] = mono[s] * slot.gain;
-            }
+            else
+                juce::FloatVectorOperations::copyWithMultiply(work, mono, slot.gain, n);
 
             if (slot.hpEnabled) {
                 if (slot.curHpFreq != slot.hpFreq) {
@@ -562,9 +560,7 @@ void PluginManager::pushFollowerSourceBuffer(TrackId sourceTrackId, const float*
                 slot.lp.process(work, n);
             }
 
-            peak = 0.0f;
-            for (int s = 0; s < n; ++s)
-                peak = std::max(peak, std::abs(work[s]));
+            peak = peakMagnitude(work, n);
         }
 
         const float outBefore = slot.mod->getCurrentValue();

--- a/magda/daw/audio/plugins/FollowerSourceTapPlugin.cpp
+++ b/magda/daw/audio/plugins/FollowerSourceTapPlugin.cpp
@@ -39,13 +39,15 @@ void FollowerSourceTapPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
     if (numChannels <= 0) {
         std::fill(mono, mono + numSamples, 0.0f);
     } else {
-        const float scale = 1.0f / static_cast<float>(numChannels);
-        for (int i = 0; i < numSamples; ++i) {
-            float sum = 0.0f;
-            for (int ch = 0; ch < numChannels; ++ch)
-                sum += fc.destBuffer->getSample(ch, fc.bufferStartSample + i);
-            mono[i] = sum * scale;
-        }
+        // Summed first and scaled once, which is the order the per-sample loop
+        // this replaced accumulated in.
+        juce::FloatVectorOperations::copy(
+            mono, fc.destBuffer->getReadPointer(0, fc.bufferStartSample), numSamples);
+        for (int ch = 1; ch < numChannels; ++ch)
+            juce::FloatVectorOperations::add(
+                mono, fc.destBuffer->getReadPointer(ch, fc.bufferStartSample), numSamples);
+        juce::FloatVectorOperations::multiply(mono, 1.0f / static_cast<float>(numChannels),
+                                              numSamples);
     }
 
     realtimeContext_->pushFollowerSourceBuffer(sourceTrackId_, mono, numSamples, sampleRate_);

--- a/magda/daw/audio/plugins/SidechainPlugin.cpp
+++ b/magda/daw/audio/plugins/SidechainPlugin.cpp
@@ -1,5 +1,6 @@
 #include "plugins/SidechainPlugin.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 namespace magda::daw::audio {
@@ -166,31 +167,51 @@ void SidechainPlugin::process(DeviceProcessContext& context) {
     const bool sidesOnly = juce::roundToInt(displayValue(kChannelModeParamIndex)) ==
                                static_cast<int>(ChannelMode::Sides) &&
                            numChannels >= 2;
+    // The gain is a serial recursion, so it stays a scalar loop; writing it out
+    // once lets each channel be walked contiguously below instead of strided,
+    // and takes the loop-invariant sidesOnly branch off the sample path. The
+    // chunk is a fixed stack buffer, so the ramp neither allocates here nor
+    // depends on prepare() having been told a block size.
+    static constexpr int kGainChunk = 256;
+    float gains[kGainChunk];
+
+    const int firstPlainChannel = sidesOnly ? 2 : 0;
     float gain = currentGain_;
-    for (int i = 0; i < numSamples; ++i) {
-        if (rampSamplesLeft_ > 0) {
-            rampValue_ += rampStep_;
-            --rampSamplesLeft_;
-            if (rampSamplesLeft_ == 0)
-                rampValue_ = lastTarget_;  // land exactly, no float drift
+
+    for (int done = 0; done < numSamples;) {
+        const int chunk = std::min(numSamples - done, kGainChunk);
+
+        for (int i = 0; i < chunk; ++i) {
+            if (rampSamplesLeft_ > 0) {
+                rampValue_ += rampStep_;
+                --rampSamplesLeft_;
+                if (rampSamplesLeft_ == 0)
+                    rampValue_ = lastTarget_;  // land exactly, no float drift
+            }
+            // Attack when ducking (gain falling), release when recovering.
+            const float coeff = rampValue_ < gain ? attackCoeff : releaseCoeff;
+            gain += coeff * (rampValue_ - gain);
+            gains[i] = gain;
         }
-        // Attack when ducking (gain falling), release when recovering.
-        const float coeff = rampValue_ < gain ? attackCoeff : releaseCoeff;
-        gain += coeff * (rampValue_ - gain);
+
+        const int chunkOffset = offset + done;
         if (sidesOnly) {
-            const float left = channels[0][offset + i];
-            const float right = channels[1][offset + i];
-            const float mid = 0.5f * (left + right);
-            const float side = 0.5f * (left - right) * gain;
-            channels[0][offset + i] = mid + side;
-            channels[1][offset + i] = mid - side;
-            for (int ch = 2; ch < numChannels; ++ch)
-                channels[ch][offset + i] *= gain;
-        } else {
-            for (int ch = 0; ch < numChannels; ++ch)
-                channels[ch][offset + i] *= gain;
+            float* left = channels[0] + chunkOffset;
+            float* right = channels[1] + chunkOffset;
+            for (int i = 0; i < chunk; ++i) {
+                const float mid = 0.5f * (left[i] + right[i]);
+                const float side = 0.5f * (left[i] - right[i]) * gains[i];
+                left[i] = mid + side;
+                right[i] = mid - side;
+            }
         }
+
+        for (int ch = firstPlainChannel; ch < numChannels; ++ch)
+            juce::FloatVectorOperations::multiply(channels[ch] + chunkOffset, gains, chunk);
+
+        done += chunk;
     }
+
     currentGain_ = gain;
 }
 

--- a/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
@@ -55,11 +55,9 @@ void MagdaClipperCompiledPlugin::beforeCompute(DeviceProcessContext& context, in
     const int channels = std::min(context.audio->getNumChannels(), engineInputCount(engineIndex));
 
     float peak = 0.0f;
-    for (int channel = 0; channel < channels; ++channel) {
-        const float* samples = context.audio->getReadPointer(channel, context.startSample);
-        for (int i = 0; i < context.numSamples; ++i)
-            peak = std::max(peak, std::fabs(samples[i]));
-    }
+    for (int channel = 0; channel < channels; ++channel)
+        peak = std::max(
+            peak, context.audio->getMagnitude(channel, context.startSample, context.numSamples));
 
     inputPeakDb_.store(20.0f * std::log10(std::max(peak, 1.0e-6f)), std::memory_order_relaxed);
 }

--- a/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "BlockMath.hpp"
 #include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
@@ -54,10 +55,14 @@ void MagdaClipperCompiledPlugin::beforeCompute(DeviceProcessContext& context, in
     // sees.
     const int channels = std::min(context.audio->getNumChannels(), engineInputCount(engineIndex));
 
+    // Not getMagnitude(): it reduces through findMinAndMax, so one NaN sample
+    // would be published into inputPeakDb_ and stay there through every later
+    // finite block, taking the curve's dot with it.
     float peak = 0.0f;
     for (int channel = 0; channel < channels; ++channel)
-        peak = std::max(
-            peak, context.audio->getMagnitude(channel, context.startSample, context.numSamples));
+        peak = std::max(peak,
+                        peakMagnitude(context.audio->getReadPointer(channel, context.startSample),
+                                      context.numSamples));
 
     inputPeakDb_.store(20.0f * std::log10(std::max(peak, 1.0e-6f)), std::memory_order_relaxed);
 }

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.cpp
@@ -388,10 +388,6 @@ void MagdaCompiledEffect::reset() {
     onReset();
 }
 
-float MagdaCompiledEffect::sanitise(float sample) {
-    return std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
-}
-
 void MagdaCompiledEffect::writeZones(DeviceProcessContext& context) {
     const float bpm =
         context.tempoMap != nullptr

--- a/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompiledEffect.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <juce_audio_basics/juce_audio_basics.h>
+
 #include <atomic>
+#include <cmath>
 #include <memory>
 #include <vector>
 
@@ -241,7 +244,13 @@ class MagdaCompiledEffect : public CompiledFaustDevice {
 
     /// Finite, and inside the same +/-16 ceiling every compiled device applies
     /// before handing a block back to the host.
-    static float sanitise(float sample);
+    ///
+    /// Defined here rather than in the .cpp: the build has no LTO, so out of
+    /// line this is one call per sample from every device that is not this one,
+    /// and the surrounding loop cannot vectorise across it.
+    static float sanitise(float sample) {
+        return std::isfinite(sample) ? juce::jlimit(-16.0f, 16.0f, sample) : 0.0f;
+    }
 
   private:
     /// What one dsp control declared about itself.

--- a/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "BlockMath.hpp"
 #include "core/ParameterInfo.hpp"
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
@@ -50,10 +51,7 @@ float gainReductionForLevel(float levelDb, float thresholdDb, float ratio, float
 
 /// Peak magnitude over @p numSamples of one channel.
 float peakOfChannel(const float* samples, int numSamples) {
-    float peak = 0.0f;
-    for (int i = 0; i < numSamples; ++i)
-        peak = std::max(peak, std::fabs(samples[i]));
-    return peak;
+    return peakMagnitude(samples, numSamples);
 }
 
 /// Peak magnitude over one channel range of @p buffer.

--- a/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
@@ -1,6 +1,7 @@
 #include "plugins/compiled/MagdaEqCompiledPlugin.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
 #include "core/ParameterInfo.hpp"
@@ -275,38 +276,39 @@ void MagdaEqCompiledPlugin::processAudio(DeviceProcessContext& context) {
     const float outputGain = std::pow(10.0f, slotDisplayValue(kOutputSlot) / 20.0f);
 
     std::fill_n(preTapScratch_.data(), numSamples, 0.0f);
-    for (int channel = 0; channel < hostChannels; ++channel) {
-        const float* source = context.audio->getReadPointer(channel, startSample);
-        for (int i = 0; i < numSamples; ++i)
-            preTapScratch_[static_cast<size_t>(i)] += source[i];
-    }
+    for (int channel = 0; channel < hostChannels; ++channel)
+        juce::FloatVectorOperations::add(
+            preTapScratch_.data(), context.audio->getReadPointer(channel, startSample), numSamples);
     const float channelInverse = 1.0f / static_cast<float>(hostChannels);
-    for (int i = 0; i < numSamples; ++i)
-        preTapScratch_[static_cast<size_t>(i)] *= channelInverse;
+    juce::FloatVectorOperations::multiply(preTapScratch_.data(), channelInverse, numSamples);
     preSpectrumTap_.write(preTapScratch_.data(), numSamples);
 
     // Heavy boosts at high Q can rarely produce non-finite samples during a
     // quick freq/Q sweep, so the output goes through the same sanitising pass
     // every compiled device applies.
+    // The enable flags hold for the whole block, so the bands that run are
+    // compacted once rather than tested numSamples x kBandCount times.
+    std::array<int, kBandCount> activeBands{};
+    int activeBandCount = 0;
+    for (int band = 0; band < kBandCount; ++band)
+        if (bandEnabled[static_cast<size_t>(band)])
+            activeBands[static_cast<size_t>(activeBandCount++)] = band;
+
     std::fill_n(postTapScratch_.data(), numSamples, 0.0f);
     for (int channel = 0; channel < hostChannels; ++channel) {
         float* out = context.audio->getWritePointer(channel, startSample);
         for (int i = 0; i < numSamples; ++i) {
             float sample = out[i];
-            for (int band = 0; band < kBandCount; ++band) {
-                if (!bandEnabled[static_cast<size_t>(band)])
-                    continue;
-                sample = processRbj(
-                    sample, coeffs[static_cast<size_t>(band)],
-                    biquadStates_[static_cast<size_t>(band)][static_cast<size_t>(channel)]);
+            for (int active = 0; active < activeBandCount; ++active) {
+                const auto band = static_cast<size_t>(activeBands[static_cast<size_t>(active)]);
+                sample = processRbj(sample, coeffs[band],
+                                    biquadStates_[band][static_cast<size_t>(channel)]);
             }
-            const float sanitized = sanitise(sample * outputGain);
-            out[i] = sanitized;
-            postTapScratch_[static_cast<size_t>(i)] += sanitized;
+            out[i] = sanitise(sample * outputGain);
         }
+        juce::FloatVectorOperations::add(postTapScratch_.data(), out, numSamples);
     }
-    for (int i = 0; i < numSamples; ++i)
-        postTapScratch_[static_cast<size_t>(i)] *= channelInverse;
+    juce::FloatVectorOperations::multiply(postTapScratch_.data(), channelInverse, numSamples);
     postSpectrumTap_.write(postTapScratch_.data(), numSamples);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,7 @@ set(TEST_SOURCES
     automation/test_automation_singleton.cpp
     agents/test_instruction_executor_context.cpp
     # Faust pool refactor (Phase 1: metadata parser)
+    dsp/test_block_math.cpp
     dsp/test_faust_metadata_parser.cpp
     dsp/test_faust_ui_harvester.cpp
     dsp/test_faust_device_layout.cpp

--- a/tests/dsp/test_block_math.cpp
+++ b/tests/dsp/test_block_math.cpp
@@ -1,0 +1,70 @@
+// peakMagnitude() replaces the scalar `peak = max(peak, fabs(x))` reduction in
+// the clipper, compressor and follower push (#2151). That form does not
+// vectorise, because reassociating a float reduction needs -ffast-math, which
+// the release build does not set. These pin the answer to the loop's.
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <vector>
+
+#include "magda/daw/audio/BlockMath.hpp"
+
+using magda::peakMagnitude;
+
+namespace {
+
+// The loop peakMagnitude() replaces, kept here as the oracle.
+float peakByLoop(const std::vector<float>& samples) {
+    float peak = 0.0f;
+    for (float sample : samples)
+        peak = std::max(peak, std::fabs(sample));
+    return peak;
+}
+
+float peakOf(const std::vector<float>& samples) {
+    return peakMagnitude(samples.data(), static_cast<int>(samples.size()));
+}
+
+}  // namespace
+
+TEST_CASE("peakMagnitude finds the loudest sample either side of zero", "[dsp][blockmath]") {
+    CHECK(peakOf({0.1f, -0.9f, 0.3f}) == 0.9f);
+    CHECK(peakOf({0.1f, 0.9f, -0.3f}) == 0.9f);
+}
+
+TEST_CASE("peakMagnitude agrees with the loop it replaces", "[dsp][blockmath]") {
+    // Lengths either side of a SIMD width, so the tail is covered too.
+    for (int length : {1, 3, 4, 5, 7, 8, 15, 16, 17, 63, 64, 65, 1023}) {
+        std::vector<float> samples;
+        samples.reserve(static_cast<size_t>(length));
+        for (int i = 0; i < length; ++i)
+            samples.push_back(std::sin(static_cast<float>(i) * 0.37f) *
+                              (i % 3 == 0 ? -1.4f : 0.6f));
+
+        INFO("length " << length);
+        CHECK(peakOf(samples) == peakByLoop(samples));
+    }
+}
+
+TEST_CASE("peakMagnitude of silence is zero, not a floor", "[dsp][blockmath]") {
+    CHECK(peakOf({0.0f, 0.0f, 0.0f, 0.0f}) == 0.0f);
+    CHECK(peakOf({-0.0f, 0.0f}) == 0.0f);
+}
+
+TEST_CASE("peakMagnitude of an empty or absent block is zero", "[dsp][blockmath]") {
+    CHECK(peakMagnitude(nullptr, 64) == 0.0f);
+
+    const std::vector<float> samples{0.5f};
+    CHECK(peakMagnitude(samples.data(), 0) == 0.0f);
+    CHECK(peakMagnitude(samples.data(), -1) == 0.0f);
+}
+
+TEST_CASE("peakMagnitude counts a lone spike in the tail", "[dsp][blockmath]") {
+    // A peak past the last whole vector is the case a hand-rolled SIMD
+    // reduction drops.
+    std::vector<float> samples(17, 0.01f);
+    samples.back() = -2.5f;
+
+    CHECK(peakOf(samples) == 2.5f);
+}

--- a/tests/dsp/test_block_math.cpp
+++ b/tests/dsp/test_block_math.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include "magda/daw/audio/BlockMath.hpp"
@@ -58,6 +59,58 @@ TEST_CASE("peakMagnitude of an empty or absent block is zero", "[dsp][blockmath]
     const std::vector<float> samples{0.5f};
     CHECK(peakMagnitude(samples.data(), 0) == 0.0f);
     CHECK(peakMagnitude(samples.data(), -1) == 0.0f);
+}
+
+TEST_CASE("peakMagnitude walks past a NaN to the real peak", "[dsp][blockmath]") {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+
+    // The peak BEFORE the NaN is the case a SIMD min/max drops: the lane that
+    // meets the NaN loses whatever it was carrying.
+    CHECK(peakOf({0.9f, nan, 0.1f}) == 0.9f);
+    CHECK(peakOf({-0.9f, 0.2f, nan, 0.1f}) == 0.9f);
+
+    // And after it, and on both sides of a vector boundary.
+    CHECK(peakOf({nan, 0.75f}) == 0.75f);
+
+    std::vector<float> block(64, 0.05f);
+    block[3] = 0.8f;
+    block[5] = nan;
+    CHECK(peakOf(block) == 0.8f);
+
+    block[40] = nan;
+    block[52] = 0.95f;
+    CHECK(peakOf(block) == 0.95f);
+}
+
+TEST_CASE("peakMagnitude ignores NaN but still counts an infinity", "[dsp][blockmath]") {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const float inf = std::numeric_limits<float>::infinity();
+
+    // The loop this replaces ignored NaN, because the compare against it fails,
+    // and let an infinity through. Both are load-bearing: a NaN that reached a
+    // meter would stick through every later finite block.
+    CHECK(peakOf({0.5f, nan}) == 0.5f);
+    CHECK(peakOf({nan, nan, nan}) == 0.0f);
+    CHECK(peakOf({0.5f, inf}) == inf);
+    CHECK(peakOf({0.5f, -inf}) == inf);
+    CHECK(peakOf({nan, inf, 0.5f}) == inf);
+}
+
+TEST_CASE("peakMagnitude agrees with the loop on blocks holding a NaN", "[dsp][blockmath]") {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+
+    for (int length : {2, 5, 8, 17, 64, 65}) {
+        for (int nanAt = 0; nanAt < length; ++nanAt) {
+            std::vector<float> samples;
+            samples.reserve(static_cast<size_t>(length));
+            for (int i = 0; i < length; ++i)
+                samples.push_back(std::sin(static_cast<float>(i) * 0.61f));
+            samples[static_cast<size_t>(nanAt)] = nan;
+
+            INFO("length " << length << ", NaN at " << nanAt);
+            CHECK(peakOf(samples) == peakByLoop(samples));
+        }
+    }
 }
 
 TEST_CASE("peakMagnitude counts a lone spike in the tail", "[dsp][blockmath]") {


### PR DESCRIPTION
Part of #2151. The scalar peak and downmix reductions in the audio path become
vector ops. `daw/audio` had no `juce::FloatVectorOperations` at all before this.

## peakMagnitude()

New, in `daw/audio/BlockMath.hpp`. Replaces the `peak = max(peak, fabs(x))`
loop in the clipper, the compressor and the three follower-push sites.

That form genuinely does not vectorise, because reassociating a float reduction
needs `-ffast-math` and the release build does not set it. At release `-O3` the
loop compiles to `ldr s1, [x0], #4` on arm64: one sample at a time. Covered in
`tests/dsp/test_block_math.cpp` against the loop it replaces, including a lone
spike in the tail past the last whole vector.

## The rest

- the gain-scaled follower peak is `rawPeak * |gain|` rather than a second pass,
  since scaling by a constant is monotone in magnitude
- the follower downmix reads channel pointers instead of `getSample()`, and sums
  before scaling so the arithmetic order matches the loop it replaces
- the EQ pre/post taps use `add` / `multiply`, and the per-band enable test is
  hoisted out of the sample loop into a compacted active-band list. It ran
  `numSamples x 8` times per block to answer a question constant for the block
- the sidechain gain is written to a fixed 256-sample stack chunk, so applying it
  is a vector multiply per channel rather than a strided store, and the
  loop-invariant `sidesOnly` branch leaves the sample path

Every one of these is bit-identical by construction, not by approximation.

## What this does not do, and why

The `sanitiseBlock()` rewrite the issue leads with. Two problems with it:

**The 20 copies are gone.** They were already collapsed into one
`MagdaCompiledEffect::sanitise()` since the audit was taken in August.

**The premise does not hold.** The issue says the per-sample `isfinite` ternary
is a branch libc++ will not fold into a vector compare. It folds it on both
shipping targets, at the release `-O3`:

| | arm64 | x86-64 SSE2 |
|---|---|---|
| clamp | `fminnm.4s` / `fmaxnm.4s` | `minps` / `maxps` |
| isfinite | `bic.4s` + `cmgt.4s` | `pand` + `pcmpgtd` |
| select | `and.16b` | `andps` |

Branchless, four lanes wide, one pass. `FloatVectorOperations::clip` would need a
second traversal for the NaN pass and would change behaviour: it maps an infinity
to +/-16, where the current form maps it to 0. The issue's own bar is
bit-identical output, which that would not meet.

## Verification

- `make debug` clean
- Catch2: 3887 passed, 13 skipped, 0 failed
- `magda_juce_tests`: all passed

One note on that last line. The first run of this branch hung: the sidechain gain
ramp was sized in `prepare()`, and in `Master sidechain ducks audio from a source
MIDI note` it had no block size, so the chunk length was 0 and `done += chunk`
never advanced. The fixed stack chunk in this PR removes the member, the
`prepare()` dependency and that failure mode together. The suite now runs to
completion.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi