### PR TITLE
Render the app's audio through magda::engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,20 @@ run-console: debug
 	@echo "🎵 Running MAGDA DAW (console mode)..."
 	"$(APP_BINARY_DEBUG)"
 
+# The native engine (#2551), until the choice becomes a setting (#2559). Console
+# mode, because that is where its diagnostics go.
+.PHONY: run-magda
+run-magda: debug
+	@echo "🎵 Running MAGDA DAW on magda::engine..."
+	MAGDA_AUDIO_ENGINE=magda "$(APP_BINARY_DEBUG)"
+
+# The same, with every note reaching a device and every publish printed in one
+# stream (#2568). For pinning down an edit-during-playback bug by ear.
+.PHONY: run-magda-trace
+run-magda-trace: debug
+	@echo "🎵 Running MAGDA DAW on magda::engine, MIDI trace on..."
+	MAGDA_AUDIO_ENGINE=magda MAGDA_ENGINE_TRACE_MIDI=1 "$(APP_BINARY_DEBUG)"
+
 .PHONY: cli
 cli:
 	@echo "🔨 Building magda-cli (Debug)..."
@@ -557,6 +571,8 @@ help:
 	@echo "Run targets:"
 	@echo "  run            - Build and run the application"
 	@echo "  run-console    - Run with console output visible"
+	@echo "  run-magda      - Run on the native engine (magda::engine)"
+	@echo "  run-magda-trace - Run on the native engine with the MIDI trace on"
 	@echo "  run-console-cpu - Run debug analyzer CPU baseline with console output"
 	@echo "  run-console-webgpu - Run debug Dawn/WebGPU analyzer POC with console output"
 	@echo "  run-console-cpu-log - Run CPU baseline and write app output to $(CPU_RUN_LOG)"

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -685,6 +685,11 @@ target_compile_definitions(magda_daw
     TRACKTION_ENABLE_TIMESTRETCH_SIGNALSMITH=1
     MAGDA_DAWPROJECT_SCHEMA_DIR="${CMAKE_SOURCE_DIR}/third_party/dawproject"
     $<$<BOOL:${JUCE_ASIO_ENABLED}>:JUCE_ASIO=1>
+    # Whether there is a second engine to choose at all (#2551). MagdaAudioEngine
+    # is compiled here whatever the answer, so it is the one place that has to
+    # ask: without the host below linked, choosing that engine is a link error
+    # rather than a quiet fallback.
+    $<$<BOOL:${MAGDA_BUILD_NATIVE_ENGINE}>:MAGDA_HAS_NATIVE_ENGINE=1>
     PRIVATE
     # Tracktion Engine carries a MAGDA test hook (magdaTestEvaluateLoopSessionDecision,
     # in tracktion_TransportControl.cpp) gated on MAGDA_ENABLE_TEST_HOOKS. TE now
@@ -713,6 +718,10 @@ target_link_libraries(magda_daw_app
     magda_agents
     magda_scripting
     MagdaAssets
+    # magda::engine and the app's end of it (#2551). Here rather than on
+    # magda_daw because magda_daw only names the host through a pimpl'd header:
+    # the engine's own includes never reach it.
+    $<$<BOOL:${MAGDA_BUILD_NATIVE_ENGINE}>:magda_engine_host>
     # JUCE/TE come transitively from magda_daw: its re-exported INTERFACE gives
     # the headers + defines to compile this target's own sources, and its
     # $<LINK_ONLY:...> forwards the modules' frameworks + the objects already in
@@ -827,6 +836,7 @@ target_include_directories(magda_plugin_scanner
 target_link_libraries(magda_cli
     PRIVATE
     magda_daw
+    $<$<BOOL:${MAGDA_BUILD_NATIVE_ENGINE}>:magda_engine_host>
     juce::juce_core
     juce::juce_events
     juce::juce_audio_devices

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "core/ChainWalk.hpp"
 #include "core/DeviceState.hpp"
 #include "core/PluginCapabilities.hpp"
 #include "plugin_manager/ExternalPluginLookup.hpp"
@@ -14,6 +15,53 @@
 namespace magda::daw::audio::engine_adapter {
 
 namespace {
+
+/// One descent, written once, over whichever constness the caller has.
+///
+/// A flat stage's elements are devices rather than a tree, so it is walked
+/// directly; flat does not mean padless, and a device carrying pads is
+/// descended into the same way a tree device is.
+template <typename Tracks, typename Master> auto collectDevices(Tracks& tracks, Master& master) {
+    using Device =
+        std::conditional_t<std::is_const_v<Master>, const magda::DeviceInfo, magda::DeviceInfo>;
+    std::map<magda::engine::DeviceKey, Device*> devices;
+
+    const auto collectTree = [&devices](auto& elements, const magda::ChainNodePath& parentPath,
+                                        magda::ChainSegment segment) {
+        magda::chain_walk::forEachDevice(
+            elements, parentPath, magda::chain_walk::Pads::Enter,
+            [&devices, segment](Device& device, const magda::ChainNodePath&) {
+                devices[magda::engine::DeviceKey{segment, device.id}] = &device;
+            });
+    };
+
+    const auto collectFlat = [&devices, &collectTree](auto& elements,
+                                                      const magda::ChainNodePath& parentPath,
+                                                      magda::ChainSegment segment) {
+        for (auto& element : elements) {
+            devices[magda::engine::DeviceKey{segment, element.device.id}] = &element.device;
+
+            if (!element.device.pads)
+                continue;
+
+            for (auto& pad : element.device.pads->chains)
+                collectTree(pad.elements, parentPath, segment);
+        }
+    };
+
+    const auto collectTrack = [&](auto& track) {
+        const auto path = magda::ChainNodePath::trackLevel(track.id);
+        collectTree(track.chain.fxChainElements, path, magda::ChainSegment::Fx);
+        collectFlat(track.chain.postFxChainElements, path, magda::ChainSegment::PostFx);
+        collectFlat(track.chain.mixerAnalysisElements, path, magda::ChainSegment::MixerAnalysis);
+    };
+
+    for (auto& track : tracks)
+        collectTrack(track);
+
+    collectTrack(master);
+    return devices;
+}
 
 /// The property a spec is looked up by, which is what a plugin state tree
 /// carries and what both catalogs match their ids and aliases against.
@@ -77,6 +125,16 @@ void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
 }
 
 }  // namespace
+
+std::map<magda::engine::DeviceKey, magda::DeviceInfo*> devicesIn(
+    std::vector<magda::TrackInfo>& tracks, magda::TrackInfo& master) {
+    return collectDevices(tracks, master);
+}
+
+std::map<magda::engine::DeviceKey, const magda::DeviceInfo*> devicesIn(
+    const std::vector<magda::TrackInfo>& tracks, const magda::TrackInfo& master) {
+    return collectDevices(tracks, master);
+}
 
 /// enableAllBuses first, at the same point the fork does it
 /// (completePluginInstanceCreation) and for the same reason: a plugin whose

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -3,10 +3,13 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include "core/DeviceInfo.hpp"
+#include "core/TrackInfo.hpp"
 #include "exec/EngineDevice.hpp"
 #include "exec/RenderContext.hpp"
 #include "plan/RenderPlan.hpp"
@@ -24,6 +27,34 @@
  */
 
 namespace magda::daw::audio::engine_adapter {
+
+/**
+ * @brief Every device a plan can emit an op for, by the key that op carries.
+ *
+ * Keyed by DeviceKey and not by DeviceId: an id is unique within a chain
+ * segment and not across them (#1899), so a map keyed by the number alone would
+ * let a post-FX device stand in for the FX device with the same one.
+ * OpKey::deviceKey() carries the segment for that reason; this has to match.
+ *
+ * The descent is the model's own (ChainWalk.hpp), entered with Pads::Enter. A
+ * Drum Grid's pads are chains of devices and PlanCompiler::emitPadRack() emits
+ * an op for each of them, so a walk that stopped at the grid would leave every
+ * plugin in every pad looked up and not found. The master's chain is walked
+ * with the rest, for the same reason: the compiler emits Device ops for it, and
+ * a caller that left it out would resolve a master limiter to nothing.
+ *
+ * One definition, shared by the corpus and the running app, because two walks
+ * of "every device in this project" drift the first time the model grows a
+ * container -- the failure #2204 is about, and one that shows up as a device
+ * silently standing in for itself.
+ */
+std::map<magda::engine::DeviceKey, magda::DeviceInfo*> devicesIn(
+    std::vector<magda::TrackInfo>& tracks, magda::TrackInfo& master);
+
+/// @overload For a caller that only reads the model, which is what a live
+/// publish does: resolution copies before it corrects.
+std::map<magda::engine::DeviceKey, const magda::DeviceInfo*> devicesIn(
+    const std::vector<magda::TrackInfo>& tracks, const magda::TrackInfo& master);
 
 /**
  * @brief The engine device @p device names, or null when nothing can make one.

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -235,6 +235,22 @@ class AudioEngine : public AudioEngineListener {
     virtual void setDevicesLoadingCallback(
         std::function<void(bool, const juce::String&)> callback) = 0;
 
+    // ===== Startup hooks =====
+    //
+    // What the application asks of an engine while it is coming up. On the
+    // interface rather than on one implementation's public fields, because the
+    // app owns the startup sequence and must not have to know which engine it
+    // was given -- naming a concrete type there is what made the choice
+    // unreachable from the running app (#2551).
+
+    /** Startup plugin-detection status, for the splash screen. */
+    virtual void setPluginScanStatusCallback(std::function<void(const juce::String&)> callback) = 0;
+
+    /** Fires the first time MIDI devices become available, and on subsequent
+        device-list changes. Work needing MIDI output ports open waits for this:
+        a SysEx send issued before JUCE opens the port is dropped. */
+    virtual void setMidiDevicesReadyCallback(std::function<void()> callback) = 0;
+
     // ===== Audio Management =====
     virtual AudioBridge* getAudioBridge() = 0;
     virtual const AudioBridge* getAudioBridge() const = 0;

--- a/magda/daw/engine/AudioEngineChoice.cpp
+++ b/magda/daw/engine/AudioEngineChoice.cpp
@@ -1,0 +1,28 @@
+#include "AudioEngineChoice.hpp"
+
+#include <juce_core/juce_core.h>
+
+#include <cstdlib>
+
+namespace magda {
+
+AudioEngineChoice chosenAudioEngine() {
+    if (const auto* value = std::getenv("MAGDA_AUDIO_ENGINE")) {
+        const auto asked = juce::String(value).trim().toLowerCase();
+        if (asked == "magda")
+            return AudioEngineChoice::Magda;
+        if (asked == "tracktion")
+            return AudioEngineChoice::Tracktion;
+    }
+
+    return AudioEngineChoice::Tracktion;
+}
+
+const char* nameOf(AudioEngineChoice choice) {
+    // Named by what each engine is rather than by which one is the newcomer:
+    // "native" only means anything while there is something for it to be
+    // native against, and after #2557 there will not be.
+    return choice == AudioEngineChoice::Magda ? "magda::engine" : "Tracktion";
+}
+
+}  // namespace magda

--- a/magda/daw/engine/AudioEngineChoice.hpp
+++ b/magda/daw/engine/AudioEngineChoice.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+/**
+ * @file AudioEngineChoice.hpp
+ * @brief Which engine renders, asked in one place (#2551).
+ *
+ * The answer has a short life: after #2557 there is one engine and this file
+ * goes. Until then it is asked from a handful of places, and where it comes
+ * from is going to change -- an environment variable today, a preference once
+ * there is one to read (#2559).
+ *
+ * So the source lives behind this function and nothing else knows it. Swapping
+ * the environment for a preference is a change to one body; every caller keeps
+ * asking the same question.
+ */
+
+namespace magda {
+
+enum class AudioEngineChoice { Tracktion, Magda };
+
+/**
+ * @brief What this run renders through.
+ *
+ * Read wherever an engine is built. Today it is MAGDA_AUDIO_ENGINE, taking
+ * "magda" or "tracktion"; anything else, including nothing, is the default.
+ *
+ * When a preference exists it is read here, with the environment kept as the
+ * override on top of it: a bug report asking "does it still happen on the
+ * other engine" is then answered by one run rather than by changing somebody's
+ * settings.
+ */
+AudioEngineChoice chosenAudioEngine();
+
+/// The choice as a word, for the one log line that says which engine ran.
+const char* nameOf(AudioEngineChoice choice);
+
+}  // namespace magda

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -50,9 +50,11 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         host/EngineHost.cpp
         host/EngineProject.cpp
         host/EngineRuntimeFactory.cpp
+        host/EngineTrace.cpp
         host/EngineHost.hpp
         host/EngineProject.hpp
         host/EngineRuntimeFactory.hpp
+        host/EngineTrace.hpp
     )
     add_library(magda::engine_host ALIAS magda_engine_host)
 

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(magda_daw PRIVATE
     TempoLaneSync.cpp
     TempoSequenceRippleCommand.cpp
     OfflineRenderHelper.cpp
+    AudioEngineChoice.cpp
     TracktionEngineWrapper.cpp
     TracktionEngineWrapperInit.cpp
     TracktionEngineWrapperDevices.cpp
@@ -24,6 +25,7 @@ target_sources(magda_daw PRIVATE
     PluginWindowManager.cpp
     # Headers (listed for IDE visibility)
     AudioEngine.hpp
+    AudioEngineChoice.hpp
     OfflineRenderHelper.hpp
     TracktionEngineWrapper.hpp
     MagdaUIBehaviour.hpp
@@ -89,3 +91,41 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
             $<TARGET_PROPERTY:${_juce_module},INTERFACE_COMPILE_DEFINITIONS>)
     endforeach()
 endif()
+
+# --- One construction site ----------------------------------------------------
+#
+# Which engine renders is decided in createDefaultAudioEngine, and that is worth
+# nothing if a caller can name an implementation instead. magda_daw_main.cpp did
+# exactly that, so #2558's seam and #2551's engine were both switchable
+# everywhere except in the running app, and the environment variable looked
+# wired while doing nothing.
+#
+# Checked at configure time rather than left to review, the way the native
+# engine's own dependency boundary is (magda/engine/CMakeLists.txt).
+#
+# The engine directory itself is exempt: the factory is here, and so is
+# MagdaAudioEngine, which holds a fork of its own by design. Tests are exempt
+# because a test that wants one engine specifically is asking a different
+# question from an application that must not care.
+file(GLOB_RECURSE MAGDA_ENGINE_CALLER_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/../*.cpp")
+
+foreach(_caller_source ${MAGDA_ENGINE_CALLER_SOURCES})
+    file(RELATIVE_PATH _caller_relative "${CMAKE_SOURCE_DIR}" "${_caller_source}")
+
+    if(_caller_relative MATCHES "^magda/daw/engine/")
+        continue()
+    endif()
+
+    file(STRINGS "${_caller_source}" _engine_construction
+        REGEX "(make_unique|make_shared)<[ \t]*(magda::)?(TracktionEngineWrapper|MagdaAudioEngine)")
+
+    if(_engine_construction)
+        message(FATAL_ERROR
+            "\n"
+            "Audio engine constructed directly in ${_caller_relative}:\n"
+            "    ${_engine_construction}\n"
+            "Which engine renders is createDefaultAudioEngine's to decide (#2551).\n"
+            "Naming an implementation here makes that choice unreachable.\n")
+    endif()
+endforeach()

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -7,7 +7,6 @@ target_sources(magda_daw PRIVATE
     TempoLaneSync.cpp
     TempoSequenceRippleCommand.cpp
     OfflineRenderHelper.cpp
-    MagdaAudioEngine.cpp
     TracktionEngineWrapper.cpp
     TracktionEngineWrapperInit.cpp
     TracktionEngineWrapperDevices.cpp
@@ -34,3 +33,57 @@ target_sources(magda_daw_app PRIVATE
     PlaybackPositionTimer.cpp
     PlaybackPositionTimer.hpp
 )
+
+# The app's end of magda::engine (#2551), and the first thing outside the test
+# binaries to link it. Its own target for the reason magda_engine_devices is
+# one: it names both the engine's headers and the app's, and magda_daw sees
+# neither of the engine's. MagdaAudioEngine reaches it through one pimpl'd
+# header, which is all that crosses that line.
+if(MAGDA_BUILD_NATIVE_ENGINE)
+    # MagdaAudioEngine is only a choice while there is a second engine to
+    # choose. Without one it would be a class whose whole reason to exist was
+    # not built, so it is compiled on the same switch rather than left as a
+    # shell that forwards everything.
+    target_sources(magda_daw PRIVATE MagdaAudioEngine.cpp MagdaAudioEngine.hpp)
+
+    add_library(magda_engine_host STATIC
+        host/EngineHost.cpp
+        host/EngineProject.cpp
+        host/EngineRuntimeFactory.cpp
+        host/EngineHost.hpp
+        host/EngineProject.hpp
+        host/EngineRuntimeFactory.hpp
+    )
+    add_library(magda::engine_host ALIAS magda_engine_host)
+
+    target_compile_features(magda_engine_host PRIVATE cxx_std_23)
+    target_include_directories(magda_engine_host PRIVATE
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/magda/daw
+        ${CMAKE_SOURCE_DIR}/magda/daw/audio
+    )
+
+    # magda_engine is added after magda/daw, so this names it before it exists.
+    # A plain target name resolves at generate time, which is what makes that
+    # legal -- the same arrangement magda_engine_devices has.
+    target_link_libraries(magda_engine_host
+        PUBLIC
+        magda_engine
+        magda_engine_devices
+    )
+
+    # JUCE headers and defines without the modules: the callback is a
+    # juce::AudioIODeviceCallback and the reader factory an
+    # AudioFormatManager, and both modules are already compiled once in
+    # magda_daw, so the symbols resolve at the final link.
+    foreach(_juce_module IN ITEMS
+            juce::juce_events
+            juce::juce_audio_devices
+            juce::juce_audio_formats
+            juce::juce_audio_processors)
+        target_include_directories(magda_engine_host PRIVATE
+            $<TARGET_PROPERTY:${_juce_module},INTERFACE_INCLUDE_DIRECTORIES>)
+        target_compile_definitions(magda_engine_host PRIVATE
+            $<TARGET_PROPERTY:${_juce_module},INTERFACE_COMPILE_DEFINITIONS>)
+    endforeach()
+endif()

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -1,6 +1,5 @@
 #include "MagdaAudioEngine.hpp"
 
-#include <cstdlib>
 #include <set>
 #include <string>
 
@@ -35,37 +34,12 @@ void MagdaAudioEngine::reportUnwired(const char* method, const char* issue) cons
 
 MagdaAudioEngine::~MagdaAudioEngine() = default;
 
-bool MagdaAudioEngine::requested(const AudioEngineOptions& options) {
-    juce::ignoreUnused(options);
-
-    // Named symmetrically, and by what each engine is rather than by which one
-    // is the newcomer: "native" only means anything while there is something
-    // for it to be native against, and after #2557 there will not be.
-    //
-    // The environment wins over the setting (#2559), so a bug report asking
-    // "does it still happen on the other engine" is answered by one run rather
-    // than by changing somebody's preferences.
-    if (const auto* value = std::getenv("MAGDA_AUDIO_ENGINE")) {
-        const auto choice = juce::String(value).trim().toLowerCase();
-        if (choice == "magda")
-            return true;
-        if (choice == "tracktion")
-            return false;
-    }
-
-    return false;
-}
-
 // --- what magda::engine answers ----------------------------------------------
 //
 // Transport and what is published with it. Everything below this section still
 // forwards, and each method moves up here as its subsystem is wired.
 
 bool MagdaAudioEngine::initialize() {
-    // Said once, out loud. Which engine a session ran on is the first question
-    // any report about it raises, and the answer should not need a debugger.
-    juce::Logger::writeToLog("[engine] rendering through magda::engine (#2551)");
-
     if (!tracktion_->initialize())
         return false;
 
@@ -238,6 +212,13 @@ bool MagdaAudioEngine::isDevicesLoading() const {
 void MagdaAudioEngine::setDevicesLoadingCallback(
     std::function<void(bool, const juce::String&)> callback) {
     tracktion_->setDevicesLoadingCallback(callback);
+}
+void MagdaAudioEngine::setPluginScanStatusCallback(
+    std::function<void(const juce::String&)> callback) {
+    tracktion_->setPluginScanStatusCallback(std::move(callback));
+}
+void MagdaAudioEngine::setMidiDevicesReadyCallback(std::function<void()> callback) {
+    tracktion_->setMidiDevicesReadyCallback(std::move(callback));
 }
 AudioBridge* MagdaAudioEngine::getAudioBridge() {
     return tracktion_->getAudioBridge();

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -78,6 +78,12 @@ juce::File MagdaAudioEngine::getEditFile() const {
     return tracktion_->getEditFile();
 }
 void MagdaAudioEngine::play() {
+    // The fork's guard, and it is about the device rather than about the
+    // engine: both render through the one the fork opens, and starting into a
+    // device that is still being enumerated is a glitch either way.
+    if (tracktion_->isDevicesLoading())
+        return;
+
     host_->play();
 }
 void MagdaAudioEngine::stop() {
@@ -334,7 +340,12 @@ void MagdaAudioEngine::onTransportStopRecording() {
     reportUnwired("onTransportStopRecording", "#2553");
 }
 void MagdaAudioEngine::onEditPositionChanged(double positionSeconds) {
-    locate(positionSeconds);
+    // Only while stopped, which is the fork's rule and the right one: this
+    // fires whenever the edit cursor moves, and clicking in the piano roll to
+    // place a note moves it. Seeking on that would drag the transport out from
+    // under whoever is listening.
+    if (!isPlaying())
+        locate(positionSeconds);
 }
 void MagdaAudioEngine::onTempoChanged(double bpm) {
     tracktion_->onTempoChanged(bpm);

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -1,9 +1,12 @@
 #include "MagdaAudioEngine.hpp"
 
 #include <cstdlib>
+#include <set>
+#include <string>
 
 #include "../core/UndoManager.hpp"  // complete type for the unique_ptr this forwards
 #include "TracktionEngineWrapper.hpp"
+#include "host/EngineHost.hpp"
 
 namespace magda {
 
@@ -14,6 +17,20 @@ MagdaAudioEngine::MagdaAudioEngine(AudioEngineOptions options) {
     auto wrapper = std::make_unique<TracktionEngineWrapper>();
     wrapper->setForceHeadless(options.headless);
     tracktion_ = std::move(wrapper);
+
+    // Here rather than in initialize(), so that everything below can ask it
+    // things without first asking whether it exists. It renders nothing until
+    // start() puts it on a device.
+    host_ = std::make_unique<daw::engine_host::EngineHost>();
+}
+
+void MagdaAudioEngine::reportUnwired(const char* method, const char* issue) const {
+    static std::set<std::string> said;
+    if (!said.insert(method).second)
+        return;
+
+    juce::Logger::writeToLog(juce::String("[engine] ") + method +
+                             " is not wired on magda::engine yet (" + issue + ")");
 }
 
 MagdaAudioEngine::~MagdaAudioEngine() = default;
@@ -39,19 +56,42 @@ bool MagdaAudioEngine::requested(const AudioEngineOptions& options) {
     return false;
 }
 
-// --- the delegated half ------------------------------------------------------
+// --- what magda::engine answers ----------------------------------------------
 //
-// Everything below forwards. Each method moves up into a native implementation
-// as its subsystem is wired, and what is left when #2554 lands is what actually
-// had to be on this interface.
+// Transport and what is published with it. Everything below this section still
+// forwards, and each method moves up here as its subsystem is wired.
 
 bool MagdaAudioEngine::initialize() {
     // Said once, out loud. Which engine a session ran on is the first question
     // any report about it raises, and the answer should not need a debugger.
     juce::Logger::writeToLog("[engine] rendering through magda::engine (#2551)");
-    return tracktion_->initialize();
+
+    if (!tracktion_->initialize())
+        return false;
+
+    // After the fork, because the device is its to open: the settings UI, the
+    // channel lists and the driver choice are all still on that side, and two
+    // device managers over one interface is the failure this class exists not
+    // to have. What changes is who fills the buffer.
+    if (auto* devices = tracktion_->getDeviceManager())
+        host_->start(*devices);
+
+    // Seeded from the fork rather than left at the engine's own 120 in 4/4. A
+    // project whose tempo never changes after it loads would otherwise place
+    // every clip at a tempo nobody chose.
+    host_->setTempo(tracktion_->getTempo());
+
+    int numerator = 4;
+    int denominator = 4;
+    tracktion_->getTimeSignature(numerator, denominator);
+    host_->setTimeSignature(numerator, denominator);
+    publishLoop();
+
+    return true;
 }
 void MagdaAudioEngine::shutdown() {
+    // Before the fork's, which closes the device this is rendering into.
+    host_->stop();
     tracktion_->shutdown();
 }
 bool MagdaAudioEngine::hasActiveEdit() const {
@@ -64,25 +104,32 @@ juce::File MagdaAudioEngine::getEditFile() const {
     return tracktion_->getEditFile();
 }
 void MagdaAudioEngine::play() {
-    tracktion_->play();
+    host_->play();
 }
 void MagdaAudioEngine::stop() {
-    tracktion_->stop();
+    host_->stopPlaying();
 }
 void MagdaAudioEngine::pause() {
-    tracktion_->pause();
+    // The engine has no pause: a stop that does not move the cursor is the same
+    // thing, and is what this asks for.
+    host_->stopPlaying();
 }
 void MagdaAudioEngine::record() {
-    tracktion_->record();
+    reportUnwired("record", "#2553");
 }
 void MagdaAudioEngine::locate(double positionSeconds) {
+    host_->locateSeconds(positionSeconds);
+
+    // The fork keeps the position too, because half the app still asks it
+    // things about the edit. Harmless while its transport is stopped, which is
+    // the one thing this class guarantees about it.
     tracktion_->locate(positionSeconds);
 }
 double MagdaAudioEngine::getCurrentPosition() const {
-    return tracktion_->getCurrentPosition();
+    return host_->positionSeconds();
 }
 bool MagdaAudioEngine::isPlaying() const {
-    return tracktion_->isPlaying();
+    return host_->isPlaying();
 }
 bool MagdaAudioEngine::isRecording() const {
     return tracktion_->isRecording();
@@ -106,19 +153,26 @@ bool MagdaAudioEngine::isSessionTrackStopPending(TrackId trackId) const {
     return tracktion_->isSessionTrackStopPending(trackId);
 }
 double MagdaAudioEngine::getAudioThreadTransportSeconds() const {
-    return tracktion_->getAudioThreadTransportSeconds();
+    return host_->positionSeconds();
 }
 void MagdaAudioEngine::deactivateAllSessionClips() {
     tracktion_->deactivateAllSessionClips();
 }
+// Tempo, time signature and loop reach both engines. The fork still owns the
+// model -- its tempo sequence is what the ruler, the grid and every
+// beats<->seconds conversion in the UI read through tempoMap() -- and the
+// engine needs the same numbers to render with (#2554 is where that authority
+// moves).
 void MagdaAudioEngine::setTempo(double bpm) {
     tracktion_->setTempo(bpm);
+    host_->setTempo(bpm);
 }
 double MagdaAudioEngine::getTempo() const {
     return tracktion_->getTempo();
 }
 void MagdaAudioEngine::setTimeSignature(int numerator, int denominator) {
     tracktion_->setTimeSignature(numerator, denominator);
+    host_->setTimeSignature(numerator, denominator);
 }
 void MagdaAudioEngine::getTimeSignature(int& numerator, int& denominator) const {
     tracktion_->getTimeSignature(numerator, denominator);
@@ -128,9 +182,18 @@ const TempoMap* MagdaAudioEngine::tempoMap() const {
 }
 void MagdaAudioEngine::setLooping(bool enabled) {
     tracktion_->setLooping(enabled);
+    publishLoop();
 }
 void MagdaAudioEngine::setLoopRegionBeats(BeatRange range) {
     tracktion_->setLoopRegionBeats(range);
+    publishLoop();
+}
+
+/// Both halves of a loop from the one place that holds them: the enable and
+/// the range arrive separately and the engine takes them as one value.
+void MagdaAudioEngine::publishLoop() {
+    const auto range = tracktion_->getLoopRegionBeats();
+    host_->setLoop(tracktion_->isLooping(), range.start.value, range.end.value);
 }
 bool MagdaAudioEngine::isLooping() const {
     return tracktion_->isLooping();
@@ -140,6 +203,7 @@ BeatRange MagdaAudioEngine::getLoopRegionBeats() const {
 }
 void MagdaAudioEngine::setMetronomeEnabled(bool enabled) {
     tracktion_->setMetronomeEnabled(enabled);
+    host_->setMetronomeEnabled(enabled);
 }
 bool MagdaAudioEngine::isMetronomeEnabled() const {
     return tracktion_->isMetronomeEnabled();
@@ -267,35 +331,45 @@ void MagdaAudioEngine::previewNoteOnTrack(const std::string& track_id, int noteN
                                           bool isNoteOn) {
     tracktion_->previewNoteOnTrack(track_id, noteNumber, velocity, isNoteOn);
 }
+// The UI's own transport, which TimelineController drives. Deliberately not
+// forwarded: the fork's versions of these are locate-and-play, and starting its
+// transport is the one thing this class must never do.
 void MagdaAudioEngine::onTransportPlay(double positionSeconds) {
-    tracktion_->onTransportPlay(positionSeconds);
+    locate(positionSeconds);
+    play();
 }
 void MagdaAudioEngine::onTransportStop(double returnPositionSeconds) {
-    tracktion_->onTransportStop(returnPositionSeconds);
+    stop();
+    locate(returnPositionSeconds);
 }
 void MagdaAudioEngine::onTransportPause() {
-    tracktion_->onTransportPause();
+    pause();
 }
 void MagdaAudioEngine::onTransportRecord(double positionSeconds) {
-    tracktion_->onTransportRecord(positionSeconds);
+    juce::ignoreUnused(positionSeconds);
+    reportUnwired("onTransportRecord", "#2553");
 }
 void MagdaAudioEngine::onTransportStopRecording() {
-    tracktion_->onTransportStopRecording();
+    reportUnwired("onTransportStopRecording", "#2553");
 }
 void MagdaAudioEngine::onEditPositionChanged(double positionSeconds) {
-    tracktion_->onEditPositionChanged(positionSeconds);
+    locate(positionSeconds);
 }
 void MagdaAudioEngine::onTempoChanged(double bpm) {
     tracktion_->onTempoChanged(bpm);
+    host_->setTempo(bpm);
 }
 void MagdaAudioEngine::onTimeSignatureChanged(int numerator, int denominator) {
     tracktion_->onTimeSignatureChanged(numerator, denominator);
+    host_->setTimeSignature(numerator, denominator);
 }
 void MagdaAudioEngine::onLoopRegionChanged(double startSeconds, double endSeconds, bool enabled) {
     tracktion_->onLoopRegionChanged(startSeconds, endSeconds, enabled);
+    publishLoop();
 }
 void MagdaAudioEngine::onLoopEnabledChanged(bool enabled) {
     tracktion_->onLoopEnabledChanged(enabled);
+    publishLoop();
 }
 
 // --- the bases' defaulted virtuals -------------------------------------------

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -72,11 +72,6 @@ class MagdaAudioEngine final : public AudioEngine {
     explicit MagdaAudioEngine(AudioEngineOptions options);
     ~MagdaAudioEngine() override;
 
-    /// Whether the app was asked for this engine. MAGDA_AUDIO_ENGINE takes
-    /// "magda" or "tracktion" and wins over the setting (#2559), so a run can
-    /// be switched without a rebuild and without touching preferences.
-    static bool requested(const AudioEngineOptions& options);
-
     bool initialize() override;
     void shutdown() override;
     bool hasActiveEdit() const override;
@@ -120,6 +115,8 @@ class MagdaAudioEngine final : public AudioEngine {
     bool isDevicesLoading() const override;
     void setDevicesLoadingCallback(
         std::function<void(bool, const juce::String&)> callback) override;
+    void setPluginScanStatusCallback(std::function<void(const juce::String&)> callback) override;
+    void setMidiDevicesReadyCallback(std::function<void()> callback) override;
     AudioBridge* getAudioBridge() override;
     const AudioBridge* getAudioBridge() const override;
     MidiBridge* getMidiBridge() override;

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -4,6 +4,10 @@
 
 #include "AudioEngine.hpp"
 
+namespace magda::daw::engine_host {
+class EngineHost;
+}
+
 /**
  * @file MagdaAudioEngine.hpp
  * @brief The app's second AudioEngine, backed by magda::engine (#2551).
@@ -17,6 +21,16 @@
  *
  * Selected in createDefaultAudioEngine rather than chosen at build time, so
  * both engines ship in one binary and switching them is a setting.
+ *
+ * ## What magda::engine answers, and what is still the fork's
+ *
+ * Transport, tempo, loop and metronome are published to an EngineSession and
+ * rendered from the audio device callback: what fills the output buffer is
+ * magda::engine and nothing else. The tempo *model* is still the fork's, since
+ * the app has no tempo track of its own, so a tempo edit reaches both.
+ *
+ * Recording, session launch and offline render are not wired yet (#2552,
+ * #2553, #2555) and say so once in the log rather than answering silently.
  *
  * ## Why it holds a Tracktion engine
  *
@@ -167,9 +181,21 @@ class MagdaAudioEngine final : public AudioEngine {
     void onPunchEnabledChanged(bool punchInEnabled, bool punchOutEnabled) override;
 
   private:
+    /// Whatever has not moved to magda::engine yet, said once per method
+    /// rather than answered with silence.
+    void reportUnwired(const char* method, const char* issue) const;
+
+    /// The loop as one value, from the fork that still holds both halves.
+    void publishLoop();
+
     /// The half of the interface that is not an engine question. See the file
     /// comment: this goes away with #2554.
     std::unique_ptr<AudioEngine> tracktion_;
+
+    /// What actually renders. Declared after the fork so it is destroyed
+    /// first: the device it has a callback on is the fork's, and the fork
+    /// closes it on its way out.
+    std::unique_ptr<daw::engine_host::EngineHost> host_;
 };
 
 }  // namespace magda

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -138,6 +138,12 @@ class TracktionEngineWrapper : public AudioEngine,
     void setTempo(double bpm) override;
     double getTempo() const override;
     const TempoMap* tempoMap() const override;
+    void setPluginScanStatusCallback(std::function<void(const juce::String&)> callback) override {
+        onPluginScanStatus = std::move(callback);
+    }
+    void setMidiDevicesReadyCallback(std::function<void()> callback) override {
+        onMidiDevicesReady = std::move(callback);
+    }
     void setTimeSignature(int numerator, int denominator) override;
     void getTimeSignature(int& numerator, int& denominator) const override;
     void setLooping(bool enabled) override;

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -15,6 +15,7 @@
 #include "../project/ProjectManager.hpp"
 #include "../ui/state/TimelineController.hpp"
 #include "../ui/state/TimelineEvents.hpp"
+#include "AudioEngineChoice.hpp"
 #if MAGDA_HAS_NATIVE_ENGINE
     #include "MagdaAudioEngine.hpp"
 #endif
@@ -37,12 +38,23 @@ TracktionEngineWrapper::~TracktionEngineWrapper() {
 }
 
 std::unique_ptr<AudioEngine> createDefaultAudioEngine(AudioEngineOptions options) {
+    const auto choice = chosenAudioEngine();
+
+    // Out loud, once, wherever an engine is built. Which one a session ran on
+    // is the first question any report about it raises, and the answer should
+    // not need a debugger -- or a guess about which construction site the app
+    // took.
+    juce::Logger::writeToLog(juce::String("[engine] rendering through ") + nameOf(choice) +
+                             " (#2551)");
+
     // The native engine holds a fork of its own for the half of the interface
     // that is not an engine question, so this is a choice between two engines
-    // rather than a choice about whether the fork is built (#2551).
+    // rather than a choice about whether the fork is built.
 #if MAGDA_HAS_NATIVE_ENGINE
-    if (MagdaAudioEngine::requested(options))
+    if (choice == AudioEngineChoice::Magda)
         return std::make_unique<MagdaAudioEngine>(options);
+#else
+    juce::ignoreUnused(choice);
 #endif
 
     auto engine = std::make_unique<TracktionEngineWrapper>();

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -15,7 +15,9 @@
 #include "../project/ProjectManager.hpp"
 #include "../ui/state/TimelineController.hpp"
 #include "../ui/state/TimelineEvents.hpp"
-#include "MagdaAudioEngine.hpp"
+#if MAGDA_HAS_NATIVE_ENGINE
+    #include "MagdaAudioEngine.hpp"
+#endif
 #include "MagdaEngineBehaviour.hpp"
 #include "MagdaUIBehaviour.hpp"
 #include "PluginScanCoordinator.hpp"
@@ -38,8 +40,10 @@ std::unique_ptr<AudioEngine> createDefaultAudioEngine(AudioEngineOptions options
     // The native engine holds a fork of its own for the half of the interface
     // that is not an engine question, so this is a choice between two engines
     // rather than a choice about whether the fork is built (#2551).
+#if MAGDA_HAS_NATIVE_ENGINE
     if (MagdaAudioEngine::requested(options))
         return std::make_unique<MagdaAudioEngine>(options);
+#endif
 
     auto engine = std::make_unique<TracktionEngineWrapper>();
     engine->setForceHeadless(options.headless);

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <ranges>
 
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ClipManager.hpp"
@@ -79,6 +80,29 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         return session_ != nullptr ? session_->positionBeats() : 0.0;
     }
 
+    /**
+     * @brief What the plan asked for and what it got.
+     *
+     * The other half of whether this path is live: a trace with no notes in it
+     * means one of a device nothing could build, a callback that never ran, or
+     * an engine that was never chosen, and those look identical from silence.
+     */
+    void tracePlan(const engine::RenderPlan& plan) {
+        if (!EngineTrace::enabled())
+            return;
+
+        const auto devices =
+            std::ranges::count(plan.ops, engine::OpKind::Device, &engine::PlanOp::kind);
+        const auto midi =
+            std::ranges::count(plan.ops, engine::OpKind::ClipMidi, &engine::PlanOp::kind);
+
+        EngineTrace::print("plan: " + juce::String(devices) + " device ops (" +
+                           juce::String(static_cast<int>(unbuilt_.size())) + " unbuilt), " +
+                           juce::String(midi) + " clip-midi ops, " +
+                           juce::String(rendered_.load(std::memory_order_relaxed)) +
+                           " callbacks so far");
+    }
+
     void start(juce::AudioDeviceManager& devices) {
         if (devices_ != nullptr)
             return;
@@ -136,6 +160,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
 
         livePlan_ = std::move(plan);
         traceEdit(EngineTrace::Kind::Swap);
+        tracePlan(*livePlan_);
         reportUnbuiltDevices();
     }
 
@@ -312,6 +337,14 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         rate_.store(device->getCurrentSampleRate());
         blockSize_.store(device->getCurrentBufferSizeSamples());
         triggerAsyncUpdate();
+
+        if (EngineTrace::enabled())
+            EngineTrace::print(
+                "device \"" + device->getName() + "\" at " +
+                juce::String(device->getCurrentSampleRate(), 0) + " Hz, " +
+                juce::String(device->getCurrentBufferSizeSamples()) + " samples, " +
+                juce::String(device->getActiveOutputChannels().countNumberOfSetBits()) +
+                " outputs");
     }
 
     void audioDeviceStopped() override {}
@@ -321,6 +354,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                                           const juce::AudioIODeviceCallbackContext&) override {
         for (auto channel = 0; channel < numOutputChannels; ++channel)
             juce::FloatVectorOperations::clear(output[channel], numSamples);
+
+        rendered_.fetch_add(1, std::memory_order_relaxed);
 
         // Read without a guard because there is nothing to guard against:
         // rebuild() takes this callback off the device before it touches the
@@ -406,6 +441,10 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     std::atomic<bool> plan_{false};
     std::atomic<bool> values_{false};
     std::atomic<bool> clips_{false};
+
+    /// Callbacks this host has rendered. Only ever read by the trace, and the
+    /// one number that separates "nothing sounded" from "nothing ran".
+    std::atomic<std::uint64_t> rendered_{0};
 
     std::vector<juce::String> unbuilt_;
     EngineTrace trace_;

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -55,16 +55,17 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         // thread, and reading them in order is the whole point.
         factory_.traceInto(trace_);
         startTimer(100);
+        EngineTrace::print("MIDI trace on. Publishes and what reached each device, in order.");
     }
 
     ~Impl() override {
         detach();
     }
 
-    /// The audio thread's side of the trace, on the thread allowed to log it.
+    /// The audio thread's side of the trace, on the thread allowed to print it.
     void timerCallback() override {
         for (const auto& line : trace_.drain())
-            juce::Logger::writeToLog(line);
+            EngineTrace::print(line);
     }
 
     /// Where the transport was when the model moved, in the same stream as the

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -1,0 +1,456 @@
+#include "EngineHost.hpp"
+
+#include <juce_audio_devices/juce_audio_devices.h>
+
+#include <algorithm>
+#include <atomic>
+
+#include "../../core/AutomationManager.hpp"
+#include "../../core/ClipManager.hpp"
+#include "../../core/TrackManager.hpp"
+#include "EngineProject.hpp"
+#include "EngineRuntimeFactory.hpp"
+#include "clip/ClipSnapshotCompiler.hpp"
+#include "clip/ClipVoicePool.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanValues.hpp"
+#include "io/PrefetchThread.hpp"
+#include "plan/PlanCompiler.hpp"
+
+namespace magda::daw::engine_host {
+
+namespace {
+
+/// Stereo, like everything else in the engine: the model has no mono tracks,
+/// and a narrow device is a declared width rather than a smaller buffer.
+constexpr int kChannels = 2;
+
+/// Anything a publish could not honour, named by the half that reported it.
+void report(const juce::String& what, const std::vector<std::string>& messages) {
+    for (const auto& message : messages)
+        juce::Logger::writeToLog("[engine] " + what + ": " + juce::String(message));
+}
+
+}  // namespace
+
+/**
+ * @brief The session, the callback that drives it, and the model it follows.
+ *
+ * One class rather than three because the three cannot be separated: what the
+ * callback renders is what the model last published, and both are bounded by
+ * the device's own start and stop.
+ */
+struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
+                                private juce::AsyncUpdater,
+                                private TrackManagerListener,
+                                private ClipManagerListener {
+    ~Impl() override {
+        detach();
+    }
+
+    void start(juce::AudioDeviceManager& devices) {
+        if (devices_ != nullptr)
+            return;
+
+        devices_ = &devices;
+        TrackManager::getInstance().addListener(this);
+        ClipManager::getInstance().addListener(this);
+        devices_->addAudioCallback(this);
+    }
+
+    void detach() {
+        if (devices_ == nullptr)
+            return;
+
+        // The callback first: what follows destroys the session it renders
+        // through, and removeAudioCallback returns only once the audio thread
+        // is out of here.
+        devices_->removeAudioCallback(this);
+        ClipManager::getInstance().removeListener(this);
+        TrackManager::getInstance().removeListener(this);
+        devices_ = nullptr;
+
+        cancelPendingUpdate();
+        session_.reset();
+        voiceThread_.reset();
+        voices_.reset();
+    }
+
+    // ===== Publishing, all on the message thread =====
+
+    /// The four things a plan publish is: the topology, the values resolved
+    /// against it, the IDs the model still holds, and the context they render
+    /// under.
+    void publishPlan() {
+        const auto& tracks = TrackManager::getInstance().getTracks();
+        const auto* master = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+        if (session_ == nullptr || master == nullptr)
+            return;
+
+        factory_.setModel(tracks, *master);
+
+        auto plan =
+            std::make_shared<const engine::RenderPlan>(engine::compileRenderPlan(tracks, *master));
+        report("plan", plan->diagnostics);
+
+        engine::PlanValues values;
+        report("values", resolveValues(*plan, tracks, *master, values));
+
+        const auto ids = engine::collectRuntimeStateIds(tracks, *master);
+        const auto result = session_->publish(plan, context_, ids, std::move(values));
+        report("publish", result.messages);
+
+        if (!result.published)
+            return;
+
+        livePlan_ = std::move(plan);
+        reportUnbuiltDevices();
+    }
+
+    /// A mixer move: the same values against the plan already playing. It
+    /// escalates itself into a structural publish when a link edit changed the
+    /// parameter table's shape, which is the one thing values cannot carry.
+    void publishValues() {
+        const auto& tracks = TrackManager::getInstance().getTracks();
+        const auto* master = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+        if (session_ == nullptr || livePlan_ == nullptr || master == nullptr)
+            return;
+
+        engine::PlanValues values;
+        report("values", resolveValues(*livePlan_, tracks, *master, values));
+        report("values", session_->publishValues(std::move(values)).messages);
+    }
+
+    /// What every track plays, resolved against the tempo the transport is
+    /// published with: a snapshot compiled against a different map would place
+    /// every clip at the seconds that map gave it.
+    void publishClips() {
+        if (session_ == nullptr)
+            return;
+
+        const auto& tracks = TrackManager::getInstance().getTracks();
+        auto snapshot = std::make_shared<const engine::ClipSnapshot>(
+            engine::compileClipSnapshot(clipLanesFor(tracks), clipSources(), tempoMap()));
+        report("clips", snapshot->diagnostics);
+
+        session_->publishClips(std::move(snapshot));
+    }
+
+    void publishTransport() {
+        if (session_ == nullptr)
+            return;
+
+        session_->publishTransport(
+            {.tempo = tempoMap(), .loop = loop_, .click = click_, .request = request_});
+    }
+
+    /// A play, a stop or a locate. The generation is what makes a snapshot a
+    /// request rather than a description, so it is bumped here and nowhere
+    /// else.
+    void publishRequest(const engine::TransportRequest& request) {
+        request_ = request;
+        request_.generation = ++generation_;
+        publishTransport();
+    }
+
+    // ===== Following the model =====
+
+    void tracksChanged() override {
+        wantPlan();
+    }
+    void trackDevicesChanged(TrackId) override {
+        wantPlan();
+    }
+    void deviceAdded(const ChainNodePath&, const DeviceInfo&) override {
+        wantPlan();
+    }
+    void trackPropertyChanged(int) override {
+        wantValues();
+    }
+    void masterChannelChanged() override {
+        wantValues();
+    }
+    void devicePropertyChanged(const ChainNodePath&) override {
+        wantValues();
+    }
+    void deviceParameterChanged(const ChainNodePath&, int, float) override {
+        wantValues();
+    }
+    void deviceModifiersChanged(TrackId) override {
+        wantValues();
+    }
+    void clipsChanged() override {
+        wantClips();
+    }
+    void clipPropertyChanged(ClipId) override {
+        wantClips();
+    }
+
+    void wantPlan() {
+        plan_.store(true, std::memory_order_relaxed);
+        triggerAsyncUpdate();
+    }
+    void wantValues() {
+        values_.store(true, std::memory_order_relaxed);
+        triggerAsyncUpdate();
+    }
+    void wantClips() {
+        clips_.store(true, std::memory_order_relaxed);
+        triggerAsyncUpdate();
+    }
+
+    /// Everything the model has asked for since the last one. A plan publish
+    /// resolves values on its way through, so the two are alternatives; clips
+    /// travel on their own and are published beside either.
+    void handleAsyncUpdate() override {
+        const engine::RenderContext wanted{.sampleRate = rate_.load(),
+                                           .maxBlockSize = blockSize_.load(),
+                                           .numChannels = kChannels};
+        if (wanted.sampleRate <= 0.0 || wanted.maxBlockSize <= 0)
+            return;
+
+        if (session_ == nullptr || wanted != context_) {
+            rebuild(wanted);
+            return;
+        }
+
+        // All three taken before any of them runs, so a plan publish clears the
+        // values it already resolved rather than leaving them to be published
+        // again at whatever the next edit turns out to be.
+        const auto plan = plan_.exchange(false);
+        const auto values = values_.exchange(false);
+        const auto clips = clips_.exchange(false);
+
+        if (plan)
+            publishPlan();
+        else if (values)
+            publishValues();
+
+        if (clips)
+            publishClips();
+    }
+
+    /**
+     * @brief Build the session the device just described, and fill it.
+     *
+     * A sample rate or block size change means every prepared object is
+     * prepared for the wrong one, and the pool's readers are cued in the wrong
+     * samples, so the session is remade rather than adjusted. Off the device
+     * for the length of it: everything here allocates, and the session being
+     * destroyed is the one the callback renders through.
+     */
+    void rebuild(const engine::RenderContext& context) {
+        devices_->removeAudioCallback(this);
+
+        session_.reset();
+        voiceThread_.reset();
+        voices_.reset();
+        livePlan_.reset();
+
+        context_ = context;
+        scratch_.setSize(kChannels, context.maxBlockSize);
+
+        voices_ = std::make_unique<engine::ClipVoicePool>(files_, reader_, context);
+        voiceThread_ = std::make_unique<engine::ClipVoiceThread>(*voices_);
+
+        // No render pool: every block renders on the audio thread alone, which
+        // is the same executor with one thread instead of many. Spreading a
+        // block across realtime workers is the next question this can be asked,
+        // and not one to answer in the same change that first made a sound.
+        session_ = std::make_unique<engine::EngineSession>(factory_, nullptr, voices_.get());
+        factory_.attach(session_->clipFeed(), voices_->feed(), session_->launchHandleFeed());
+
+        plan_.store(false, std::memory_order_relaxed);
+        values_.store(false, std::memory_order_relaxed);
+        clips_.store(false, std::memory_order_relaxed);
+
+        publishTransport();
+        publishPlan();
+        publishClips();
+
+        devices_->addAudioCallback(this);
+    }
+
+    // ===== The device =====
+
+    void audioDeviceAboutToStart(juce::AudioIODevice* device) override {
+        // Only what the device is. Building a session allocates and publishing
+        // one waits, and both belong to the publishing thread.
+        rate_.store(device->getCurrentSampleRate());
+        blockSize_.store(device->getCurrentBufferSizeSamples());
+        triggerAsyncUpdate();
+    }
+
+    void audioDeviceStopped() override {}
+
+    void audioDeviceIOCallbackWithContext(const float* const*, int, float* const* output,
+                                          int numOutputChannels, int numSamples,
+                                          const juce::AudioIODeviceCallbackContext&) override {
+        for (auto channel = 0; channel < numOutputChannels; ++channel)
+            juce::FloatVectorOperations::clear(output[channel], numSamples);
+
+        // Read without a guard because there is nothing to guard against:
+        // rebuild() takes this callback off the device before it touches the
+        // session, and removeAudioCallback returns only once this has left.
+        if (session_ == nullptr || numSamples <= 0)
+            return;
+
+        const auto outputs = std::min(numOutputChannels, kChannels);
+
+        // In pieces no longer than the plan was prepared for. A driver handing
+        // over more than the block size it declared is rare and legal, and
+        // rendering it in one go is a buffer overrun rather than a wrong sound.
+        for (auto done = 0; done < numSamples;) {
+            const auto piece = std::min(numSamples - done, scratch_.getNumSamples());
+            juce::AudioBuffer<float> block(scratch_.getArrayOfWritePointers(), kChannels, piece);
+
+            session_->process(piece, block);
+
+            for (auto channel = 0; channel < outputs; ++channel)
+                juce::FloatVectorOperations::copy(output[channel] + done,
+                                                  scratch_.getReadPointer(channel), piece);
+            done += piece;
+        }
+    }
+
+    // ===== Odds and ends =====
+
+    engine::TempoMap tempoMap() const {
+        return tempoMapAt(bpm_, numerator_, denominator_);
+    }
+
+    std::vector<std::string> resolveValues(const engine::RenderPlan& plan,
+                                           const std::vector<TrackInfo>& tracks,
+                                           const TrackInfo& master,
+                                           engine::PlanValues& values) const {
+        const auto& automation = AutomationManager::getInstance();
+        return engine::resolvePlanValues(plan, tracks, master, values, automation.getLanes(),
+                                         automation.getClips());
+    }
+
+    /// Devices the model names and no catalog could build. Named rather than
+    /// counted, and only when the set changes: every external plugin is one of
+    /// these until the plugin scan reaches this factory (#2566), and a line per
+    /// publish would bury everything else.
+    void reportUnbuiltDevices() {
+        if (factory_.unbuilt() == unbuilt_)
+            return;
+
+        unbuilt_ = factory_.unbuilt();
+        for (const auto& name : unbuilt_)
+            juce::Logger::writeToLog("[engine] nothing to build \"" + name + "\" with");
+    }
+
+    EngineFileReaders files_;
+    engine::PrefetchThread reader_;
+    EngineRuntimeFactory factory_;
+
+    juce::AudioDeviceManager* devices_ = nullptr;
+    engine::RenderContext context_{};
+    juce::AudioBuffer<float> scratch_;
+
+    // Declared so that destruction unwinds inwards: the session lets go of the
+    // pool before the thread servicing it stops, and the thread stops before
+    // the pool it is inside goes away.
+    std::unique_ptr<engine::ClipVoicePool> voices_;
+    std::unique_ptr<engine::ClipVoiceThread> voiceThread_;
+    std::unique_ptr<engine::EngineSession> session_;
+
+    /// The plan the session is rendering, kept so a mixer move can resolve
+    /// values against it without compiling another.
+    std::shared_ptr<const engine::RenderPlan> livePlan_;
+
+    double bpm_ = 120.0;
+    int numerator_ = 4;
+    int denominator_ = 4;
+    engine::LoopRange loop_;
+    engine::ClickSettings click_;
+    engine::TransportRequest request_;
+    std::uint64_t generation_ = 0;
+
+    std::atomic<double> rate_{0.0};
+    std::atomic<int> blockSize_{0};
+    std::atomic<bool> plan_{false};
+    std::atomic<bool> values_{false};
+    std::atomic<bool> clips_{false};
+
+    std::vector<juce::String> unbuilt_;
+};
+
+EngineHost::EngineHost() : impl_(std::make_unique<Impl>()) {}
+
+EngineHost::~EngineHost() = default;
+
+void EngineHost::start(juce::AudioDeviceManager& devices) {
+    impl_->start(devices);
+}
+
+void EngineHost::stop() {
+    impl_->detach();
+}
+
+void EngineHost::play() {
+    impl_->publishRequest({.playing = true, .locate = false});
+}
+
+void EngineHost::stopPlaying() {
+    impl_->publishRequest({.playing = false, .locate = false});
+}
+
+void EngineHost::locateSeconds(double seconds) {
+    impl_->publishRequest({.playing = impl_->request_.playing,
+                           .locate = true,
+                           .positionBeat = impl_->tempoMap().timeToBeat(seconds)});
+}
+
+bool EngineHost::isPlaying() const {
+    return impl_->request_.playing;
+}
+
+double EngineHost::positionBeats() const {
+    return impl_->session_ != nullptr ? impl_->session_->positionBeats() : 0.0;
+}
+
+double EngineHost::positionSeconds() const {
+    return impl_->tempoMap().beatToTime(positionBeats());
+}
+
+void EngineHost::setTempo(double bpm) {
+    impl_->bpm_ = bpm;
+    impl_->publishTransport();
+
+    // The snapshot's seconds were derived through the map that just changed, so
+    // it is compiled again rather than left placing clips at the old tempo.
+    impl_->publishClips();
+}
+
+double EngineHost::tempo() const {
+    return impl_->bpm_;
+}
+
+void EngineHost::setTimeSignature(int numerator, int denominator) {
+    impl_->numerator_ = numerator;
+    impl_->denominator_ = denominator;
+    impl_->publishTransport();
+}
+
+void EngineHost::getTimeSignature(int& numerator, int& denominator) const {
+    numerator = impl_->numerator_;
+    denominator = impl_->denominator_;
+}
+
+void EngineHost::setLoop(bool enabled, double startBeat, double endBeat) {
+    impl_->loop_ = {.enabled = enabled, .startBeat = startBeat, .endBeat = endBeat};
+    impl_->publishTransport();
+}
+
+void EngineHost::setMetronomeEnabled(bool enabled) {
+    impl_->click_.enabled = enabled;
+    impl_->publishTransport();
+}
+
+bool EngineHost::isMetronomeEnabled() const {
+    return impl_->click_.enabled;
+}
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -10,6 +10,7 @@
 #include "../../core/TrackManager.hpp"
 #include "EngineProject.hpp"
 #include "EngineRuntimeFactory.hpp"
+#include "EngineTrace.hpp"
 #include "clip/ClipSnapshotCompiler.hpp"
 #include "clip/ClipVoicePool.hpp"
 #include "exec/EngineSession.hpp"
@@ -42,10 +43,39 @@ void report(const juce::String& what, const std::vector<std::string>& messages) 
  */
 struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                                 private juce::AsyncUpdater,
+                                private juce::Timer,
                                 private TrackManagerListener,
                                 private ClipManagerListener {
+    Impl() {
+        if (!EngineTrace::enabled())
+            return;
+
+        // Both ends of the race into one stream (#2568): the publishes below
+        // write to it on this thread and the devices write to it on the audio
+        // thread, and reading them in order is the whole point.
+        factory_.traceInto(trace_);
+        startTimer(100);
+    }
+
     ~Impl() override {
         detach();
+    }
+
+    /// The audio thread's side of the trace, on the thread allowed to log it.
+    void timerCallback() override {
+        for (const auto& line : trace_.drain())
+            juce::Logger::writeToLog(line);
+    }
+
+    /// Where the transport was when the model moved, in the same stream as the
+    /// notes, so an edit can be placed against the block that sounded one.
+    void traceEdit(EngineTrace::Kind kind) {
+        if (EngineTrace::enabled())
+            trace_.write({.kind = kind, .beat = positionBeats()});
+    }
+
+    double positionBeats() const {
+        return session_ != nullptr ? session_->positionBeats() : 0.0;
     }
 
     void start(juce::AudioDeviceManager& devices) {
@@ -104,6 +134,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
             return;
 
         livePlan_ = std::move(plan);
+        traceEdit(EngineTrace::Kind::Swap);
         reportUnbuiltDevices();
     }
 
@@ -133,6 +164,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
             engine::compileClipSnapshot(clipLanesFor(tracks), clipSources(), tempoMap()));
         report("clips", snapshot->diagnostics);
 
+        traceEdit(EngineTrace::Kind::Publish);
         session_->publishClips(std::move(snapshot));
     }
 
@@ -375,6 +407,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     std::atomic<bool> clips_{false};
 
     std::vector<juce::String> unbuilt_;
+    EngineTrace trace_;
 };
 
 EngineHost::EngineHost() : impl_(std::make_unique<Impl>()) {}
@@ -408,7 +441,7 @@ bool EngineHost::isPlaying() const {
 }
 
 double EngineHost::positionBeats() const {
-    return impl_->session_ != nullptr ? impl_->session_->positionBeats() : 0.0;
+    return impl_->positionBeats();
 }
 
 double EngineHost::positionSeconds() const {

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <memory>
+
+namespace juce {
+class AudioDeviceManager;
+}
+
+/**
+ * @file EngineHost.hpp
+ * @brief The app's end of magda::engine: a device callback and a publisher.
+ *
+ * Everything the engine can do it has so far done offline, driven by a harness
+ * (#2551). This is the first thing to drive it from an audio device: it owns an
+ * EngineSession, renders it from the callback, and republishes the project
+ * whenever the model moves.
+ *
+ * The engine's own types stay out of this header on purpose. MagdaAudioEngine
+ * is compiled into magda_daw, which does not see magda_engine's includes; what
+ * crosses that line is one pointer.
+ *
+ * Threading: everything but the callback runs on the message thread, which is
+ * the session's one publishing thread. Model edits are coalesced through an
+ * async update rather than published where they are noticed, so a drag that
+ * fires a hundred property changes publishes once.
+ */
+
+namespace magda::daw::engine_host {
+
+class EngineHost {
+  public:
+    EngineHost();
+    ~EngineHost();
+
+    EngineHost(const EngineHost&) = delete;
+    EngineHost& operator=(const EngineHost&) = delete;
+
+    /**
+     * @brief Render into @p devices, and follow the model from here on.
+     *
+     * The device decides the sample rate and block size, so the session behind
+     * this is built on the first callback rather than here: until then the
+     * output is silence and the cursor stands still, which is what a session
+     * with no plan renders anyway (EngineSession::process).
+     */
+    void start(juce::AudioDeviceManager& devices);
+
+    /// Take the callback back off the device and stop following the model.
+    /// Safe to call twice, and called by the destructor.
+    void stop();
+
+    // ===== Transport =====
+    //
+    // Play, stop and locate are a request the clock applies once, so each of
+    // these publishes a transport rather than reaching into the audio thread.
+
+    void play();
+    void stopPlaying();
+    void locateSeconds(double seconds);
+    bool isPlaying() const;
+
+    /// Where the cursor is. Readable from any thread; what a playhead is drawn
+    /// from.
+    double positionBeats() const;
+    double positionSeconds() const;
+
+    // ===== What the transport is published with =====
+
+    void setTempo(double bpm);
+    double tempo() const;
+    void setTimeSignature(int numerator, int denominator);
+    void getTimeSignature(int& numerator, int& denominator) const;
+    void setLoop(bool enabled, double startBeat, double endBeat);
+    void setMetronomeEnabled(bool enabled);
+    bool isMetronomeEnabled() const;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineProject.cpp
+++ b/magda/daw/engine/host/EngineProject.cpp
@@ -1,0 +1,51 @@
+#include "EngineProject.hpp"
+
+#include "../../core/ClipManager.hpp"
+#include "../../core/SourcePool.hpp"
+
+namespace magda::daw::engine_host {
+
+std::vector<engine::ClipLane> clipLanesFor(const std::vector<TrackInfo>& tracks) {
+    const auto& clips = ClipManager::getInstance();
+
+    std::vector<engine::ClipLane> lanes;
+    lanes.reserve(tracks.size());
+
+    for (const auto& track : tracks) {
+        engine::ClipLane lane;
+        lane.trackId = track.id;
+        lane.playbackMode = track.playbackMode;
+        lane.clips = clips.arrangementLane(track.id);
+
+        for (const auto id : clips.getClipsOnTrack(track.id, ClipView::Session))
+            if (const auto* clip = clips.getClip(id))
+                lane.session.push_back(*clip);
+
+        lanes.push_back(std::move(lane));
+    }
+
+    return lanes;
+}
+
+std::vector<engine::ClipSourceInfo> clipSources() {
+    std::vector<engine::ClipSourceInfo> sources;
+
+    for (const auto& source : SourcePool::getInstance().snapshot())
+        sources.push_back({.id = source.id,
+                           .path = source.filePath.toStdString(),
+                           .sampleRate = source.sampleRate,
+                           .durationSeconds = source.durationSeconds});
+
+    return sources;
+}
+
+engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator) {
+    return engine::TempoMap({engine::TempoChange{.startBeat = 0.0, .bpm = bpm}},
+                            {engine::TimeSignatureChange{
+                                .startBeat = 0.0,
+                                .numerator = numerator,
+                                .denominator = denominator,
+                            }});
+}
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineProject.hpp
+++ b/magda/daw/engine/host/EngineProject.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <vector>
+
+#include "clip/ClipSnapshotCompiler.hpp"
+#include "core/TrackInfo.hpp"
+#include "transport/TempoMap.hpp"
+
+/**
+ * @file EngineProject.hpp
+ * @brief The project as magda::engine wants it, read off the app's model.
+ *
+ * The engine compiles from plain values and reaches no singleton, which is what
+ * makes a compile deterministic (ClipSnapshotCompiler.hpp). Somebody still has
+ * to go to ClipManager and SourcePool for those values, and this is that
+ * somebody, so the host reads as a publish rather than as a tour of the model.
+ *
+ * Tracks are not here: TrackManager already holds them in the shape the
+ * compiler takes, so the host passes them straight through.
+ */
+
+namespace magda::daw::engine_host {
+
+/// What each of @p tracks plays, arrangement and session apart. The split is
+/// the caller's to make: a session clip is a slot positioned by scene, and the
+/// compiler's guard exists to catch a caller who confused the two.
+std::vector<engine::ClipLane> clipLanesFor(const std::vector<TrackInfo>& tracks);
+
+/// Every pooled source, as facts. The engine never probes a file: a snapshot
+/// compiled during playback would open one on the publishing thread.
+std::vector<engine::ClipSourceInfo> clipSources();
+
+/// A flat map at @p bpm. Flat because the model is: tempo curves live in the
+/// fork's tempo sequence and the app has no tempo track of its own to bake
+/// (#2554 moves that).
+engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator);
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -1,0 +1,95 @@
+#include "EngineRuntimeFactory.hpp"
+
+#include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
+#include "clip/ClipAudioSource.hpp"
+#include "clip/ClipMidiSource.hpp"
+
+namespace magda::daw::engine_host {
+
+namespace adapter = magda::daw::audio::engine_adapter;
+
+EngineFileReaders::EngineFileReaders() {
+    formats_.registerBasicFormats();
+}
+
+std::unique_ptr<engine::AudioFileReader> EngineFileReaders::open(const std::string& path) {
+    std::unique_ptr<juce::AudioFormatReader> reader(
+        formats_.createReaderFor(juce::File(juce::String(path))));
+    if (reader == nullptr)
+        return nullptr;
+
+    return std::make_unique<engine::JuceAudioFileReader>(std::move(reader));
+}
+
+void EngineRuntimeFactory::attach(engine::ClipSnapshotFeed& clips, engine::ClipStreamFeed& streams,
+                                  engine::LaunchHandleFeed& handles) {
+    clips_ = &clips;
+    streams_ = &streams;
+    handles_ = &handles;
+}
+
+void EngineRuntimeFactory::setModel(const std::vector<TrackInfo>& tracks, const TrackInfo& master) {
+    devices_.clear();
+    unbuilt_.clear();
+
+    for (const auto& [key, device] : adapter::devicesIn(tracks, master))
+        devices_.emplace(key, *device);
+}
+
+std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine::DeviceKey key) {
+    const auto found = devices_.find(key);
+    if (found == devices_.end())
+        return nullptr;
+
+    if (auto device = adapter::createEngineDevice(found->second))
+        return device;
+
+    // Said out loud once per publish rather than left as silence. A device the
+    // app can build and the engine cannot is a project playing without part of
+    // itself, and the executor's own "unbound op" says a key, not a name.
+    unbuilt_.push_back(found->second.name);
+    return nullptr;
+}
+
+std::unique_ptr<engine::EngineAudioSource> EngineRuntimeFactory::createClipAudioSource(
+    TrackId trackId) {
+    return audioSource(trackId, engine::Section::Arrangement);
+}
+
+std::unique_ptr<engine::EngineMidiSource> EngineRuntimeFactory::createClipMidiSource(
+    TrackId trackId) {
+    return midiSource(trackId, engine::Section::Arrangement);
+}
+
+std::unique_ptr<engine::EngineAudioSource> EngineRuntimeFactory::createSessionAudioSource(
+    TrackId trackId) {
+    return audioSource(trackId, engine::Section::Session);
+}
+
+std::unique_ptr<engine::EngineMidiSource> EngineRuntimeFactory::createSessionMidiSource(
+    TrackId trackId) {
+    return midiSource(trackId, engine::Section::Session);
+}
+
+// Both sections through the handle-reading constructor, including the
+// arrangement's. The plain one is the same source over an empty handle table,
+// so taking the feed always costs a project with no session nothing and spares
+// the factory a question it would have to ask the snapshot to answer.
+std::unique_ptr<engine::EngineAudioSource> EngineRuntimeFactory::audioSource(
+    TrackId trackId, engine::Section section) {
+    if (clips_ == nullptr || streams_ == nullptr || handles_ == nullptr)
+        return nullptr;
+
+    return std::make_unique<engine::ClipAudioSource>(trackId, *clips_, *streams_, *handles_,
+                                                     section);
+}
+
+std::unique_ptr<engine::EngineMidiSource> EngineRuntimeFactory::midiSource(
+    TrackId trackId, engine::Section section) {
+    if (clips_ == nullptr || handles_ == nullptr)
+        return nullptr;
+
+    return std::make_unique<engine::ClipMidiSource>(trackId, *clips_, *handles_, section);
+}
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -41,8 +41,12 @@ std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine:
     if (found == devices_.end())
         return nullptr;
 
-    if (auto device = adapter::createEngineDevice(found->second))
+    if (auto device = adapter::createEngineDevice(found->second)) {
+        if (trace_ != nullptr)
+            return std::make_unique<TracingDevice>(std::move(device), *trace_);
+
         return device;
+    }
 
     // Said out loud once per publish rather than left as silence. A device the
     // app can build and the engine cannot is a project playing without part of

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "clip/ClipSnapshotFeed.hpp"
+#include "clip/ClipStreamFeed.hpp"
+#include "core/DeviceInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/RuntimeStateStore.hpp"
+#include "io/AudioFileReader.hpp"
+#include "launch/SessionLauncher.hpp"
+
+/**
+ * @file EngineRuntimeFactory.hpp
+ * @brief What the app answers when the engine asks for a runtime object.
+ *
+ * The engine knows a section-aware DeviceKey and a TrackId; which plugin that
+ * key is, and which formats this build can decode, are the host's business
+ * (RuntimeStateStore.hpp). This is the host's side of that split, and the only
+ * place in the app that knows both halves.
+ *
+ * Everything here runs on the publishing thread, inside a publish.
+ */
+
+namespace magda::daw::engine_host {
+
+/// Opens the files a snapshot names. The one thing the engine leaves entirely
+/// to the host: a snapshot carries paths because that is what the model has.
+class EngineFileReaders final : public engine::AudioFileReaderFactory {
+  public:
+    EngineFileReaders();
+
+    std::unique_ptr<engine::AudioFileReader> open(const std::string& path) override;
+
+  private:
+    juce::AudioFormatManager formats_;
+};
+
+/**
+ * @brief The runtime objects behind a live plan's leaf ops.
+ *
+ * Built before the session it serves, because the session takes it by
+ * reference, so the feeds it hands its sources arrive afterwards through
+ * @ref attach. Asking for a source before that returns null, which the executor
+ * reports as an unbound op rather than treating as silence.
+ */
+class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
+  public:
+    /// The feeds every source it makes will read. Once, before the first
+    /// publish; all three outlive every source bound into any plan.
+    void attach(engine::ClipSnapshotFeed& clips, engine::ClipStreamFeed& streams,
+                engine::LaunchHandleFeed& handles);
+
+    /**
+     * @brief What the model holds now, for the publish about to happen.
+     *
+     * Devices are asked for by key during publish(), and the key alone says
+     * nothing about which plugin it is. Refreshed rather than looked up live so
+     * that every device a publish creates comes from one reading of the model.
+     */
+    void setModel(const std::vector<TrackInfo>& tracks, const TrackInfo& master);
+
+    /// Devices the model names that no catalog could build, by display name.
+    /// Read after a publish; external plugins are all of them for now (#2566).
+    const std::vector<juce::String>& unbuilt() const {
+        return unbuilt_;
+    }
+
+    std::unique_ptr<engine::EngineDevice> createDevice(engine::DeviceKey key) override;
+    std::unique_ptr<engine::EngineAudioSource> createClipAudioSource(TrackId trackId) override;
+    std::unique_ptr<engine::EngineMidiSource> createClipMidiSource(TrackId trackId) override;
+    std::unique_ptr<engine::EngineAudioSource> createSessionAudioSource(TrackId trackId) override;
+    std::unique_ptr<engine::EngineMidiSource> createSessionMidiSource(TrackId trackId) override;
+
+  private:
+    std::unique_ptr<engine::EngineAudioSource> audioSource(TrackId trackId,
+                                                           engine::Section section);
+    std::unique_ptr<engine::EngineMidiSource> midiSource(TrackId trackId, engine::Section section);
+
+    engine::ClipSnapshotFeed* clips_ = nullptr;
+    engine::ClipStreamFeed* streams_ = nullptr;
+    engine::LaunchHandleFeed* handles_ = nullptr;
+
+    std::map<engine::DeviceKey, DeviceInfo> devices_;
+    std::vector<juce::String> unbuilt_;
+};
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 
+#include "EngineTrace.hpp"
 #include "clip/ClipSnapshotFeed.hpp"
 #include "clip/ClipStreamFeed.hpp"
 #include "core/DeviceInfo.hpp"
@@ -70,6 +71,13 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
         return unbuilt_;
     }
 
+    /// Record what reaches every device this makes from now on (#2568). Set
+    /// before the first publish, and only when the trace is switched on: a
+    /// device already made is not wrapped retrospectively.
+    void traceInto(EngineTrace& trace) {
+        trace_ = &trace;
+    }
+
     std::unique_ptr<engine::EngineDevice> createDevice(engine::DeviceKey key) override;
     std::unique_ptr<engine::EngineAudioSource> createClipAudioSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineMidiSource> createClipMidiSource(TrackId trackId) override;
@@ -87,6 +95,7 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
 
     std::map<engine::DeviceKey, DeviceInfo> devices_;
     std::vector<juce::String> unbuilt_;
+    EngineTrace* trace_ = nullptr;
 };
 
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineTrace.cpp
+++ b/magda/daw/engine/host/EngineTrace.cpp
@@ -47,7 +47,17 @@ bool EngineTrace::enabled() {
 }
 
 void EngineTrace::print(const juce::String& line) {
+    // Both destinations, because which one somebody is reading is not this
+    // file's business: the app installs a FileLogger, so writeToLog alone
+    // reaches magda.log and never the terminal, and stderr alone is gone when
+    // the run ends.
+    //
+    // Only when a logger is installed, though. With none, JUCE's own fallback
+    // is this same stderr, and every line would arrive twice.
     std::cerr << "[trace] " << line << std::endl;
+
+    if (juce::Logger::getCurrentLogger() != nullptr)
+        juce::Logger::writeToLog("[trace] " + line);
 }
 
 void EngineTrace::write(Entry entry) {

--- a/magda/daw/engine/host/EngineTrace.cpp
+++ b/magda/daw/engine/host/EngineTrace.cpp
@@ -1,0 +1,94 @@
+#include "EngineTrace.hpp"
+
+#include <cstdlib>
+
+namespace magda::daw::engine_host {
+
+namespace {
+
+juce::String describe(const EngineTrace::Entry& entry) {
+    juce::String line;
+    line << "[trace] block " << juce::String(entry.block) << " beat " << juce::String(entry.beat, 4)
+         << "  ";
+
+    switch (entry.kind) {
+        case EngineTrace::Kind::NoteOn:
+            line << "note-on  " << entry.note << " vel " << entry.velocity << " at sample "
+                 << entry.sample;
+            break;
+        case EngineTrace::Kind::NoteOff:
+            line << "note-off " << entry.note << " at sample " << entry.sample;
+            break;
+        case EngineTrace::Kind::Publish:
+            line << "clips published";
+            break;
+        case EngineTrace::Kind::Swap:
+            line << "plan published";
+            break;
+    }
+
+    return line;
+}
+
+}  // namespace
+
+bool EngineTrace::enabled() {
+    static const bool asked = [] {
+        const auto* value = std::getenv("MAGDA_ENGINE_TRACE_MIDI");
+        if (value == nullptr)
+            return false;
+
+        const auto flag = juce::String(value).trim().toLowerCase();
+        return flag.isNotEmpty() && flag != "0" && flag != "false" && flag != "off";
+    }();
+
+    return asked;
+}
+
+void EngineTrace::write(Entry entry) {
+    const auto at = written_.load(std::memory_order_relaxed);
+
+    if (at - read_ >= kCapacity) {
+        dropped_.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    entries_[at % kCapacity] = entry;
+    written_.store(at + 1, std::memory_order_release);
+}
+
+juce::StringArray EngineTrace::drain() {
+    juce::StringArray lines;
+
+    const auto upTo = written_.load(std::memory_order_acquire);
+    for (; read_ < upTo; ++read_)
+        lines.add(describe(entries_[read_ % kCapacity]));
+
+    if (const auto lost = dropped_.exchange(0, std::memory_order_relaxed); lost > 0)
+        lines.add("[trace] " + juce::String(lost) + " entries dropped");
+
+    return lines;
+}
+
+void TracingDevice::process(magda::engine::DeviceBlock& block) {
+    if (block.midiIn != nullptr)
+        for (const auto entry : *block.midiIn) {
+            const auto message = entry.getMessage();
+            if (!message.isNoteOnOrOff())
+                continue;
+
+            trace_.write({
+                .kind = message.isNoteOn() ? EngineTrace::Kind::NoteOn : EngineTrace::Kind::NoteOff,
+                .note = message.getNoteNumber(),
+                .velocity = message.getVelocity(),
+                .sample = entry.samplePosition,
+                .beat = block.block.beats.start,
+                .block = blocks_,
+            });
+        }
+
+    ++blocks_;
+    device_->process(block);
+}
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineTrace.cpp
+++ b/magda/daw/engine/host/EngineTrace.cpp
@@ -1,6 +1,7 @@
 #include "EngineTrace.hpp"
 
 #include <cstdlib>
+#include <iostream>
 
 namespace magda::daw::engine_host {
 
@@ -8,7 +9,7 @@ namespace {
 
 juce::String describe(const EngineTrace::Entry& entry) {
     juce::String line;
-    line << "[trace] block " << juce::String(entry.block) << " beat " << juce::String(entry.beat, 4)
+    line << "block " << juce::String(entry.block) << " beat " << juce::String(entry.beat, 4)
          << "  ";
 
     switch (entry.kind) {
@@ -45,6 +46,10 @@ bool EngineTrace::enabled() {
     return asked;
 }
 
+void EngineTrace::print(const juce::String& line) {
+    std::cerr << "[trace] " << line << std::endl;
+}
+
 void EngineTrace::write(Entry entry) {
     const auto at = written_.load(std::memory_order_relaxed);
 
@@ -65,7 +70,7 @@ juce::StringArray EngineTrace::drain() {
         lines.add(describe(entries_[read_ % kCapacity]));
 
     if (const auto lost = dropped_.exchange(0, std::memory_order_relaxed); lost > 0)
-        lines.add("[trace] " + juce::String(lost) + " entries dropped");
+        lines.add(juce::String(lost) + " entries dropped");
 
     return lines;
 }

--- a/magda/daw/engine/host/EngineTrace.hpp
+++ b/magda/daw/engine/host/EngineTrace.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <array>
+#include <atomic>
+#include <memory>
+
+#include "exec/EngineDevice.hpp"
+
+/**
+ * @file EngineTrace.hpp
+ * @brief What reached an instrument, and when the model moved under it (#2568).
+ *
+ * A note that sounds twice is a race between a publish and the block that was
+ * already rendering, and neither end of it is visible from a log line on the
+ * message thread: by the time anything could be printed the block has gone and
+ * the snapshot that produced it has been replaced.
+ *
+ * So both ends are recorded on the thread that sees them -- every note-on and
+ * note-off as it reaches the device, every publish as it happens -- into one
+ * stream, stamped with where the transport was. Reading them in order is what
+ * says whether a note sounded before or after the edit that moved it.
+ *
+ * Off unless MAGDA_ENGINE_TRACE_MIDI is set, and nothing is allocated, locked
+ * or logged on the audio thread when it is: a writer takes a slot and fills it.
+ */
+
+namespace magda::daw::engine_host {
+
+class EngineTrace {
+  public:
+    /// Whether the environment asked for this. Read once.
+    static bool enabled();
+
+    enum class Kind : std::uint8_t { NoteOn, NoteOff, Publish, Swap };
+
+    struct Entry {
+        Kind kind = Kind::NoteOn;
+        int note = 0;
+        int velocity = 0;
+        int sample = 0;
+        double beat = 0.0;
+        std::uint64_t block = 0;
+    };
+
+    /// From the audio thread, once per event. Drops rather than blocks when the
+    /// reader has fallen behind, and says how many it dropped.
+    void write(Entry entry);
+
+    /// From the message thread. Everything written since the last call, in
+    /// order, as lines for the log.
+    juce::StringArray drain();
+
+  private:
+    /// A second of dense playing at a small block size, rounded up. The reader
+    /// runs on a timer, so this only has to cover the gap between two of them.
+    static constexpr std::size_t kCapacity = 4096;
+
+    std::array<Entry, kCapacity> entries_{};
+    std::atomic<std::uint64_t> written_{0};
+    std::uint64_t read_ = 0;
+    std::atomic<std::uint64_t> dropped_{0};
+};
+
+/**
+ * @brief A device with its MIDI input recorded on the way in.
+ *
+ * Wrapping rather than reaching inside the device: what is worth knowing is
+ * what the chain delivered, and a device that decided to ignore a note still
+ * received it. Every other call forwards untouched.
+ */
+class TracingDevice final : public magda::engine::EngineDevice {
+  public:
+    TracingDevice(std::unique_ptr<EngineDevice> device, EngineTrace& trace)
+        : device_(std::move(device)), trace_(trace) {}
+
+    void prepare(const magda::engine::RenderContext& context) override {
+        device_->prepare(context);
+    }
+    void reset() override {
+        device_->reset();
+    }
+    void setMidiInputBoundBytes(int bytes) override {
+        device_->setMidiInputBoundBytes(bytes);
+    }
+    void setMidiOutputBoundBytes(int bytes) override {
+        device_->setMidiOutputBoundBytes(bytes);
+    }
+    bool forwardsMidiInput() const override {
+        return device_->forwardsMidiInput();
+    }
+    int latencySamples() const override {
+        return device_->latencySamples();
+    }
+
+    void process(magda::engine::DeviceBlock& block) override;
+
+  private:
+    std::unique_ptr<EngineDevice> device_;
+    EngineTrace& trace_;
+    std::uint64_t blocks_ = 0;
+};
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineTrace.hpp
+++ b/magda/daw/engine/host/EngineTrace.hpp
@@ -33,6 +33,15 @@ class EngineTrace {
     /// Whether the environment asked for this. Read once.
     static bool enabled();
 
+    /**
+     * @brief One line of it, in front of whoever switched it on.
+     *
+     * Deliberately not juce::Logger: the app installs a FileLogger at startup,
+     * so everything written through it lands in magda.log and nothing reaches
+     * the terminal the trace was asked for from. A trace is a console tool.
+     */
+    static void print(const juce::String& line);
+
     enum class Kind : std::uint8_t { NoteOn, NoteOff, Publish, Swap };
 
     struct Entry {

--- a/magda/daw/magda.cpp
+++ b/magda/daw/magda.cpp
@@ -3,11 +3,11 @@
 #include <memory>
 
 #include "core/LLMClientProvider.hpp"
-#include "engine/TracktionEngineWrapper.hpp"
+#include "engine/AudioEngine.hpp"
 
 // Global engine instance
 namespace {
-std::unique_ptr<magda::TracktionEngineWrapper> g_engine;
+std::unique_ptr<magda::AudioEngine> g_engine;
 }  // namespace
 
 bool magda_initialize() {
@@ -15,10 +15,12 @@ bool magda_initialize() {
     DBG("Initializing system...");
 
     try {
-        // Initialize Tracktion Engine
-        g_engine = std::make_unique<magda::TracktionEngineWrapper>();
+        // Through the factory, which is where the choice of engine is made
+        // (#2551). Naming an implementation is what makes that choice
+        // unreachable from whoever took this path.
+        g_engine = magda::createDefaultAudioEngine();
         if (!g_engine->initialize()) {
-            DBG("ERROR: Failed to initialize Tracktion Engine");
+            DBG("ERROR: Failed to initialize the audio engine");
             return false;
         }
 

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -91,7 +91,7 @@ void magdaTerminateHandler() noexcept {
 class MagdaDAWApplication : public JUCEApplication {
   private:
     std::unique_ptr<juce::FileLogger> fileLogger_;
-    std::unique_ptr<magda::TracktionEngineWrapper> daw_engine_;
+    std::unique_ptr<magda::AudioEngine> daw_engine_;
     // Lua-driven MIDI controller scripts (issue #592). Lives in the app
     // layer rather than inside TracktionEngineWrapper so the engine library
     // (magda_daw) doesn't pull magda_scripting into its link line.
@@ -296,13 +296,18 @@ class MagdaDAWApplication : public JUCEApplication {
         juce::Logger::writeToLog("finishInitialisation() entered");
 
         // 3. Initialize audio engine
-        daw_engine_ = std::make_unique<magda::TracktionEngineWrapper>();
+        //
+        // Through the factory, which is where the choice of engine is made
+        // (#2551). Naming an implementation here is what made that choice
+        // unreachable from the running app while every other site looked
+        // wired: this is the site the app actually takes.
+        daw_engine_ = magda::createDefaultAudioEngine();
 
         // Show plugin scan status on splash screen
-        daw_engine_->onPluginScanStatus = [this](const juce::String& status) {
+        daw_engine_->setPluginScanStatusCallback([this](const juce::String& status) {
             if (splashScreen_)
                 splashScreen_->setStatus(status);
-        };
+        });
 
         if (splashScreen_)
             splashScreen_->setStatus("Initializing audio engine...");
@@ -331,7 +336,7 @@ class MagdaDAWApplication : public JUCEApplication {
             // script were loaded. Hook fires on first MIDI device-list change
             // after engine init, then on every subsequent change. We only want
             // the auto-load to fire once.
-            daw_engine_->onMidiDevicesReady = [this]() {
+            daw_engine_->setMidiDevicesReadyCallback([this]() {
                 if (scriptAutoLoaded_)
                     return;
                 scriptAutoLoaded_ = true;
@@ -344,7 +349,7 @@ class MagdaDAWApplication : public JUCEApplication {
                     (luaController_ ? luaController_->currentScriptName() : juce::String{}) + "'");
                 if (!ok)
                     juce::Logger::writeToLog("[lua] No controller script loaded");
-            };
+            });
             juce::MessageManager::callAsync([this]() {
                 if (scriptAutoLoaded_ || luaController_ == nullptr)
                     return;

--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -422,16 +422,29 @@ void ClipMidiSource::expectLane(juce::MidiBuffer& out, const BlockInfo& block,
 
             expected.set(channel, note);
 
-            if (!active_.active(channel, note))
-                continue;  // nobody is holding it, and a swap does not chase
-            if (active_.owner(channel, note) == clip.clipId)
-                continue;  // already sounding, from the clip that should own it
+            if (active_.active(channel, note)) {
+                if (active_.owner(channel, note) == clip.clipId)
+                    continue;  // already sounding, from the clip that should own it
 
-            // The wrong clip is holding this pitch. Hand it over rather than
-            // leaving it: ending first keeps the receiver's count right, and
-            // striking it again is what makes the new clip's own note-off
-            // legal when it arrives instead of rejected for the wrong owner.
-            endNote(out, EventSample{0}, channel, note);
+                // The wrong clip is holding this pitch. Hand it over rather
+                // than leaving it: ending first keeps the receiver's count
+                // right, and striking it again is what makes the new clip's own
+                // note-off legal when it arrives instead of rejected for the
+                // wrong owner.
+                endNote(out, EventSample{0}, channel, note);
+            }
+
+            // Nobody is holding it, and the new snapshot says it should be
+            // sounding here: a note whose pitch was shifted while it played, or
+            // one moved so that it now covers the cursor. Struck, for the
+            // reason a locate strikes what it lands inside -- the alternative
+            // is that editing a held note silences it until the next one, which
+            // is what this did before (#2568).
+            //
+            // Only a note the swap changed can reach this: one the edit left
+            // alone is still active and owned by its own clip, and was skipped
+            // above. So an unrelated edit somewhere else in the project, which
+            // republishes the whole snapshot, re-strikes nothing.
             startNote(out, block, clip, index, from);
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -544,7 +544,8 @@ target_link_libraries(magda_tests
 )
 
 if(MAGDA_BUILD_NATIVE_ENGINE)
-    target_link_libraries(magda_tests PRIVATE magda_engine magda_engine_devices)
+    target_link_libraries(magda_tests PRIVATE magda_engine magda_engine_devices
+                          magda_engine_host)
 endif()
 
 # Include directories
@@ -811,6 +812,11 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         MgdFixture.cpp
         MgdFixtures.cpp
         engine/test_real_project_corpus_juce.cpp
+
+        # What the app hands the engine at runtime (#2551). Here rather than in
+        # magda_tests because it reads TrackManager and ClipManager, and those
+        # are the singletons a running MAGDA keeps its model in.
+        engine/test_engine_host_publish_juce.cpp
     )
 endif()
 
@@ -841,8 +847,13 @@ target_link_libraries(magda_juce_tests
 # magda_engine_devices with it (#2174): the device layer the native leg binds a
 # Device op through, so both legs run the app's own devices rather than a pair
 # written for the corpus.
+#
+# magda_engine_host because magda_daw now carries MagdaAudioEngine, which calls
+# into it (#2551). Nothing here drives the app's engine; this is the link the
+# class needs to exist at all.
 if(MAGDA_BUILD_NATIVE_ENGINE)
-    target_link_libraries(magda_juce_tests PRIVATE magda_engine magda_engine_devices)
+    target_link_libraries(magda_juce_tests PRIVATE magda_engine magda_engine_devices
+                          magda_engine_host)
 endif()
 
 # The Faust standard library is deliberately NOT staged beside this binary,

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -185,76 +185,6 @@ class ImpulseSynthDevice final : public EngineDevice {
     }
 };
 
-/// Every device in @p elements and everything nested inside them, keyed in
-/// @p segment.
-///
-/// Keyed by DeviceKey and not by DeviceId: an id is unique within a chain
-/// segment and not across them (#1899), so a map keyed by the number alone
-/// would let a post-FX device stand in for the FX device with the same one.
-/// OpKey::deviceKey() carries the segment for that reason; this has to match.
-///
-/// The walk is the model's own (ChainWalk.hpp) rather than one written here,
-/// entered with Pads::Enter. A Drum Grid's pads are chains of devices and
-/// PlanCompiler::emitPadRack() emits an op for each of them, so a walk that
-/// stopped at the grid would leave every plugin in every pad looked up and not
-/// found -- bound to a stand-in, never resolved, and reported as nothing. Two
-/// definitions of "every device in a project" is exactly the disagreement that
-/// file exists to prevent.
-void collectDevices(std::vector<magda::ChainElement>& elements,
-                    const magda::ChainNodePath& parentPath, ChainSegment segment,
-                    std::map<DeviceKey, magda::DeviceInfo*>& out) {
-    magda::chain_walk::forEachDevice(
-        elements, parentPath, magda::chain_walk::Pads::Enter,
-        [&out, segment](magda::DeviceInfo& device, const magda::ChainNodePath&) {
-            out[DeviceKey{segment, device.id}] = &device;
-        });
-}
-
-/// The same for a flat stage, whose elements are devices rather than a tree.
-///
-/// Flat means no racks; it does not mean no pads, so a device that carries them
-/// is descended into the same way.
-void collectFlatDevices(std::vector<magda::PostFxChainElement>& elements,
-                        const magda::ChainNodePath& parentPath, ChainSegment segment,
-                        std::map<DeviceKey, magda::DeviceInfo*>& out) {
-    for (auto& element : elements) {
-        out[DeviceKey{segment, element.device.id}] = &element.device;
-
-        if (!element.device.pads)
-            continue;
-
-        for (auto& pad : element.device.pads->chains)
-            collectDevices(pad.elements, parentPath, segment, out);
-    }
-}
-
-/// Every device the plan can emit an op for, by the key the op carries.
-///
-/// The master's chain is walked with the rest. It is as much of the project as
-/// any track's, the compiler emits Device ops for it, and a master left out of
-/// this map is a master limiter that silently becomes a stand-in: the case
-/// still renders, still compares, and is measuring a project without its
-/// master chain in it.
-std::map<DeviceKey, magda::DeviceInfo*> devicesIn(std::vector<TrackInfo>& tracks,
-                                                  TrackInfo& master) {
-    std::map<DeviceKey, magda::DeviceInfo*> devices;
-
-    const auto collectTrack = [&devices](TrackInfo& track) {
-        const auto trackPath = magda::ChainNodePath::trackLevel(track.id);
-        collectDevices(track.chain.fxChainElements, trackPath, ChainSegment::Fx, devices);
-        collectFlatDevices(track.chain.postFxChainElements, trackPath, ChainSegment::PostFx,
-                           devices);
-        collectFlatDevices(track.chain.mixerAnalysisElements, trackPath,
-                           ChainSegment::MixerAnalysis, devices);
-    };
-
-    for (auto& track : tracks)
-        collectTrack(track);
-
-    collectTrack(master);
-    return devices;
-}
-
 /// Whether @p device is a plugin somebody else shipped, which is the one kind
 /// this leg cannot build from a catalog and has to find on the machine.
 bool isExternalDevice(const magda::DeviceInfo& device) {
@@ -282,7 +212,7 @@ std::map<DeviceKey, std::string> resolveExternalDevices(
     const adapter::ExternalPluginServices& services) {
     std::map<DeviceKey, std::string> identities;
 
-    for (auto& [key, device] : devicesIn(tracks, master)) {
+    for (auto& [key, device] : adapter::devicesIn(tracks, master)) {
         if (!isExternalDevice(*device))
             continue;
 
@@ -346,7 +276,7 @@ std::map<DeviceKey, adapter::ExternalDeviceResult> createExternalDevices(
     const adapter::ExternalPluginServices& services) {
     std::map<DeviceKey, adapter::ExternalDeviceResult> created;
 
-    for (auto& [key, device] : devicesIn(tracks, master)) {
+    for (auto& [key, device] : adapter::devicesIn(tracks, master)) {
         if (!isExternalDevice(*device) || !reached.contains(key))
             continue;
 
@@ -586,7 +516,7 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     std::vector<std::unique_ptr<GainDevice>> gains;
     std::vector<std::unique_ptr<ImpulseSynthDevice>> synths;
 
-    const auto modelDevices = devicesIn(tracks, master);
+    const auto modelDevices = adapter::devicesIn(tracks, master);
 
     // The tracks the corpus compares MIDI for, which is the same question the
     // incumbent asks when it decides where to put a capture. Asked once, of the

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <ranges>
 
 #include "JuceTestStateGuard.hpp"
 #include "clip/ClipVoicePool.hpp"
@@ -248,7 +249,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
     }
 
     void testNoteMovedWhileRolling() {
-        beginTest("A note moved while the transport rolls sounds once, where it was moved to");
+        beginTest("A note whose pitch shifts while it sounds carries on at the new pitch");
 
         auto& trackManager = magda::TrackManager::getInstance();
         const auto trackId = trackManager.createTrack("Instrument");
@@ -259,13 +260,11 @@ class EngineHostPublishTest final : public juce::UnitTest {
 
         track->chain.fxChainElements.emplace_back(polySynth(1));
 
+        // Long enough that the edit lands well inside it.
         auto& clips = magda::ClipManager::getInstance();
         const auto clipId = clips.createMidiClipBeats(trackId, 0.0, 8.0);
-        expect(clips.addMidiNote(clipId, magda::MidiNote{.noteNumber = 60,
-                                                         .velocity = 100,
-                                                         .startBeat = 6.0,
-                                                         .lengthBeats = 1.0}),
-               "The clip holds a note");
+        clips.addMidiNote(clipId,
+                          magda::MidiNote{.noteNumber = 60, .startBeat = 2.0, .lengthBeats = 4.0});
 
         const auto& tracks = trackManager.getTracks();
         const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
@@ -289,11 +288,8 @@ class EngineHostPublishTest final : public juce::UnitTest {
 
         engine::PlanValues values;
         engine::resolvePlanValues(*plan, tracks, *master, values);
-        expect(session
-                   .publish(plan, context, engine::collectRuntimeStateIds(tracks, *master),
-                            std::move(values))
-                   .published,
-               "The plan publishes");
+        session.publish(plan, context, engine::collectRuntimeStateIds(tracks, *master),
+                        std::move(values));
 
         const auto publishClips = [&] {
             session.publishClips(
@@ -304,27 +300,23 @@ class EngineHostPublishTest final : public juce::UnitTest {
         publishClips();
         session.publishTransport({.tempo = tempo, .request = {.generation = 1, .playing = true}});
 
-        // Up to beat 2, which is well before the note and well before where it
-        // is about to be moved to.
         juce::AudioBuffer<float> output(2, context.maxBlockSize);
         const auto render = [&](int blocks) {
             for (auto block = 0; block < blocks; ++block)
                 session.process(context.maxBlockSize, output);
         };
 
-        render(86);
+        // Beat 3, which is a beat into the note.
+        render(130);
 
-        // The move the clip editor makes: one note, in place, and a republish.
         auto* clip = clips.getClip(clipId);
-        expect(clip != nullptr && clip->midiNotes.size() == 1, "One note, before the move");
         if (clip == nullptr || clip->midiNotes.size() != 1)
             return;
 
         clip->midiNotes[0].noteNumber = 64;
         publishClips();
 
-        // Past beat 4 and past where the note used to be.
-        render(258);
+        render(130);
 
         expect(factory.capture != nullptr, "The instrument slot was bound");
         if (factory.capture == nullptr)
@@ -335,7 +327,20 @@ class EngineHostPublishTest final : public juce::UnitTest {
             logMessage("note-on " + juce::String(strike.note) + " at block " +
                        juce::String(strike.block));
 
-        expect(strikes.size() == 1, "The moved note sounds once, not once per position");
+        // The old pitch, then the new one taking over where the edit landed.
+        // Before #2568 the shift ended the old pitch and struck nothing, so the
+        // rest of the note was silence.
+        expect(strikes.size() == 2, "The old pitch and then the new one");
+        if (strikes.size() != 2)
+            return;
+
+        expect(strikes[0].note == 60, "It started at the pitch it was written at");
+        expect(strikes[1].note == 64, "It carries on at the pitch it was shifted to");
+
+        const auto releases = factory.capture->releases;
+        expect(
+            std::ranges::any_of(releases, [](const auto& release) { return release.note == 60; }),
+            "The pitch it left is released rather than left hanging");
     }
 };
 

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -1,0 +1,168 @@
+#include <juce_core/juce_core.h>
+
+#include <algorithm>
+#include <memory>
+
+#include "JuceTestStateGuard.hpp"
+#include "clip/ClipVoicePool.hpp"
+#include "core/SourcePool.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanValues.hpp"
+#include "io/PrefetchThread.hpp"
+#include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/engine/host/EngineProject.hpp"
+#include "magda/daw/engine/host/EngineRuntimeFactory.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * What the app hands magda::engine at runtime (#2551).
+ *
+ * The corpus proves the engine renders what it is given; what it had never been
+ * given is the app's own model, read off the singletons a running MAGDA keeps
+ * it in. That translation is the whole of this slice, and it is the only thing
+ * here that can be wrong on its own.
+ *
+ * The device callback is deliberately not covered. It needs an open audio
+ * device, which CI does not have; everything up to it is a publish, and the
+ * publish is what these run.
+ */
+
+namespace {
+
+namespace host = magda::daw::engine_host;
+
+/// The Poly Synth as a project saves it. Every compiled synth MAGDA ships is
+/// one of these, and it is the shortest path from a note to a sound.
+magda::DeviceInfo polySynth(magda::DeviceId id) {
+    using PolySynth = magda::daw::audio::compiled::MagdaPolySynthCompiledPlugin;
+
+    magda::DeviceInfo device;
+    device.id = id;
+    device.name = "Poly Synth";
+    device.pluginId = PolySynth::xmlTypeName;
+    device.deviceType = magda::DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    device.format = magda::PluginFormat::Internal;
+    device.audioInputChannels = 0;
+    device.audioOutputChannels = 2;
+
+    const PolySynth metadata;
+    for (auto index = 0; index < metadata.parameterCount(); ++index) {
+        auto info = metadata.parameterInfo(index);
+        info.currentValue = info.defaultValue;
+        device.parameters.push_back(std::move(info));
+    }
+
+    return device;
+}
+
+class EngineHostPublishTest final : public juce::UnitTest {
+  public:
+    EngineHostPublishTest() : juce::UnitTest("Engine Host Publish Tests", "magda") {}
+
+    void runTest() override {
+        magda::test::runWithCleanJuceState([this] { testLanesSplitBySection(); });
+        magda::test::runWithCleanJuceState([this] { testMidiClipReachesAnInstrument(); });
+    }
+
+  private:
+    void testLanesSplitBySection() {
+        beginTest("Clip lanes split the model's two sections apart");
+
+        auto& clips = magda::ClipManager::getInstance();
+        const auto trackId = magda::TrackManager::getInstance().createTrack("Track");
+        const auto arrangement =
+            clips.createMidiClipBeats(trackId, 0.0, 4.0, magda::ClipView::Arrangement);
+        const auto session = clips.createMidiClipBeats(trackId, 0.0, 4.0, magda::ClipView::Session);
+
+        const auto lanes = host::clipLanesFor(magda::TrackManager::getInstance().getTracks());
+        expect(lanes.size() == 1, "One lane per track");
+        if (lanes.size() != 1)
+            return;
+
+        // A session clip is a slot positioned by scene and an arrangement clip
+        // is positioned by beat. The compiler's guard exists to catch a caller
+        // that confused them, and this is the caller deciding which is which.
+        expect(lanes[0].trackId == trackId, "The lane names its track");
+        expect(lanes[0].clips.size() == 1 && lanes[0].clips[0].id == arrangement,
+               "The arrangement clip is on the timeline");
+        expect(lanes[0].session.size() == 1 && lanes[0].session[0].id == session,
+               "The session clip is a slot");
+    }
+
+    void testMidiClipReachesAnInstrument() {
+        beginTest("A MIDI clip on an instrument track sounds through the app's model");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Instrument");
+        auto* track = trackManager.getTrack(trackId);
+        expect(track != nullptr, "The track exists");
+        if (track == nullptr)
+            return;
+
+        track->chain.fxChainElements.emplace_back(polySynth(1));
+
+        auto& clips = magda::ClipManager::getInstance();
+        const auto clipId = clips.createMidiClipBeats(trackId, 0.0, 4.0);
+        expect(clips.addMidiNote(clipId, magda::MidiNote{.noteNumber = 60,
+                                                         .velocity = 100,
+                                                         .startBeat = 0.0,
+                                                         .lengthBeats = 2.0}),
+               "The clip holds a note");
+
+        const auto& tracks = trackManager.getTracks();
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(master != nullptr, "The master exists");
+        if (master == nullptr)
+            return;
+
+        const magda::engine::RenderContext context{.sampleRate = 44100.0, .maxBlockSize = 512};
+        const auto tempo = host::tempoMapAt(120.0, 4, 4);
+
+        host::EngineFileReaders files;
+        magda::engine::PrefetchThread reader(false);
+        host::EngineRuntimeFactory factory;
+        factory.setModel(tracks, *master);
+
+        magda::engine::ClipVoicePool voices(files, reader, context);
+        magda::engine::EngineSession session(factory, nullptr, &voices);
+        factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed());
+
+        const auto plan = std::make_shared<const magda::engine::RenderPlan>(
+            magda::engine::compileRenderPlan(tracks, *master));
+
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(*plan, tracks, *master, values);
+
+        const auto published =
+            session.publish(plan, context, magda::engine::collectRuntimeStateIds(tracks, *master),
+                            std::move(values));
+        expect(published.published, "The plan the app compiled is one the engine takes");
+        expect(factory.unbuilt().empty(), "Every device the model names was built");
+
+        session.publishClips(
+            std::make_shared<const magda::engine::ClipSnapshot>(magda::engine::compileClipSnapshot(
+                host::clipLanesFor(tracks), host::clipSources(), tempo)));
+        session.publishTransport({.tempo = tempo, .request = {.generation = 1, .playing = true}});
+
+        // Half a second at 120 bpm, which is well inside the note.
+        juce::AudioBuffer<float> output(2, context.maxBlockSize);
+        auto peak = 0.0f;
+        for (auto block = 0; block < 43; ++block) {
+            session.process(context.maxBlockSize, output);
+            peak = std::max(peak, output.getMagnitude(0, context.maxBlockSize));
+        }
+
+        // What this pins is the translation rather than the level: a project
+        // the app was holding reached a compiled instrument and came back as
+        // audio.
+        expect(peak > 0.0f, "The note made a sound");
+    }
+};
+
+EngineHostPublishTest engineHostPublishTest;
+
+}  // namespace

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -6,6 +6,7 @@
 #include "JuceTestStateGuard.hpp"
 #include "clip/ClipVoicePool.hpp"
 #include "core/SourcePool.hpp"
+#include "exec/EngineDevice.hpp"
 #include "exec/EngineSession.hpp"
 #include "exec/PlanValues.hpp"
 #include "io/PrefetchThread.hpp"
@@ -14,6 +15,7 @@
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/engine/host/EngineProject.hpp"
 #include "magda/daw/engine/host/EngineRuntimeFactory.hpp"
+#include "magda/daw/engine/host/EngineTrace.hpp"
 #include "plan/PlanCompiler.hpp"
 
 /**
@@ -32,6 +34,7 @@
 namespace {
 
 namespace host = magda::daw::engine_host;
+namespace engine = magda::engine;
 
 /// The Poly Synth as a project saves it. Every compiled synth MAGDA ships is
 /// one of these, and it is the shortest path from a note to a sound.
@@ -59,6 +62,77 @@ magda::DeviceInfo polySynth(magda::DeviceId id) {
     return device;
 }
 
+/// Every note-on that reached the instrument, and when. Bound in the
+/// instrument's place so that what is measured is what the chain delivered
+/// rather than what came out of a synth.
+class NoteCapture final : public engine::EngineDevice {
+  public:
+    struct Strike {
+        int note = 0;
+        int block = 0;
+    };
+
+    void process(engine::DeviceBlock& block) override {
+        if (block.midiIn != nullptr)
+            for (const auto entry : *block.midiIn) {
+                const auto message = entry.getMessage();
+                if (message.isNoteOn())
+                    strikes.push_back({message.getNoteNumber(), blocks});
+                else if (message.isNoteOff())
+                    releases.push_back({message.getNoteNumber(), blocks});
+            }
+
+        block.audio.clear();
+        ++blocks;
+    }
+
+    std::vector<Strike> strikes;
+    std::vector<Strike> releases;
+    int blocks = 0;
+};
+
+/// The app's own factory with the instrument swapped for a capture, so a case
+/// can say which notes reached the chain rather than inferring it from a level.
+class CapturingFactory final : public engine::RuntimeStateFactory {
+  public:
+    void attach(engine::ClipSnapshotFeed& clips, engine::ClipStreamFeed& streams,
+                engine::LaunchHandleFeed& handles) {
+        inner_.attach(clips, streams, handles);
+    }
+
+    void setModel(const std::vector<magda::TrackInfo>& tracks, const magda::TrackInfo& master) {
+        inner_.setModel(tracks, master);
+    }
+
+    std::unique_ptr<engine::EngineDevice> createDevice(engine::DeviceKey) override {
+        auto device = std::make_unique<NoteCapture>();
+        capture = device.get();
+        return device;
+    }
+
+    std::unique_ptr<engine::EngineAudioSource> createClipAudioSource(
+        magda::TrackId trackId) override {
+        return inner_.createClipAudioSource(trackId);
+    }
+    std::unique_ptr<engine::EngineMidiSource> createClipMidiSource(
+        magda::TrackId trackId) override {
+        return inner_.createClipMidiSource(trackId);
+    }
+    std::unique_ptr<engine::EngineAudioSource> createSessionAudioSource(
+        magda::TrackId trackId) override {
+        return inner_.createSessionAudioSource(trackId);
+    }
+    std::unique_ptr<engine::EngineMidiSource> createSessionMidiSource(
+        magda::TrackId trackId) override {
+        return inner_.createSessionMidiSource(trackId);
+    }
+
+    NoteCapture* capture = nullptr;
+
+  private:
+    host::EngineRuntimeFactory inner_;
+};
+
 class EngineHostPublishTest final : public juce::UnitTest {
   public:
     EngineHostPublishTest() : juce::UnitTest("Engine Host Publish Tests", "magda") {}
@@ -66,6 +140,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
     void runTest() override {
         magda::test::runWithCleanJuceState([this] { testLanesSplitBySection(); });
         magda::test::runWithCleanJuceState([this] { testMidiClipReachesAnInstrument(); });
+        magda::test::runWithCleanJuceState([this] { testNoteMovedWhileRolling(); });
     }
 
   private:
@@ -127,6 +202,12 @@ class EngineHostPublishTest final : public juce::UnitTest {
         host::EngineRuntimeFactory factory;
         factory.setModel(tracks, *master);
 
+        // The instrumentation the app runs under MAGDA_ENGINE_TRACE_MIDI
+        // (#2568), exercised here so a trace nobody can read is a failing test
+        // rather than an empty log in the middle of a repro.
+        host::EngineTrace trace;
+        factory.traceInto(trace);
+
         magda::engine::ClipVoicePool voices(files, reader, context);
         magda::engine::EngineSession session(factory, nullptr, &voices);
         factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed());
@@ -160,6 +241,101 @@ class EngineHostPublishTest final : public juce::UnitTest {
         // the app was holding reached a compiled instrument and came back as
         // audio.
         expect(peak > 0.0f, "The note made a sound");
+
+        const auto traced = trace.drain();
+        expect(traced.joinIntoString("\n").contains("note-on  60"),
+               "The trace records the note-on that reached the instrument");
+    }
+
+    void testNoteMovedWhileRolling() {
+        beginTest("A note moved while the transport rolls sounds once, where it was moved to");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Instrument");
+        auto* track = trackManager.getTrack(trackId);
+        expect(track != nullptr, "The track exists");
+        if (track == nullptr)
+            return;
+
+        track->chain.fxChainElements.emplace_back(polySynth(1));
+
+        auto& clips = magda::ClipManager::getInstance();
+        const auto clipId = clips.createMidiClipBeats(trackId, 0.0, 8.0);
+        expect(clips.addMidiNote(clipId, magda::MidiNote{.noteNumber = 60,
+                                                         .velocity = 100,
+                                                         .startBeat = 6.0,
+                                                         .lengthBeats = 1.0}),
+               "The clip holds a note");
+
+        const auto& tracks = trackManager.getTracks();
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        if (master == nullptr)
+            return;
+
+        const engine::RenderContext context{.sampleRate = 44100.0, .maxBlockSize = 512};
+        const auto tempo = host::tempoMapAt(120.0, 4, 4);
+
+        host::EngineFileReaders files;
+        engine::PrefetchThread reader(false);
+        CapturingFactory factory;
+        factory.setModel(tracks, *master);
+
+        engine::ClipVoicePool voices(files, reader, context);
+        engine::EngineSession session(factory, nullptr, &voices);
+        factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed());
+
+        const auto plan =
+            std::make_shared<const engine::RenderPlan>(engine::compileRenderPlan(tracks, *master));
+
+        engine::PlanValues values;
+        engine::resolvePlanValues(*plan, tracks, *master, values);
+        expect(session
+                   .publish(plan, context, engine::collectRuntimeStateIds(tracks, *master),
+                            std::move(values))
+                   .published,
+               "The plan publishes");
+
+        const auto publishClips = [&] {
+            session.publishClips(
+                std::make_shared<const engine::ClipSnapshot>(engine::compileClipSnapshot(
+                    host::clipLanesFor(tracks), host::clipSources(), tempo)));
+        };
+
+        publishClips();
+        session.publishTransport({.tempo = tempo, .request = {.generation = 1, .playing = true}});
+
+        // Up to beat 2, which is well before the note and well before where it
+        // is about to be moved to.
+        juce::AudioBuffer<float> output(2, context.maxBlockSize);
+        const auto render = [&](int blocks) {
+            for (auto block = 0; block < blocks; ++block)
+                session.process(context.maxBlockSize, output);
+        };
+
+        render(86);
+
+        // The move the clip editor makes: one note, in place, and a republish.
+        auto* clip = clips.getClip(clipId);
+        expect(clip != nullptr && clip->midiNotes.size() == 1, "One note, before the move");
+        if (clip == nullptr || clip->midiNotes.size() != 1)
+            return;
+
+        clip->midiNotes[0].noteNumber = 64;
+        publishClips();
+
+        // Past beat 4 and past where the note used to be.
+        render(258);
+
+        expect(factory.capture != nullptr, "The instrument slot was bound");
+        if (factory.capture == nullptr)
+            return;
+
+        const auto& strikes = factory.capture->strikes;
+        for (const auto& strike : strikes)
+            logMessage("note-on " + juce::String(strike.note) + " at block " +
+                       juce::String(strike.block));
+
+        expect(strikes.size() == 1, "The moved note sounds once, not once per position");
     }
 };
 

--- a/tests/project/test_project_serialization.cpp
+++ b/tests/project/test_project_serialization.cpp
@@ -223,6 +223,8 @@ class ProjectBoundaryResetEngine : public AudioEngine {
     }
 
     void setDevicesLoadingCallback(std::function<void(bool, const juce::String&)>) override {}
+    void setPluginScanStatusCallback(std::function<void(const juce::String&)>) override {}
+    void setMidiDevicesReadyCallback(std::function<void()>) override {}
 
     AudioBridge* getAudioBridge() override {
         return nullptr;


### PR DESCRIPTION
Slice 1 of #1897, second half. #2558 built the seam; this puts an `EngineSession` on the audio device.

## What it does

`EngineHost` (`magda/daw/engine/host/`) owns the session, renders it from an `AudioIODeviceCallback` on the device the fork opened, and republishes the project as the model moves:

| Model change | What is published |
| --- | --- |
| tracks, devices | a plan, with values resolved against it |
| fader, pan, mute, a device parameter | values against the plan already playing |
| a clip added, moved, edited | a clip snapshot |

All three coalesce through one async update, so a drag publishes once rather than per mouse move. A sample-rate or block-size change takes the callback off the device, remakes the session and puts it back — the one moment a prepared object can be re-prepared safely.

`EngineProject` is the model→engine translation (clip lanes, pooled sources, a flat tempo map). `EngineRuntimeFactory` is the host's side of `RuntimeStateFactory`: devices through `createEngineDevice`, clip and session sources against the session's feeds.

## MagdaAudioEngine's transport half stops forwarding

Play, stop, locate, the position, and the two callbacks `TimelineController` drives are the engine's now. Tempo, time signature and loop reach **both** engines, because the fork still owns the tempo model that every beats↔seconds conversion in the UI reads through `tempoMap()` — #2554 is where that authority moves.

That also makes the class's own file comment true for the first time. It claimed the fork's transport is never started; forwarding `play()` had been starting it.

## Linking

`magda_engine` was a dark target — nothing in the app linked it. `magda_engine_host` is its own static library for the reason `magda_engine_devices` is one: it names both the engine's headers and the app's, and `magda_daw` sees neither of the engine's. What crosses that line is one pimpl'd header.

`MagdaAudioEngine.cpp` moves onto the `MAGDA_BUILD_NATIVE_ENGINE` switch: without the engine there is no second engine to choose, and a class whose whole reason to exist was not built is not worth compiling as a shell that forwards everything.

## Not in this slice, and saying so

Recording (#2553) and external plugins (#2566, filed) name themselves once in the log rather than answering silently. Every block renders on the audio thread alone; a render pool is one argument away and not a question to answer in the change that first made a sound.

## Naming

Everything here is `Engine*` rather than `Native*`. `MagdaAudioEngine::requested` already wrote the rule down — *"native" only means anything while there is something for it to be native against, and after #2557 there will not be.*

## Verification

- The corpus's 74 cases are byte-identical: `devicesIn()` moved to `EngineDeviceFactory` so the corpus and the app walk a project's devices once rather than twice, and that is the change that could have moved them.
- `make test` (3883 passed, 13 skipped) and `make test-juce` are green.
- New: `tests/engine/test_engine_host_publish_juce.cpp` builds a Poly Synth track and a MIDI clip in `TrackManager`/`ClipManager`, publishes them, and asserts the note made a sound. Verified negatively — break `clipLanesFor` and both cases fail.

**Still needs a person.** The device callback needs an open audio device, which is exactly what #2551's verification section is about: run with `MAGDA_AUDIO_ENGINE=magda`, load a project with a MIDI clip on an instrument, and press play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN