### PR TITLE
External plugins on the native engine's live path

### DIFF
--- a/docs/architecture/engine-device-factory.md
+++ b/docs/architecture/engine-device-factory.md
@@ -100,3 +100,14 @@ had a preset applied, or been deleted — so:
 
 `isInstalledExternalPlugin` only says a scanned plugin exists to try loading
 — it does not promise instantiation will succeed.
+
+### Who drives the asynchronous path
+
+`magda/daw/engine/host/ExternalPluginLoader.hpp` (#2566). It owns the
+`PluginAssignments` a live session registers against, starts one load per slot,
+and answers `EngineRuntimeFactory::createDevice` with null until the instance
+arrives — which is why the store re-asks rather than remembering a null
+(`RuntimeStateStore.hpp`). Completion writes `resolvedDevice` and
+`restoredParameters` into the model on the message thread and publishes a plan
+compiled from it: the corpus's two-pass compile, spread over as many message
+loop turns as the plugins take.

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -16,21 +16,18 @@ namespace magda::daw::audio::engine_adapter {
 
 namespace {
 
-/// One descent, written once, over whichever constness the caller has.
+/// One track's descent, written once, over whichever constness the caller has.
 ///
 /// A flat stage's elements are devices rather than a tree, so it is walked
 /// directly; flat does not mean padless, and a device carrying pads is
 /// descended into the same way a tree device is.
-template <typename Tracks, typename Master> auto collectDevices(Tracks& tracks, Master& master) {
-    using Device =
-        std::conditional_t<std::is_const_v<Master>, const magda::DeviceInfo, magda::DeviceInfo>;
-    std::map<magda::engine::DeviceKey, Device*> devices;
-
+template <typename Track, typename Devices>
+void collectTrackDevices(Track& track, Devices& devices) {
     const auto collectTree = [&devices](auto& elements, const magda::ChainNodePath& parentPath,
                                         magda::ChainSegment segment) {
         magda::chain_walk::forEachDevice(
             elements, parentPath, magda::chain_walk::Pads::Enter,
-            [&devices, segment](Device& device, const magda::ChainNodePath&) {
+            [&devices, segment](auto& device, const magda::ChainNodePath&) {
                 devices[magda::engine::DeviceKey{segment, device.id}] = &device;
             });
     };
@@ -49,17 +46,21 @@ template <typename Tracks, typename Master> auto collectDevices(Tracks& tracks, 
         }
     };
 
-    const auto collectTrack = [&](auto& track) {
-        const auto path = magda::ChainNodePath::trackLevel(track.id);
-        collectTree(track.chain.fxChainElements, path, magda::ChainSegment::Fx);
-        collectFlat(track.chain.postFxChainElements, path, magda::ChainSegment::PostFx);
-        collectFlat(track.chain.mixerAnalysisElements, path, magda::ChainSegment::MixerAnalysis);
-    };
+    const auto path = magda::ChainNodePath::trackLevel(track.id);
+    collectTree(track.chain.fxChainElements, path, magda::ChainSegment::Fx);
+    collectFlat(track.chain.postFxChainElements, path, magda::ChainSegment::PostFx);
+    collectFlat(track.chain.mixerAnalysisElements, path, magda::ChainSegment::MixerAnalysis);
+}
+
+template <typename Tracks, typename Master> auto collectDevices(Tracks& tracks, Master& master) {
+    using Device =
+        std::conditional_t<std::is_const_v<Master>, const magda::DeviceInfo, magda::DeviceInfo>;
+    std::map<magda::engine::DeviceKey, Device*> devices;
 
     for (auto& track : tracks)
-        collectTrack(track);
+        collectTrackDevices(track, devices);
 
-    collectTrack(master);
+    collectTrackDevices(master, devices);
     return devices;
 }
 
@@ -134,6 +135,16 @@ std::map<magda::engine::DeviceKey, magda::DeviceInfo*> devicesIn(
 std::map<magda::engine::DeviceKey, const magda::DeviceInfo*> devicesIn(
     const std::vector<magda::TrackInfo>& tracks, const magda::TrackInfo& master) {
     return collectDevices(tracks, master);
+}
+
+std::map<magda::engine::DeviceKey, magda::DeviceInfo*> devicesIn(magda::TrackInfo& track) {
+    std::map<magda::engine::DeviceKey, magda::DeviceInfo*> devices;
+    collectTrackDevices(track, devices);
+    return devices;
+}
+
+bool isExternalDevice(const magda::DeviceInfo& device) {
+    return device.format != magda::PluginFormat::Internal;
 }
 
 /// enableAllBuses first, at the same point the fork does it

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp
@@ -56,6 +56,18 @@ std::map<magda::engine::DeviceKey, magda::DeviceInfo*> devicesIn(
 std::map<magda::engine::DeviceKey, const magda::DeviceInfo*> devicesIn(
     const std::vector<magda::TrackInfo>& tracks, const magda::TrackInfo& master);
 
+/// @overload For a host that holds the model one track at a time, which is
+/// what TrackManager hands out mutably.
+std::map<magda::engine::DeviceKey, magda::DeviceInfo*> devicesIn(magda::TrackInfo& track);
+
+/**
+ * @brief Whether @p device is a plugin somebody else shipped.
+ *
+ * The one kind neither catalog can build: it is a file on this machine, found
+ * through the scan and loaded, rather than a class this build contains.
+ */
+bool isExternalDevice(const magda::DeviceInfo& device);
+
 /**
  * @brief The engine device @p device names, or null when nothing can make one.
  *

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -53,10 +53,12 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         host/EngineProject.cpp
         host/EngineRuntimeFactory.cpp
         host/EngineTrace.cpp
+        host/ExternalPluginLoader.cpp
         host/EngineHost.hpp
         host/EngineProject.hpp
         host/EngineRuntimeFactory.hpp
         host/EngineTrace.hpp
+        host/ExternalPluginLoader.hpp
     )
     add_library(magda::engine_host ALIAS magda_engine_host)
 

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -15,6 +15,7 @@ MagdaAudioEngine::MagdaAudioEngine(AudioEngineOptions options) {
     // starts a plugin scan. The CLI is such a caller.
     auto wrapper = std::make_unique<TracktionEngineWrapper>();
     wrapper->setForceHeadless(options.headless);
+    fork_ = wrapper.get();
     tracktion_ = std::move(wrapper);
 
     // Here rather than in initialize(), so that everything below can ask it
@@ -42,6 +43,10 @@ MagdaAudioEngine::~MagdaAudioEngine() = default;
 bool MagdaAudioEngine::initialize() {
     if (!tracktion_->initialize())
         return false;
+
+    // Before the device, so the first publish can already load the plugins a
+    // project names rather than going without them until the second (#2566).
+    host_->setPluginServices(fork_->getPluginFormatManager(), fork_->getKnownPluginList());
 
     // After the fork, because the device is its to open: the settings UI, the
     // channel lists and the driver choice are all still on that side, and two

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -8,6 +8,10 @@ namespace magda::daw::engine_host {
 class EngineHost;
 }
 
+namespace magda {
+class TracktionEngineWrapper;
+}
+
 /**
  * @file MagdaAudioEngine.hpp
  * @brief The app's second AudioEngine, backed by magda::engine (#2551).
@@ -188,6 +192,11 @@ class MagdaAudioEngine final : public AudioEngine {
     /// The half of the interface that is not an engine question. See the file
     /// comment: this goes away with #2554.
     std::unique_ptr<AudioEngine> tracktion_;
+
+    /// The same object as itself. The plugin scan and the formats that can open
+    /// a plugin are the plugin manager's, and AudioEngine exposes neither
+    /// (#2566); a pointer rather than a cast so the ownership stays above.
+    TracktionEngineWrapper* fork_ = nullptr;
 
     /// What actually renders. Declared after the fork so it is destroyed
     /// first: the device it has a callback on is the fork's, and the fork

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -404,6 +404,15 @@ class TracktionEngineWrapper : public AudioEngine,
      */
     juce::KnownPluginList& getKnownPluginList();
     const juce::KnownPluginList& getKnownPluginList() const;
+
+    /**
+     * @brief The formats this build can open a plugin with.
+     *
+     * The plugin manager's own, handed to magda::engine so it can create the
+     * plugins a plan names (#2566); getKnownPluginList() is the other half of
+     * the same question.
+     */
+    juce::AudioPluginFormatManager& getPluginFormatManager();
     juce::Array<juce::PluginDescription> getKnownPluginTypes() const override;
     void addPluginListChangeListener(juce::ChangeListener* listener) override;
     void removePluginListChangeListener(juce::ChangeListener* listener) override;

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -315,6 +315,10 @@ const juce::KnownPluginList& TracktionEngineWrapper::getKnownPluginList() const 
     return engine_->getPluginManager().knownPluginList;
 }
 
+juce::AudioPluginFormatManager& TracktionEngineWrapper::getPluginFormatManager() {
+    return engine_->getPluginManager().pluginFormatManager;
+}
+
 juce::Array<juce::PluginDescription> TracktionEngineWrapper::getKnownPluginTypes() const {
     return getKnownPluginList().getTypes();
 }

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -6,12 +6,15 @@
 #include <atomic>
 #include <ranges>
 
+#include "../../audio/plugin_manager/ExternalPluginState.hpp"
+#include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/TrackManager.hpp"
 #include "EngineProject.hpp"
 #include "EngineRuntimeFactory.hpp"
 #include "EngineTrace.hpp"
+#include "ExternalPluginLoader.hpp"
 #include "clip/ClipSnapshotCompiler.hpp"
 #include "clip/ClipVoicePool.hpp"
 #include "exec/EngineSession.hpp"
@@ -20,6 +23,8 @@
 #include "plan/PlanCompiler.hpp"
 
 namespace magda::daw::engine_host {
+
+namespace adapter = magda::daw::audio::engine_adapter;
 
 namespace {
 
@@ -47,7 +52,14 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                                 private juce::Timer,
                                 private TrackManagerListener,
                                 private ClipManagerListener {
-    Impl() {
+    Impl()
+        : loader_([this](engine::DeviceKey key) { return modelDevice(key); },
+                  [this](engine::DeviceKey key, const DeviceInfo& resolved,
+                         const std::vector<RestoredParameter>& restored) {
+                      applyLoadedDevice(key, resolved, restored);
+                  }) {
+        factory_.loadExternalsWith(loader_);
+
         if (!EngineTrace::enabled())
             return;
 
@@ -97,8 +109,9 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
             std::ranges::count(plan.ops, engine::OpKind::ClipMidi, &engine::PlanOp::kind);
 
         EngineTrace::print("plan: " + juce::String(devices) + " device ops (" +
-                           juce::String(static_cast<int>(unbuilt_.size())) + " unbuilt), " +
-                           juce::String(midi) + " clip-midi ops, " +
+                           juce::String(static_cast<int>(unbuilt_.size())) + " unbuilt, " +
+                           juce::String(static_cast<int>(factory_.loadingExternals())) +
+                           " loading), " + juce::String(midi) + " clip-midi ops, " +
                            juce::String(rendered_.load(std::memory_order_relaxed)) +
                            " callbacks so far");
     }
@@ -308,6 +321,10 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         context_ = context;
         scratch_.setSize(kChannels, context.maxBlockSize);
 
+        // What a plugin is created at. Everything the store held has gone with
+        // the session, so the publish below asks for each of them again.
+        loader_.setContext(context);
+
         voices_ = std::make_unique<engine::ClipVoicePool>(files_, reader_, context);
         voiceThread_ = std::make_unique<engine::ClipVoiceThread>(*voices_);
 
@@ -396,10 +413,63 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                                          automation.getClips());
     }
 
+    /**
+     * @brief The model's own DeviceInfo at @p key, or null.
+     *
+     * Read when it is asked for rather than from the publish's copy: a plugin
+     * load takes seconds, and what the model holds when one finishes is what
+     * its state has to be restored onto. Per track because TrackManager hands
+     * out mutable tracks but not a mutable project.
+     */
+    DeviceInfo* modelDevice(engine::DeviceKey key) {
+        DeviceInfo* found = nullptr;
+
+        TrackManager::getInstance().forEachTrackIncludingMaster([&found, key](TrackInfo& track) {
+            if (found != nullptr)
+                return;
+
+            const auto devices = adapter::devicesIn(track);
+            if (const auto device = devices.find(key); device != devices.end())
+                found = device->second;
+        });
+
+        return found;
+    }
+
+    /**
+     * @brief Write what a plugin turned out to be back into the model.
+     *
+     * The engine never corrects the model itself, so this is where an external
+     * plugin's real bus widths, MIDI capability and role arrive, and the plan
+     * compiles port widths and MIDI edges from exactly those. The parameters
+     * come with them because a chunk is allowed to disagree with the array a
+     * project saved, and everything downstream reads the model.
+     */
+    void applyLoadedDevice(engine::DeviceKey key, const DeviceInfo& resolved,
+                           const std::vector<RestoredParameter>& restored) {
+        auto* device = modelDevice(key);
+        if (device == nullptr)
+            return;
+
+        *device = resolved;
+        applyRestoredParameters(*device, restored);
+
+        // Only the main FX chain has a path to tell: findDevicePath searches
+        // that segment alone, and a DeviceId is section-local, so a post-FX id
+        // would find whichever unrelated device holds the same number there.
+        if (key.segment == ChainSegment::Fx)
+            if (const auto path = TrackManager::getInstance().findDevicePath(key.deviceId);
+                path.isValid())
+                TrackManager::getInstance().notifyDevicePropertyChanged(path);
+
+        // Last, so the plan that binds the loader's instance is compiled from
+        // the model as corrected above.
+        wantPlan();
+    }
+
     /// Devices the model names and no catalog could build. Named rather than
-    /// counted, and only when the set changes: every external plugin is one of
-    /// these until the plugin scan reaches this factory (#2566), and a line per
-    /// publish would bury everything else.
+    /// counted, and only when the set changes: a line per publish would bury
+    /// everything else.
     void reportUnbuiltDevices() {
         if (factory_.unbuilt() == unbuilt_)
             return;
@@ -412,6 +482,11 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     EngineFileReaders files_;
     engine::PrefetchThread reader_;
     EngineRuntimeFactory factory_;
+
+    /// After the factory, so it is destroyed first: a load still in flight is
+    /// gated on the assignment table this owns, and a table that has gone is a
+    /// load nobody is waiting for.
+    ExternalPluginLoader loader_;
 
     juce::AudioDeviceManager* devices_ = nullptr;
     engine::RenderContext context_{};
@@ -456,6 +531,11 @@ EngineHost::~EngineHost() = default;
 
 void EngineHost::start(juce::AudioDeviceManager& devices) {
     impl_->start(devices);
+}
+
+void EngineHost::setPluginServices(juce::AudioPluginFormatManager& formats,
+                                   const juce::KnownPluginList& knownPlugins) {
+    impl_->loader_.setServices(&formats, &knownPlugins);
 }
 
 void EngineHost::stop() {

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -4,7 +4,9 @@
 
 namespace juce {
 class AudioDeviceManager;
-}
+class AudioPluginFormatManager;
+class KnownPluginList;
+}  // namespace juce
 
 /**
  * @file EngineHost.hpp
@@ -44,6 +46,17 @@ class EngineHost {
      * with no plan renders anyway (EngineSession::process).
      */
     void start(juce::AudioDeviceManager& devices);
+
+    /**
+     * @brief Where external plugins are found and what can open them (#2566).
+     *
+     * Both are the fork's, which owns the scan; the engine has no catalog of
+     * its own for a plugin that is a file on a machine rather than a class this
+     * build contains. Before @ref start, or the first publish goes without
+     * them.
+     */
+    void setPluginServices(juce::AudioPluginFormatManager& formats,
+                           const juce::KnownPluginList& knownPlugins);
 
     /// Take the callback back off the device and stop following the model.
     /// Safe to call twice, and called by the destructor.

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -34,6 +34,12 @@ void EngineRuntimeFactory::setModel(const std::vector<TrackInfo>& tracks, const 
 
     for (const auto& [key, device] : adapter::devicesIn(tracks, master))
         devices_.emplace(key, *device);
+
+    // Before anything is asked for, so a device that has changed plugin since
+    // the last publish has expired the load it had in flight by the time this
+    // publish asks for one.
+    if (externals_ != nullptr)
+        externals_->syncAssignments(devices_);
 }
 
 std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine::DeviceKey key) {
@@ -41,18 +47,30 @@ std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine:
     if (found == devices_.end())
         return nullptr;
 
-    if (auto device = adapter::createEngineDevice(found->second)) {
-        if (trace_ != nullptr)
-            return std::make_unique<TracingDevice>(std::move(device), *trace_);
+    // An external plugin is a file on this machine rather than a class either
+    // catalog holds, so it is not built here and not counted as unbuilt when it
+    // is not ready: the loader answers null while it opens one, and the store
+    // asks again at the next publish (#2566).
+    if (adapter::isExternalDevice(found->second))
+        return traced(externals_ != nullptr ? externals_->device(key, found->second) : nullptr);
 
-        return device;
-    }
+    if (auto device = adapter::createEngineDevice(found->second))
+        return traced(std::move(device));
 
     // Said out loud once per publish rather than left as silence. A device the
     // app can build and the engine cannot is a project playing without part of
     // itself, and the executor's own "unbound op" says a key, not a name.
     unbuilt_.push_back(found->second.name);
     return nullptr;
+}
+
+/// Every device this factory hands over, through the trace when one is on.
+std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::traced(
+    std::unique_ptr<engine::EngineDevice> device) {
+    if (device == nullptr || trace_ == nullptr)
+        return device;
+
+    return std::make_unique<TracingDevice>(std::move(device), *trace_);
 }
 
 std::unique_ptr<engine::EngineAudioSource> EngineRuntimeFactory::createClipAudioSource(

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "EngineTrace.hpp"
+#include "ExternalPluginLoader.hpp"
 #include "clip/ClipSnapshotFeed.hpp"
 #include "clip/ClipStreamFeed.hpp"
 #include "core/DeviceInfo.hpp"
@@ -66,9 +67,23 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
     void setModel(const std::vector<TrackInfo>& tracks, const TrackInfo& master);
 
     /// Devices the model names that no catalog could build, by display name.
-    /// Read after a publish; external plugins are all of them for now (#2566).
+    /// Read after a publish. External plugins are not among them: they are not
+    /// built from a catalog at all (#2566).
     const std::vector<juce::String>& unbuilt() const {
         return unbuilt_;
+    }
+
+    /// Where external plugins come from. Set before the first publish; without
+    /// one every external device in the project stays unbound, which the
+    /// executor renders as a pass-through.
+    void loadExternalsWith(ExternalPluginLoader& loader) {
+        externals_ = &loader;
+    }
+
+    /// External plugins this publish is still waiting on. A plan with unbound
+    /// device ops and none of these is a plan whose plugins are not coming.
+    std::size_t loadingExternals() const {
+        return externals_ != nullptr ? externals_->loading() : 0;
     }
 
     /// Record what reaches every device this makes from now on (#2568). Set
@@ -85,6 +100,7 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
     std::unique_ptr<engine::EngineMidiSource> createSessionMidiSource(TrackId trackId) override;
 
   private:
+    std::unique_ptr<engine::EngineDevice> traced(std::unique_ptr<engine::EngineDevice> device);
     std::unique_ptr<engine::EngineAudioSource> audioSource(TrackId trackId,
                                                            engine::Section section);
     std::unique_ptr<engine::EngineMidiSource> midiSource(TrackId trackId, engine::Section section);
@@ -96,6 +112,7 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
     std::map<engine::DeviceKey, DeviceInfo> devices_;
     std::vector<juce::String> unbuilt_;
     EngineTrace* trace_ = nullptr;
+    ExternalPluginLoader* externals_ = nullptr;
 };
 
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/ExternalPluginLoader.cpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.cpp
@@ -62,6 +62,11 @@ void ExternalPluginLoader::syncAssignments(const std::map<engine::DeviceKey, Dev
             continue;
         }
 
+        // Every load in flight against the old assignment expires here. A
+        // device the store has already bound does not: it keeps what it holds
+        // for a key it is asked for again, so this reaches a slot whose plugin
+        // changed while its first load was still running, and #2572 is the
+        // other half.
         assignments_.replaceAssignment(key);
         found->second = Slot{.identity = std::move(identity), .generation = ++generation_};
     }

--- a/magda/daw/engine/host/ExternalPluginLoader.cpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.cpp
@@ -1,0 +1,164 @@
+#include "ExternalPluginLoader.hpp"
+
+#include <set>
+#include <utility>
+
+namespace magda::daw::engine_host {
+
+namespace adapter = magda::daw::audio::engine_adapter;
+
+namespace {
+
+/// Which plugin a slot is asking for, as one string to compare.
+///
+/// Every field the scan is searched by (ExternalPluginLookup.hpp), and nothing
+/// a load is entitled to correct: the role, the bus widths and the MIDI flags
+/// are all written back from the live instance, and including one of them would
+/// make a successful load look like the slot asking for something else.
+juce::String pluginIdentityOf(const DeviceInfo& device) {
+    return device.uniqueId + "|" + device.fileOrIdentifier + "|" + device.name + "|" +
+           device.manufacturer + "|" + device.getFormatString();
+}
+
+}  // namespace
+
+ExternalPluginLoader::ExternalPluginLoader(adapter::CurrentDeviceLookup currentDevice,
+                                           Loaded loaded)
+    : currentDevice_(std::move(currentDevice)), loaded_(std::move(loaded)) {}
+
+void ExternalPluginLoader::setServices(juce::AudioPluginFormatManager* formats,
+                                       const juce::KnownPluginList* knownPlugins) {
+    services_.formats = formats;
+    services_.knownPlugins = knownPlugins;
+}
+
+void ExternalPluginLoader::setContext(const engine::RenderContext& context) {
+    services_.context = context;
+}
+
+void ExternalPluginLoader::syncAssignments(const std::map<engine::DeviceKey, DeviceInfo>& devices) {
+    std::set<engine::DeviceKey> named;
+
+    for (const auto& [key, device] : devices) {
+        if (!adapter::isExternalDevice(device))
+            continue;
+
+        named.insert(key);
+        auto identity = pluginIdentityOf(device);
+        const auto found = slots_.find(key);
+
+        if (found == slots_.end()) {
+            assignments_.ensureAssignment(key);
+            slots_.emplace(key, Slot{.identity = std::move(identity), .generation = ++generation_});
+            continue;
+        }
+
+        if (found->second.identity == identity) {
+            // The ordinary case, and the one that must not mint an assignment:
+            // a plan compiled again for an unrelated edit re-registers every
+            // device in the project, and a new assignment each time would
+            // expire the load that is still running.
+            assignments_.ensureAssignment(key);
+            continue;
+        }
+
+        assignments_.replaceAssignment(key);
+        found->second = Slot{.identity = std::move(identity), .generation = ++generation_};
+    }
+
+    for (auto slot = slots_.begin(); slot != slots_.end();) {
+        if (named.contains(slot->first)) {
+            ++slot;
+            continue;
+        }
+
+        assignments_.release(slot->first);
+        slot = slots_.erase(slot);
+    }
+}
+
+std::unique_ptr<engine::EngineDevice> ExternalPluginLoader::device(engine::DeviceKey key,
+                                                                   const DeviceInfo& model) {
+    auto found = slots_.find(key);
+
+    // Nothing registered this key, so a load started for it would be refused at
+    // completion anyway (PluginAssignments.hpp). Only reachable if a plan names
+    // a device the publish's own model did not.
+    if (found == slots_.end())
+        return nullptr;
+
+    if (found->second.instance != nullptr)
+        return std::exchange(found->second.instance, nullptr);
+
+    if (found->second.pending || found->second.spent)
+        return nullptr;
+
+    found->second.pending = true;
+    const auto resolved = adapter::createEngineExternalDeviceAsync(
+        model, key, services_, /*offlineRender=*/false, assignments_, currentDevice_,
+        [this, key, generation = found->second.generation](adapter::ExternalDeviceResult result) {
+            complete(key, generation, std::move(result));
+        });
+
+    // Asked again, because a format that answered without deferring has already
+    // run complete() by here -- which is also how a resolution failure arrives.
+    found = slots_.find(key);
+    if (found == slots_.end())
+        return nullptr;
+
+    // A plugin the scan has never heard of has spent nothing, and a scan
+    // finishing is exactly what changes the answer. So it is asked again at the
+    // next publish, which costs a walk of the known list; anything that got as
+    // far as instantiating is left spent.
+    if (!resolved)
+        found->second.spent = false;
+
+    return std::exchange(found->second.instance, nullptr);
+}
+
+std::size_t ExternalPluginLoader::held() const {
+    std::size_t held = 0;
+    for (const auto& [key, slot] : slots_)
+        held += slot.instance != nullptr ? 1 : 0;
+
+    return held;
+}
+
+std::size_t ExternalPluginLoader::loading() const {
+    std::size_t loading = 0;
+    for (const auto& [key, slot] : slots_)
+        loading += slot.pending ? 1 : 0;
+
+    return loading;
+}
+
+void ExternalPluginLoader::complete(engine::DeviceKey key, std::uint64_t generation,
+                                    adapter::ExternalDeviceResult result) {
+    const auto found = slots_.find(key);
+
+    // The load was started against an assignment this slot no longer holds, or
+    // against a slot that has gone. completeExternalPluginLoad() has already
+    // refused it on the same grounds; this is the loader's own bookkeeping
+    // declining to write a stale answer over the one it is waiting for.
+    if (found == slots_.end() || found->second.generation != generation)
+        return;
+
+    auto& slot = found->second;
+    slot.pending = false;
+
+    if (result.device == nullptr) {
+        slot.spent = true;
+
+        if (!std::exchange(slot.reported, true))
+            juce::Logger::writeToLog("[engine] " + result.failure);
+
+        return;
+    }
+
+    slot.instance = std::move(result.device);
+    juce::Logger::writeToLog("[engine] loaded \"" + result.resolvedDevice->name + "\"");
+
+    loaded_(key, *result.resolvedDevice, result.restoredParameters);
+}
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/ExternalPluginLoader.hpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
+
+/**
+ * @file ExternalPluginLoader.hpp
+ * @brief The plugins a live plan names, loaded while the project keeps playing (#2566).
+ *
+ * A Device op is an identity, and for an external plugin turning it into
+ * something that renders means finding a file on this machine and asking a
+ * third party to open it, which takes seconds. A session cannot wait for that:
+ * the publish that asks runs on the message thread, and a project of ten
+ * plugins opened one after another is a frozen window.
+ *
+ * So a load is started and the op is left unbound, which the executor already
+ * renders as a pass-through. When the instance arrives, the model is corrected
+ * from what the plugin turned out to be and the plan is compiled again. That is
+ * the same two-pass shape the corpus runs in one go
+ * (tests/NullDiffNativeLeg.cpp), spread over as many message-loop turns as the
+ * plugins take.
+ *
+ * Message thread only, which is where a publish and JUCE's own load completion
+ * both run.
+ */
+
+namespace magda::daw::engine_host {
+
+class ExternalPluginLoader final {
+  public:
+    /**
+     * @brief What an instance turned out to be, for the model to record.
+     *
+     * @p resolved is the device as the live plugin describes it -- bus widths,
+     * MIDI capability, role -- and @p restored what it holds after its own
+     * saved state went back on. The host writes both and publishes a plan
+     * compiled from the result.
+     */
+    using Loaded = std::function<void(engine::DeviceKey key, const DeviceInfo& resolved,
+                                      const std::vector<magda::RestoredParameter>& restored)>;
+
+    /// @p currentDevice is read at completion rather than captured at request
+    /// time, so a slow load cannot clobber an edit made while it ran.
+    ExternalPluginLoader(audio::engine_adapter::CurrentDeviceLookup currentDevice, Loaded loaded);
+
+    ExternalPluginLoader(const ExternalPluginLoader&) = delete;
+    ExternalPluginLoader& operator=(const ExternalPluginLoader&) = delete;
+
+    /// Where plugins are found and what can open them. Both are the fork's,
+    /// which owns the scan; without them nothing external loads at all.
+    void setServices(juce::AudioPluginFormatManager* formats,
+                     const juce::KnownPluginList* knownPlugins);
+
+    /// What an instance is created at. The session's, and it changes only with
+    /// the audio device.
+    void setContext(const engine::RenderContext& context);
+
+    /**
+     * @brief Register what @p devices says is live, before anything is asked for.
+     *
+     * The identity boundary's own bookkeeping (PluginAssignments.hpp): a slot
+     * still holding the plugin it held keeps its assignment, so a load in
+     * flight stays wanted; a slot now naming a different plugin gets a new one,
+     * which expires every load outstanding against the old.
+     *
+     * Once per publish, from EngineRuntimeFactory::setModel.
+     */
+    void syncAssignments(const std::map<engine::DeviceKey, DeviceInfo>& devices);
+
+    /**
+     * @brief The instance for @p key, or nothing yet.
+     *
+     * Starts a load for a slot that has none and returns null, which the store
+     * asks about again at the next publish. Null is also the answer while a
+     * load is running and for one that has already failed.
+     */
+    std::unique_ptr<engine::EngineDevice> device(engine::DeviceKey key, const DeviceInfo& model);
+
+    /// How many plugins are loaded and waiting to be bound. For tests.
+    std::size_t held() const;
+
+    /// How many are still opening. What tells a plan whose plugins have not
+    /// arrived yet from one whose plugins are never coming.
+    std::size_t loading() const;
+
+  private:
+    /// One slot's whole state: which plugin it asks for, which assignment that
+    /// is, and where its load has got to.
+    struct Slot {
+        juce::String identity;
+        std::uint64_t generation = 0;
+
+        bool pending = false;
+
+        /// The load ran and did not produce an instance, so it is not run
+        /// again: a plugin that failed to open takes seconds to fail again, and
+        /// a publish per edit would spend them for the rest of the session.
+        bool spent = false;
+
+        /// Whether the failure has been said. Kept across a retry so a plugin
+        /// the scan cannot find is named once rather than once per publish.
+        bool reported = false;
+
+        std::unique_ptr<engine::EngineDevice> instance;
+    };
+
+    void complete(engine::DeviceKey key, std::uint64_t generation,
+                  audio::engine_adapter::ExternalDeviceResult result);
+
+    audio::engine_adapter::CurrentDeviceLookup currentDevice_;
+    Loaded loaded_;
+
+    audio::engine_adapter::ExternalPluginServices services_;
+    audio::engine_adapter::PluginAssignments assignments_;
+
+    std::map<engine::DeviceKey, Slot> slots_;
+
+    /// Never reused, so a completion can tell the assignment it was started
+    /// against from the one holding the key now -- including a key released and
+    /// registered again, which starts a fresh slot.
+    std::uint64_t generation_ = 0;
+};
+
+}  // namespace magda::daw::engine_host

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -185,12 +185,6 @@ class ImpulseSynthDevice final : public EngineDevice {
     }
 };
 
-/// Whether @p device is a plugin somebody else shipped, which is the one kind
-/// this leg cannot build from a catalog and has to find on the machine.
-bool isExternalDevice(const magda::DeviceInfo& device) {
-    return device.format != magda::PluginFormat::Internal;
-}
-
 /**
  * @brief Correct every external device against the scan, before the plan reads it.
  *
@@ -213,7 +207,7 @@ std::map<DeviceKey, std::string> resolveExternalDevices(
     std::map<DeviceKey, std::string> identities;
 
     for (auto& [key, device] : adapter::devicesIn(tracks, master)) {
-        if (!isExternalDevice(*device))
+        if (!adapter::isExternalDevice(*device))
             continue;
 
         auto resolved = adapter::resolveEngineExternalPlugin(*device, services);
@@ -277,7 +271,7 @@ std::map<DeviceKey, adapter::ExternalDeviceResult> createExternalDevices(
     std::map<DeviceKey, adapter::ExternalDeviceResult> created;
 
     for (auto& [key, device] : adapter::devicesIn(tracks, master)) {
-        if (!isExternalDevice(*device) || !reached.contains(key))
+        if (!adapter::isExternalDevice(*device) || !reached.contains(key))
             continue;
 
         // Built for an offline render, which is what this leg is; see the
@@ -619,7 +613,7 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
                     break;
                 }
 
-                if (model != nullptr && isExternalDevice(*model)) {
+                if (model != nullptr && adapter::isExternalDevice(*model)) {
                     // Already made, above, because the plan was compiled from
                     // what the instance turned out to be rather than from what
                     // the project guessed. This binds that instance; a second

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -25,6 +25,8 @@
 #include "magda/daw/audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "magda/daw/audio/plugins/engine/EngineExternalDevice.hpp"
 #include "magda/daw/audio/plugins/engine/PluginAssignments.hpp"
+#include "magda/daw/engine/host/EngineRuntimeFactory.hpp"
+#include "magda/daw/engine/host/ExternalPluginLoader.hpp"
 #include "param/ParamBlock.hpp"
 #include "transport/TempoMap.hpp"
 
@@ -49,6 +51,7 @@
 namespace {
 
 namespace adapter = magda::daw::audio::engine_adapter;
+namespace host = magda::daw::engine_host;
 
 /**
  * @brief One parameter of the stub, automatable or not.
@@ -638,6 +641,14 @@ juce::PluginDescription descriptionFor(const magda::DeviceInfo& device) {
 /// The key a device holds while these tests keep it in the main FX section.
 magda::engine::DeviceKey keyFor(const magda::DeviceInfo& device) {
     return {magda::ChainSegment::Fx, device.id};
+}
+
+/// Run the message loop until every queued plugin load has been delivered.
+/// JUCE stores a completion and runs it a turn or more later, so a test that
+/// read the answer straight after asking would read it before it was written.
+void dispatchPendingLoads() {
+    for (int attempts = 0; attempts < 20; ++attempts)
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
 }
 
 /// Read a plugin and write what it holds into @p device, which is what a caller
@@ -3164,4 +3175,204 @@ TEST_CASE("The dry signal survives a plugin that produced nothing usable",
 
     CHECK(block.buffer.getSample(0, 0) == Catch::Approx(0.25f));
     CHECK(block.buffer.getSample(0, 1) == Catch::Approx(0.25f));
+}
+
+// =============================================================================
+// The live path (#2566)
+// =============================================================================
+//
+// Everything above is the adapter answering one question about one plugin. This
+// is the loader driving it for a session: a publish asks for a device, gets
+// nothing while the plugin opens, and asks again at the next one. What these
+// cases are about is the gap between those two publishes, which is where a
+// project can be edited.
+
+namespace {
+
+/// One external device, the plugin the scan matched it to, and the formats that
+/// can open it. The fixture every case below starts from.
+struct LiveSlot {
+    magda::DeviceInfo model = externalDevice();
+    juce::KnownPluginList known;
+    juce::AudioPluginFormatManager formats;
+
+    LiveSlot() {
+        model.fileOrIdentifier = "stub.plugin";
+        formats.addFormat(std::make_unique<StubFormat>());
+    }
+
+    /// Put @p device's plugin in the scan's results, which is what the loader
+    /// searches. Defaults to this slot's own.
+    void install() {
+        install(model);
+    }
+
+    void install(const magda::DeviceInfo& device) {
+        auto installed = descriptionFor(device);
+        installed.pluginFormatName = "StubFormat";
+        installed.fileOrIdentifier = device.fileOrIdentifier;
+        known.addType(installed);
+    }
+
+    magda::engine::DeviceKey key() const {
+        return keyFor(model);
+    }
+};
+
+}  // namespace
+
+TEST_CASE("An external plugin a live plan names is loaded and handed over",
+          "[engine][external][host]") {
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    LiveSlot slot;
+    slot.install();
+
+    std::optional<magda::DeviceInfo> published;
+    host::ExternalPluginLoader loader(
+        [&slot](magda::engine::DeviceKey) { return &slot.model; },
+        [&published](magda::engine::DeviceKey, const magda::DeviceInfo& resolved,
+                     const std::vector<magda::RestoredParameter>&) { published = resolved; });
+
+    loader.setServices(&slot.formats, &slot.known);
+    loader.setContext(contextFor());
+    loader.syncAssignments({{slot.key(), slot.model}});
+
+    // The publish that asks gets nothing, which is the point: it returns to the
+    // message loop instead of waiting seconds for a plugin to open, and the op
+    // it left unbound passes audio through meanwhile.
+    CHECK(loader.device(slot.key(), slot.model) == nullptr);
+    CHECK(loader.held() == 0);
+
+    dispatchPendingLoads();
+
+    // The model is corrected before the plan that binds the instance is
+    // compiled: the widths and the MIDI edges come from what the plugin turned
+    // out to be, not from what the project guessed.
+    REQUIRE(published.has_value());
+    CHECK(published->audioOutputChannels == 2);
+    CHECK(loader.held() == 1);
+
+    CHECK(loader.device(slot.key(), slot.model) != nullptr);
+    CHECK(loader.held() == 0);
+}
+
+TEST_CASE("A slot re-registered for the same plugin keeps the load it started",
+          "[engine][external][host]") {
+    // Every publish registers every device in the project, and a project
+    // publishes on every edit. Minting a new assignment each time would expire
+    // the load still running -- so a plugin would never finish loading in a
+    // session anybody was using.
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    LiveSlot slot;
+    slot.install();
+
+    host::ExternalPluginLoader loader([&slot](magda::engine::DeviceKey) { return &slot.model; },
+                                      [](magda::engine::DeviceKey, const magda::DeviceInfo&,
+                                         const std::vector<magda::RestoredParameter>&) {});
+
+    loader.setServices(&slot.formats, &slot.known);
+    loader.setContext(contextFor());
+    loader.syncAssignments({{slot.key(), slot.model}});
+    CHECK(loader.device(slot.key(), slot.model) == nullptr);
+
+    for (int again = 0; again < 3; ++again)
+        loader.syncAssignments({{slot.key(), slot.model}});
+
+    dispatchPendingLoads();
+    CHECK(loader.device(slot.key(), slot.model) != nullptr);
+}
+
+TEST_CASE("A slot that changed plugin while loading is not published onto",
+          "[engine][external][host]") {
+    // The identity boundary, from the side that owns it. The answer arrives for
+    // a question the slot has stopped asking, and restoring it would put one
+    // plugin's state onto another.
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    LiveSlot slot;
+    slot.install();
+
+    auto replaced = slot.model;
+    replaced.name = "Another Stub";
+    replaced.fileOrIdentifier = "another.plugin";
+    slot.install(replaced);
+
+    const magda::DeviceInfo* current = &slot.model;
+    bool published = false;
+    host::ExternalPluginLoader loader(
+        [&current](magda::engine::DeviceKey) { return current; },
+        [&published](magda::engine::DeviceKey, const magda::DeviceInfo&,
+                     const std::vector<magda::RestoredParameter>&) { published = true; });
+
+    loader.setServices(&slot.formats, &slot.known);
+    loader.setContext(contextFor());
+    loader.syncAssignments({{slot.key(), slot.model}});
+    CHECK(loader.device(slot.key(), slot.model) == nullptr);
+
+    current = &replaced;
+    loader.syncAssignments({{slot.key(), replaced}});
+
+    dispatchPendingLoads();
+    CHECK_FALSE(published);
+    CHECK(loader.held() == 0);
+
+    // And the refusal does not take the slot with it. The load that failed
+    // answered the assignment before this one, so it says nothing about whether
+    // the plugin the slot now names can be opened.
+    CHECK(loader.device(slot.key(), replaced) == nullptr);
+    dispatchPendingLoads();
+
+    CHECK(loader.device(slot.key(), replaced) != nullptr);
+    CHECK(published);
+}
+
+TEST_CASE("A plugin the scan has not found yet is asked about again", "[engine][external][host]") {
+    // A session opens before the scan finishes, and a project loaded then names
+    // plugins nothing has heard of. Nothing was spent finding that out -- no
+    // instance was made -- so the next publish asks again, and the scan
+    // finishing is what changes the answer.
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    LiveSlot slot;
+
+    host::ExternalPluginLoader loader([&slot](magda::engine::DeviceKey) { return &slot.model; },
+                                      [](magda::engine::DeviceKey, const magda::DeviceInfo&,
+                                         const std::vector<magda::RestoredParameter>&) {});
+
+    loader.setServices(&slot.formats, &slot.known);
+    loader.setContext(contextFor());
+    loader.syncAssignments({{slot.key(), slot.model}});
+
+    CHECK(loader.device(slot.key(), slot.model) == nullptr);
+
+    slot.install();
+    CHECK(loader.device(slot.key(), slot.model) == nullptr);
+
+    dispatchPendingLoads();
+    CHECK(loader.device(slot.key(), slot.model) != nullptr);
+}
+
+TEST_CASE("An external device is not reported as one no catalog could build",
+          "[engine][external][host]") {
+    // Two different findings, and one used to read as the other. A device the
+    // app knows and the engine cannot build is a project rendering without part
+    // of itself; an external plugin still opening is a project about to render
+    // with all of it, and naming every one of those buried the first.
+    host::EngineRuntimeFactory factory;
+
+    magda::TrackInfo track;
+    track.id = 1;
+    track.chain.fxChainElements.emplace_back(externalDevice());
+
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+
+    factory.setModel({track}, master);
+
+    // Null, because no loader is attached: the op stays unbound, which the
+    // executor renders as a pass-through.
+    CHECK(factory.createDevice(keyFor(externalDevice())) == nullptr);
+    CHECK(factory.unbuilt().empty());
 }


### PR DESCRIPTION
Closes #2566 (close by hand — this merges to `dev/0.20.0`, not `main`).

## What was wrong

`EngineRuntimeFactory::createDevice` resolved a plan's `Device` op through the internal
and compiled-Faust catalogs alone. Every external plugin in a project was therefore named
in the log (`nothing to build "..." with`) and bound to nothing: the track rendered without
it. This was the one item on #2551's verification list that had not been started, and it is
what limited hands-on testing to projects built from internal devices.

## What this does

`magda/daw/engine/host/ExternalPluginLoader` is the host side of what #2243 built.

- A publish asks for a device; the loader starts `createEngineExternalDeviceAsync` and
  answers null. The executor already renders an unbound op as a pass-through, and
  `RuntimeStateStore` re-asks the factory rather than remembering a null, so the next
  publish picks the instance up. A project of ten plugins does not freeze the window.
- Completion writes `resolvedDevice` (real bus widths, MIDI capability, role) and
  `restoredParameters` into the model on the message thread, then publishes a plan compiled
  from it. That is the corpus's two-pass compile (`tests/NullDiffNativeLeg.cpp`) spread over
  as many message-loop turns as the plugins take.
- `CurrentDeviceLookup` reads the model when the load finishes, through the same
  `devicesIn` walk the compiler uses — a new per-track overload, since `TrackManager` hands
  out mutable tracks but not a mutable project.

The identity boundary is the loader's own bookkeeping beside the adapter's:

- A slot re-registered for the same plugin keeps its assignment. Every publish registers
  every device, and minting a new assignment each time would expire the load still running
  — repeatedly, so a plugin would never finish loading in a session anybody was using.
- A slot that changed plugin gets a new assignment, and the generation on it makes the old
  completion a no-op rather than something that marks the slot spent and blocks the plugin
  the slot now names.
- A plugin the scan has not found yet is asked about again at the next publish: nothing was
  spent finding that out, and a scan finishing is what changes the answer. Anything that got
  as far as instantiating is left spent, so a plugin that fails to open does not cost seconds
  once per edit.

Two smaller things travel with it:

- The fork's `AudioPluginFormatManager` and `KnownPluginList` reach the host through
  `MagdaAudioEngine`, which keeps the wrapper as itself: `AudioEngine` exposes neither, and
  this is a dependency #2554 deletes rather than one worth growing the interface for.
- The trace's plan line now says how many plugins are still opening, so a plan with unbound
  device ops can be told from one whose plugins are never coming.

## Tested

- Five new cases in `tests/engine/test_engine_external_device.cpp`, over a real
  `AudioPluginFormat` seam. Each of the four behaviours above was verified negatively —
  reverting the guard and watching the case fail: the generation check, `ensureAssignment`
  vs `replaceAssignment`, the not-installed retry, and the factory's routing.
- `magda_tests`: 3902 passed, 13 skipped, 0 failed.
- `magda_juce_tests`: all passed.
- Null-diff corpus: 65 ok, 9 FAIL — the same nine as an unmodified `dev/0.20.0`, checked by
  stashing this branch and rebuilding. Eight are the audio cases the previous session
  recorded as inherited; the ninth, `session.launch.sustained`, is new on dev since then and
  is filed separately.

Not hands-on tested with a real VST/AU yet — that needs a run on Luca's machine with
`MAGDA_AUDIO_ENGINE` on the native engine and a project carrying a plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN