### PR TITLE
Make the engine a setting rather than an environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,19 +194,14 @@ run-console: debug
 	@echo "🎵 Running MAGDA DAW (console mode)..."
 	"$(APP_BINARY_DEBUG)"
 
-# The native engine (#2551), until the choice becomes a setting (#2559). Console
-# mode, because that is where its diagnostics go.
-.PHONY: run-magda
-run-magda: debug
-	@echo "🎵 Running MAGDA DAW on magda::engine..."
-	MAGDA_AUDIO_ENGINE=magda "$(APP_BINARY_DEBUG)"
-
-# The same, with every note reaching a device and every publish printed in one
-# stream (#2568). For pinning down an edit-during-playback bug by ear.
-.PHONY: run-magda-trace
-run-magda-trace: debug
-	@echo "🎵 Running MAGDA DAW on magda::engine, MIDI trace on..."
-	MAGDA_AUDIO_ENGINE=magda MAGDA_ENGINE_TRACE_MIDI=1 "$(APP_BINARY_DEBUG)"
+# Every note reaching a device and every publish, printed in one stream
+# (#2568), for pinning down an edit-during-playback bug by ear. Which engine
+# runs is the setting in the audio dialog (#2559) and this does not override
+# it; the trace comes from the native engine, so it prints nothing on the fork.
+.PHONY: run-trace
+run-trace: debug
+	@echo "🎵 Running MAGDA DAW with the MIDI trace on..."
+	MAGDA_ENGINE_TRACE_MIDI=1 "$(APP_BINARY_DEBUG)"
 
 .PHONY: cli
 cli:
@@ -571,8 +566,7 @@ help:
 	@echo "Run targets:"
 	@echo "  run            - Build and run the application"
 	@echo "  run-console    - Run with console output visible"
-	@echo "  run-magda      - Run on the native engine (magda::engine)"
-	@echo "  run-magda-trace - Run on the native engine with the MIDI trace on"
+	@echo "  run-trace      - Run with the MIDI trace on (native engine only)"
 	@echo "  run-console-cpu - Run debug analyzer CPU baseline with console output"
 	@echo "  run-console-webgpu - Run debug Dawn/WebGPU analyzer POC with console output"
 	@echo "  run-console-cpu-log - Run CPU baseline and write app output to $(CPU_RUN_LOG)"

--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -373,6 +373,15 @@ the old epoch is destroyed right there, on the publishing thread. The callback n
 **Crossfade** (`plan/PlanCrossfade.hpp`) ramps the edges an edit moved. Fades are ops the
 compiler never emitted, added by a pass over its output and gone again at the next publish.
 
+**A note that is already sounding follows the edit.** Change a playing note's pitch and the
+pitch changes under your fingers, because a voice renders what the published snapshot says
+rather than what an event said when it started. The fork cannot do that: by then the note is a
+MIDI message its plugin has already been handed, and the model no longer reaches it.
+
+This is intended, and it is worth writing down because nothing would catch it being taken away.
+The null-diff corpus pins renders, and a render never edits anything mid-note, so a later pass
+chasing parity could remove this and every suite would stay green.
+
 ---
 
 ## 5. Who runs what

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -180,6 +180,7 @@ void Config::save() {
     root->setProperty("preferredAudioDevice", toJuceString(preferredAudioDevice));
     root->setProperty("preferredInputDevice", toJuceString(preferredInputDevice));
     root->setProperty("preferredOutputDevice", toJuceString(preferredOutputDevice));
+    root->setProperty("audioEngine", toJuceString(audioEngine));
     root->setProperty("preferredInputChannels", preferredInputChannels);
     root->setProperty("preferredOutputChannels", preferredOutputChannels);
 
@@ -571,6 +572,7 @@ void Config::load() {
     preferredAudioDevice = getString("preferredAudioDevice", preferredAudioDevice);
     preferredInputDevice = getString("preferredInputDevice", preferredInputDevice);
     preferredOutputDevice = getString("preferredOutputDevice", preferredOutputDevice);
+    audioEngine = getString("audioEngine", audioEngine);
     preferredInputChannels = getInt("preferredInputChannels", preferredInputChannels);
     preferredOutputChannels = getInt("preferredOutputChannels", preferredOutputChannels);
 

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -347,6 +347,17 @@ class Config {
         preferredOutputDevice = deviceName;
     }
 
+    /// Which engine renders, as the word MAGDA_AUDIO_ENGINE takes (#2559). A
+    /// word rather than the enum because core does not depend on the engine
+    /// layer and the file stores a word either way; parseAudioEngine and
+    /// settingWordFor in AudioEngineChoice.hpp are the only two conversions.
+    std::string getAudioEngine() const {
+        return audioEngine;
+    }
+    void setAudioEngine(const std::string& word) {
+        audioEngine = word;
+    }
+
     int getPreferredInputChannels() const {
         return preferredInputChannels;
     }
@@ -1601,11 +1612,12 @@ class Config {
     int bounceBitDepth = 32;  // 16, 24, 32 — default 32-bit for internal bounces
 
     // Audio device settings
-    std::string preferredAudioDevice;   // Preferred audio interface (empty = system default)
-    std::string preferredInputDevice;   // Preferred input device (empty = system default)
-    std::string preferredOutputDevice;  // Preferred output device (empty = system default)
-    int preferredInputChannels = 0;     // Preferred input channel count (0 = use device default)
-    int preferredOutputChannels = 0;    // Preferred output channel count (0 = use device default)
+    std::string preferredAudioDevice;       // Preferred audio interface (empty = system default)
+    std::string preferredInputDevice;       // Preferred input device (empty = system default)
+    std::string preferredOutputDevice;      // Preferred output device (empty = system default)
+    std::string audioEngine = "tracktion";  // Which engine renders (#2559)
+    int preferredInputChannels = 0;   // Preferred input channel count (0 = use device default)
+    int preferredOutputChannels = 0;  // Preferred output channel count (0 = use device default)
 
     // Language
     std::string language = "en";  // Language code, matches lang/<code>.json

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -15,6 +15,7 @@
 #include "../core/ParameterDetector.hpp"
 #include "../core/TempoMap.hpp"
 #include "../core/TimeTypes.hpp"
+#include "AudioEngineChoice.hpp"
 #include "AudioEngineListener.hpp"
 #include "PluginExclusions.hpp"
 
@@ -132,6 +133,14 @@ struct AudioEngineOptions {
 class AudioEngine : public AudioEngineListener {
   public:
     ~AudioEngine() override = default;
+
+    /// Which engine this is, for the about box (#2559). Asked of the engine
+    /// that was built rather than of chosenAudioEngine(), whose answer moves
+    /// the moment the setting changes and only means anything at the next
+    /// start.
+    virtual juce::String engineName() const {
+        return nameOf(AudioEngineChoice::Tracktion);
+    }
 
     // ===== Lifecycle =====
     virtual bool initialize() = 0;

--- a/magda/daw/engine/AudioEngineChoice.cpp
+++ b/magda/daw/engine/AudioEngineChoice.cpp
@@ -4,18 +4,33 @@
 
 #include <cstdlib>
 
+#include "../core/Config.hpp"
+
 namespace magda {
 
 AudioEngineChoice chosenAudioEngine() {
-    if (const auto* value = std::getenv("MAGDA_AUDIO_ENGINE")) {
-        const auto asked = juce::String(value).trim().toLowerCase();
-        if (asked == "magda")
-            return AudioEngineChoice::Magda;
-        if (asked == "tracktion")
-            return AudioEngineChoice::Tracktion;
-    }
+    // The variable on top of the setting, so "does it still happen on the other
+    // engine" is answered by one run rather than by changing somebody's
+    // preferences (#2559).
+    if (const auto* value = std::getenv("MAGDA_AUDIO_ENGINE"))
+        if (const auto asked = parseAudioEngine(value))
+            return *asked;
 
-    return AudioEngineChoice::Tracktion;
+    return parseAudioEngine(Config::getInstance().getAudioEngine())
+        .value_or(AudioEngineChoice::Tracktion);
+}
+
+const char* settingWordFor(AudioEngineChoice choice) {
+    return choice == AudioEngineChoice::Magda ? "magda" : "tracktion";
+}
+
+std::optional<AudioEngineChoice> parseAudioEngine(const juce::String& word) {
+    const auto asked = word.trim().toLowerCase();
+    if (asked == settingWordFor(AudioEngineChoice::Magda))
+        return AudioEngineChoice::Magda;
+    if (asked == settingWordFor(AudioEngineChoice::Tracktion))
+        return AudioEngineChoice::Tracktion;
+    return std::nullopt;
 }
 
 const char* nameOf(AudioEngineChoice choice) {

--- a/magda/daw/engine/AudioEngineChoice.hpp
+++ b/magda/daw/engine/AudioEngineChoice.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <juce_core/juce_core.h>
+
+#include <optional>
+
 /**
  * @file AudioEngineChoice.hpp
  * @brief Which engine renders, asked in one place (#2551).
@@ -33,5 +37,18 @@ AudioEngineChoice chosenAudioEngine();
 
 /// The choice as a word, for the one log line that says which engine ran.
 const char* nameOf(AudioEngineChoice choice);
+
+/**
+ * @brief The choice as the word the variable takes and the config file stores.
+ *
+ * Not @ref nameOf, which reads as a log line rather than as a value: a setting
+ * and an environment variable have to be the same vocabulary, so that a report
+ * quoting one is answered by typing the other (#2559).
+ */
+const char* settingWordFor(AudioEngineChoice choice);
+
+/// Nothing, rather than a default, for anything that is neither word: an unset
+/// variable and a hand-edited config file are different callers' decisions.
+std::optional<AudioEngineChoice> parseAudioEngine(const juce::String& word);
 
 }  // namespace magda

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "AudioEngine.hpp"
+#include "AudioEngineChoice.hpp"
 
 namespace magda::daw::engine_host {
 class EngineHost;
@@ -75,6 +76,10 @@ class MagdaAudioEngine final : public AudioEngine {
   public:
     explicit MagdaAudioEngine(AudioEngineOptions options);
     ~MagdaAudioEngine() override;
+
+    juce::String engineName() const override {
+        return nameOf(AudioEngineChoice::Magda);
+    }
 
     bool initialize() override;
     void shutdown() override;

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -38,6 +38,13 @@ TracktionEngineWrapper::~TracktionEngineWrapper() {
 }
 
 std::unique_ptr<AudioEngine> createDefaultAudioEngine(AudioEngineOptions options) {
+    // The setting is read before either engine exists to read it: the config is
+    // otherwise loaded inside initialize(), which runs after this call has
+    // already chosen (#2559). Loading it here rather than moving that call
+    // leaves every other caller of initialize() alone, and load() only reads
+    // the file into fields.
+    Config::getInstance().load();
+
     const auto choice = chosenAudioEngine();
 
     // Out loud, once, wherever an engine is built. Which one a session ran on

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -303,6 +303,12 @@ class MagdaDAWApplication : public JUCEApplication {
         // wired: this is the site the app actually takes.
         daw_engine_ = magda::createDefaultAudioEngine();
 
+        // Named on the splash as soon as there is one, from the engine itself
+        // rather than from the setting, which takes a restart to mean anything
+        // (#2559).
+        if (splashScreen_ && daw_engine_)
+            splashScreen_->setEngine(daw_engine_->engineName());
+
         // Show plugin scan status on splash screen
         daw_engine_->setPluginScanStatusCallback([this](const juce::String& status) {
             if (splashScreen_)

--- a/magda/daw/ui/dialogs/AboutDialog.cpp
+++ b/magda/daw/ui/dialogs/AboutDialog.cpp
@@ -3,6 +3,7 @@
 #include "BinaryData.h"
 #include "core/StringTable.hpp"
 #include "core/TechnicalText.hpp"
+#include "engine/AudioEngineChoice.hpp"
 #include "magda.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -20,7 +21,7 @@ const juce::String kConceptualMachinesCopyright("(C) 2026 Conceptual Machines");
 
 class AboutDialog::ContentComponent : public juce::Component {
   public:
-    ContentComponent() {
+    explicit ContentComponent(juce::String engineName) : engineName_(std::move(engineName)) {
         // Load the SVG logo
         if (auto xml = juce::XmlDocument::parse(
                 juce::String::fromUTF8(BinaryData::magdalisa_svg, BinaryData::magdalisa_svgSize))) {
@@ -113,11 +114,16 @@ class AboutDialog::ContentComponent : public juce::Component {
         g.drawText("Multi-Agent Digital Audio", bounds.removeFromTop(24),
                    juce::Justification::centred);
 
-        // Version
+        // Version, and the engine beside it only where it is not the default
+        // one: a report from somebody running the native engine says which, and
+        // every other about box reads as it always did (#2559).
+        auto versionText = tr("about.version_prefix") + MAGDA_VERSION;
+        if (engineName_.isNotEmpty() && engineName_ != nameOf(AudioEngineChoice::Tracktion))
+            versionText << " (" << engineName_ << ")";
+
         g.setFont(fm.getUIFont(12.0f));
         g.setColour(DarkTheme::getColour(DarkTheme::TEXT_DIM));
-        g.drawText(tr("about.version_prefix") + MAGDA_VERSION, bounds.removeFromTop(20),
-                   juce::Justification::centred);
+        g.drawText(versionText, bounds.removeFromTop(20), juce::Justification::centred);
 
         // Credits line
         bounds.removeFromTop(10);
@@ -243,6 +249,7 @@ class AboutDialog::ContentComponent : public juce::Component {
     }
 
   private:
+    const juce::String engineName_;
     std::unique_ptr<juce::Drawable> logo_;
     std::unique_ptr<juce::Drawable> conceptualMachinesBadge_;
     std::unique_ptr<juce::Drawable> teLogo_;
@@ -256,11 +263,11 @@ class AboutDialog::ContentComponent : public juce::Component {
 // AboutDialog
 // =============================================================================
 
-AboutDialog::AboutDialog()
+AboutDialog::AboutDialog(juce::String engineName)
     : DialogWindow(tr("dialogs.about")
                        .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Magda)),
                    DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND), true) {
-    setContentOwned(new ContentComponent(), true);
+    setContentOwned(new ContentComponent(std::move(engineName)), true);
     setUsingNativeTitleBar(false);
     setResizable(false, false);
     centreWithSize(getWidth(), getHeight());
@@ -271,8 +278,8 @@ void AboutDialog::closeButtonPressed() {
     delete this;
 }
 
-void AboutDialog::show() {
-    auto* dialog = new AboutDialog();
+void AboutDialog::show(juce::String engineName) {
+    auto* dialog = new AboutDialog(std::move(engineName));
     dialog->setVisible(true);
     dialog->toFront(true);
 }

--- a/magda/daw/ui/dialogs/AboutDialog.hpp
+++ b/magda/daw/ui/dialogs/AboutDialog.hpp
@@ -6,10 +6,12 @@ namespace magda {
 
 class AboutDialog : public juce::DialogWindow {
   public:
-    AboutDialog();
+    /// @param engineName what the running engine calls itself, shown beside the
+    ///        version only where it is not the default one (#2559).
+    explicit AboutDialog(juce::String engineName = {});
 
     void closeButtonPressed() override;
-    static void show();
+    static void show(juce::String engineName = {});
 
   private:
     class ContentComponent;

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
@@ -1,13 +1,31 @@
 #include "AudioSettingsDialog.hpp"
 
+#include <cstdlib>
+
 #include "../../audio/AudioDriverUtils.hpp"
 #include "../../core/Config.hpp"
 #include "../../engine/AudioEngine.hpp"
+#include "../../engine/AudioEngineChoice.hpp"
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
 
 namespace magda {
+
+namespace {
+
+/// A JUCE item id of zero means "nothing selected", so the engine ids are the
+/// enum shifted by one rather than the enum itself (#2559).
+int engineItemId(AudioEngineChoice choice) {
+    return static_cast<int>(choice) + 1;
+}
+
+AudioEngineChoice engineForItemId(int itemId) {
+    return itemId == engineItemId(AudioEngineChoice::Magda) ? AudioEngineChoice::Magda
+                                                            : AudioEngineChoice::Tracktion;
+}
+
+}  // namespace
 
 namespace {
 
@@ -383,6 +401,33 @@ AudioSettingsDialog::AudioSettingsDialog(AudioEngine* audioEngine)
     setAsPreferredCheckbox_.setToggleState(inputMatches && outputMatches,
                                            juce::dontSendNotification);
 
+    // Which engine renders. An audio-device-level choice, so it sits with the
+    // devices rather than in a preferences pane of its own (#2559).
+    engineLabel_.setText("Audio Engine:", juce::dontSendNotification);
+    engineLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
+    addAndMakeVisible(engineLabel_);
+
+    engineComboBox_.addItem("Tracktion Engine", engineItemId(AudioEngineChoice::Tracktion));
+    engineComboBox_.addItem("MAGDA Engine (beta)", engineItemId(AudioEngineChoice::Magda));
+    engineComboBox_.setSelectedId(
+        engineItemId(
+            parseAudioEngine(config.getAudioEngine()).value_or(AudioEngineChoice::Tracktion)),
+        juce::dontSendNotification);
+    engineComboBox_.onChange = [this]() { onAudioEngineSelected(); };
+    addAndMakeVisible(engineComboBox_);
+
+    // Said rather than implied. The engine is chosen once on the way up, and
+    // swapping one under a loaded project with open plugin editors is not a
+    // thing to do quietly for a setting used twice.
+    const auto* engineOverride = std::getenv("MAGDA_AUDIO_ENGINE");
+    engineRestartLabel_.setText(engineOverride != nullptr
+                                    ? "MAGDA_AUDIO_ENGINE overrides this for the current run"
+                                    : "Takes effect after a restart",
+                                juce::dontSendNotification);
+    engineRestartLabel_.setFont(FontManager::getInstance().getUIFont(12.0f));
+    engineRestartLabel_.setColour(juce::Label::textColourId, juce::Colours::white.withAlpha(0.72f));
+    addAndMakeVisible(engineRestartLabel_);
+
     // Create the device selector component (MIDI only, no audio device selection)
     deviceSelector_ = std::make_unique<juce::AudioDeviceSelectorComponent>(
         *deviceManager_,
@@ -513,6 +558,15 @@ void AudioSettingsDialog::resized() {
 
     // "Set as preferred" checkbox
     setAsPreferredCheckbox_.setBounds(bounds.removeFromTop(24));
+    bounds.removeFromTop(5);  // spacing
+
+    // Engine choice, with its restart note beside it rather than under it
+    auto engineArea = bounds.removeFromTop(28);
+    engineLabel_.setBounds(engineArea.removeFromLeft(120));
+    engineArea.removeFromLeft(10);  // spacing
+    engineComboBox_.setBounds(engineArea.removeFromLeft(220));
+    engineArea.removeFromLeft(10);  // spacing
+    engineRestartLabel_.setBounds(engineArea);
     bounds.removeFromTop(15);  // spacing
 
     // Close button at bottom
@@ -839,6 +893,12 @@ void AudioSettingsDialog::savePreferencesIfNeeded() {
     DBG("Saved preferred devices: Input=" << preferredInputDevice << " (" << inputChannelCount
                                           << " ch), Output=" << preferredOutputDevice << " ("
                                           << outputChannelCount << " ch)");
+}
+
+void AudioSettingsDialog::onAudioEngineSelected() {
+    auto& config = magda::Config::getInstance();
+    config.setAudioEngine(settingWordFor(engineForItemId(engineComboBox_.getSelectedId())));
+    config.save();
 }
 
 void AudioSettingsDialog::showDialog(juce::Component* parent, AudioEngine* audioEngine) {

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
@@ -82,6 +82,7 @@ class AudioSettingsDialog : public juce::Component,
     void onOutputDeviceSelected();
     void enableAllChannelsOnCurrentDevice();
     void savePreferencesIfNeeded();
+    void onAudioEngineSelected();
 
     std::unique_ptr<juce::AudioDeviceSelectorComponent> deviceSelector_;
     std::unique_ptr<CustomChannelSelector> inputChannelSelector_;
@@ -95,6 +96,12 @@ class AudioSettingsDialog : public juce::Component,
     juce::ProgressBar deviceRefreshSpinner_;
     juce::Label deviceRefreshLabel_;
     juce::ToggleButton setAsPreferredCheckbox_;
+
+    // Which engine renders. Here because it is an audio-device-level choice and
+    // this is where a user already comes to change one (#2559).
+    juce::Label engineLabel_;
+    juce::ComboBox engineComboBox_;
+    juce::Label engineRestartLabel_;
 
     juce::TextButton closeButton_;
     juce::Label deviceNameLabel_;

--- a/magda/daw/ui/dialogs/SplashScreen.cpp
+++ b/magda/daw/ui/dialogs/SplashScreen.cpp
@@ -2,6 +2,7 @@
 
 #include "BinaryData.h"
 #include "core/StringTable.hpp"
+#include "engine/AudioEngineChoice.hpp"
 #include "magda.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -105,11 +106,16 @@ class SplashScreen::ContentComponent : public juce::Component {
         g.drawText("Multi-Agent Digital Audio", bounds.removeFromTop(24),
                    juce::Justification::centred);
 
-        // Version
+        // Version, and the engine beside it once there is one and it is not the
+        // default: a report from the native engine says so from the first
+        // thing on screen, and every other splash reads as it always did.
+        auto versionText = tr("splash.version_prefix") + MAGDA_VERSION;
+        if (engineName_.isNotEmpty() && engineName_ != nameOf(AudioEngineChoice::Tracktion))
+            versionText << " (" << engineName_ << ")";
+
         g.setFont(fm.getUIFont(12.0f));
         g.setColour(DarkTheme::getColour(DarkTheme::TEXT_DIM));
-        g.drawText(tr("splash.version_prefix") + MAGDA_VERSION, bounds.removeFromTop(20),
-                   juce::Justification::centred);
+        g.drawText(versionText, bounds.removeFromTop(20), juce::Justification::centred);
 
         // Status text
         bounds.removeFromTop(4);
@@ -212,6 +218,11 @@ class SplashScreen::ContentComponent : public juce::Component {
         repaint();
     }
 
+    void setEngine(const juce::String& engineName) {
+        engineName_ = engineName;
+        repaint();
+    }
+
     void mouseDown(const juce::MouseEvent& e) override {
         if (badgeBounds_.contains(e.getPosition()))
             kConceptualMachinesUrl.launchInDefaultBrowser();
@@ -225,6 +236,7 @@ class SplashScreen::ContentComponent : public juce::Component {
     std::unique_ptr<juce::Drawable> faustLogo_;
     juce::Rectangle<int> badgeBounds_;
     juce::String statusText_;
+    juce::String engineName_;
 };
 
 // =============================================================================
@@ -249,6 +261,11 @@ void SplashScreen::lookAndFeelChanged() {
 
 void SplashScreen::dismiss() {
     setVisible(false);
+}
+
+void SplashScreen::setEngine(const juce::String& engineName) {
+    if (auto* content = dynamic_cast<ContentComponent*>(getContentComponent()))
+        content->setEngine(engineName);
 }
 
 void SplashScreen::setStatus(const juce::String& text) {

--- a/magda/daw/ui/dialogs/SplashScreen.hpp
+++ b/magda/daw/ui/dialogs/SplashScreen.hpp
@@ -20,6 +20,11 @@ class SplashScreen : public juce::DocumentWindow {
     void dismiss();
     void setStatus(const juce::String& text);
 
+    /// Name the engine beside the version, once it has been built (#2559).
+    /// Called with what the engine calls itself, so the splash reports the one
+    /// that is running rather than the one the setting currently names.
+    void setEngine(const juce::String& engineName);
+
     static std::unique_ptr<SplashScreen> create();
 
   private:

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -972,7 +972,10 @@ void MainWindow::setupMenuCallbacks() {
         });
     };
 
-    callbacks.onAbout = []() { AboutDialog::show(); };
+    callbacks.onAbout = [this]() {
+        auto* engine = mainComponent ? mainComponent->getAudioEngine() : nullptr;
+        AboutDialog::show(engine != nullptr ? engine->engineName() : juce::String());
+    };
 
     // Settings menu callbacks
     callbacks.onControllerSettings = [this]() { ControllersDialog::showDialog(this); };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,6 +181,9 @@ set(TEST_SOURCES
     TestConfigRedirect.cpp
     project/test_config_path_redirect.cpp
     # Keyboard clip nudging (#1957)
+    # Which engine a run comes up on (#2559): the variable, the setting, and the
+    # order between them.
+    engine/test_audio_engine_choice.cpp
     clips/test_clip_nudge.cpp
     # The MPE pitch glide's curve (#2198): the shape the piano roll draws, the
     # compiler compiles and the Tracktion bridge hands over, and the inverse the

--- a/tests/engine/test_audio_engine_choice.cpp
+++ b/tests/engine/test_audio_engine_choice.cpp
@@ -1,0 +1,146 @@
+// Which engine a run comes up on (#2559). Three inputs decide it - the
+// environment variable, the setting, and the default - and the order between
+// them is the whole contract: a bug report asking "does it still happen on the
+// other engine" is answered by one run rather than by editing preferences.
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+
+#include "magda/daw/core/Config.hpp"
+#include "magda/daw/engine/AudioEngineChoice.hpp"
+
+using magda::AudioEngineChoice;
+using magda::chosenAudioEngine;
+using magda::Config;
+using magda::parseAudioEngine;
+using magda::settingWordFor;
+
+namespace {
+
+/// The variable, set and put back. Windows has no setenv, and _putenv_s with an
+/// empty value is how it removes one.
+class ScopedEngineVariable {
+  public:
+    explicit ScopedEngineVariable(const char* value) {
+        if (const auto* previous = std::getenv(kName))
+            previous_ = previous;
+        set(value);
+    }
+
+    ~ScopedEngineVariable() {
+        set(previous_.isEmpty() ? nullptr : previous_.toRawUTF8());
+    }
+
+  private:
+    static void set(const char* value) {
+#if JUCE_WINDOWS
+        _putenv_s(kName, value != nullptr ? value : "");
+#else
+        if (value != nullptr)
+            setenv(kName, value, 1);
+        else
+            unsetenv(kName);
+#endif
+    }
+
+    static constexpr const char* kName = "MAGDA_AUDIO_ENGINE";
+    juce::String previous_;
+};
+
+/// The setting, restored the same way: the singleton outlives one test case.
+class ScopedEngineSetting {
+  public:
+    explicit ScopedEngineSetting(AudioEngineChoice choice)
+        : previous_(Config::getInstance().getAudioEngine()) {
+        Config::getInstance().setAudioEngine(settingWordFor(choice));
+    }
+
+    ~ScopedEngineSetting() {
+        Config::getInstance().setAudioEngine(previous_);
+    }
+
+  private:
+    std::string previous_;
+};
+
+}  // namespace
+
+TEST_CASE("The engine's name is the wire format both sides read", "[engine][engine-choice]") {
+    CHECK(parseAudioEngine("magda") == AudioEngineChoice::Magda);
+    CHECK(parseAudioEngine("tracktion") == AudioEngineChoice::Tracktion);
+
+    // The variable is typed by hand, so it is trimmed and case-folded.
+    CHECK(parseAudioEngine("  MAGDA  ") == AudioEngineChoice::Magda);
+    CHECK(parseAudioEngine("Tracktion") == AudioEngineChoice::Tracktion);
+
+    // Anything else is not a choice, and the caller decides what to do about it.
+    CHECK_FALSE(parseAudioEngine("").has_value());
+    CHECK_FALSE(parseAudioEngine("native").has_value());
+    CHECK_FALSE(parseAudioEngine("magda engine").has_value());
+
+    // The word the file stores round-trips, which is what a preference set on
+    // one run and read on the next depends on.
+    CHECK(parseAudioEngine(settingWordFor(AudioEngineChoice::Magda)) == AudioEngineChoice::Magda);
+    CHECK(parseAudioEngine(settingWordFor(AudioEngineChoice::Tracktion)) ==
+          AudioEngineChoice::Tracktion);
+}
+
+TEST_CASE("The setting survives the config file", "[engine][engine-choice]") {
+    // The key is spelled twice, once to write and once to read, and a mismatch
+    // between them loses the choice without failing anything else. Safe against
+    // the developer's own settings: TestConfigRedirect points the path
+    // somewhere disposable before main().
+    auto& config = Config::getInstance();
+    const auto previous = config.getAudioEngine();
+
+    config.setAudioEngine(settingWordFor(AudioEngineChoice::Magda));
+    config.save();
+
+    config.setAudioEngine(settingWordFor(AudioEngineChoice::Tracktion));
+    config.load();
+    CHECK(parseAudioEngine(config.getAudioEngine()) == AudioEngineChoice::Magda);
+
+    config.setAudioEngine(previous);
+    config.save();
+}
+
+TEST_CASE("An unset preference is the fork", "[engine][engine-choice]") {
+    const ScopedEngineVariable variable(nullptr);
+    const ScopedEngineSetting setting(AudioEngineChoice::Tracktion);
+
+    CHECK(chosenAudioEngine() == AudioEngineChoice::Tracktion);
+}
+
+TEST_CASE("The setting decides when the environment says nothing", "[engine][engine-choice]") {
+    const ScopedEngineVariable variable(nullptr);
+
+    {
+        const ScopedEngineSetting setting(AudioEngineChoice::Magda);
+        CHECK(chosenAudioEngine() == AudioEngineChoice::Magda);
+    }
+    {
+        const ScopedEngineSetting setting(AudioEngineChoice::Tracktion);
+        CHECK(chosenAudioEngine() == AudioEngineChoice::Tracktion);
+    }
+}
+
+TEST_CASE("The environment wins over the setting, both ways", "[engine][engine-choice]") {
+    {
+        const ScopedEngineSetting setting(AudioEngineChoice::Tracktion);
+        const ScopedEngineVariable variable("magda");
+        CHECK(chosenAudioEngine() == AudioEngineChoice::Magda);
+    }
+    {
+        const ScopedEngineSetting setting(AudioEngineChoice::Magda);
+        const ScopedEngineVariable variable("tracktion");
+        CHECK(chosenAudioEngine() == AudioEngineChoice::Tracktion);
+    }
+}
+
+TEST_CASE("A variable that names neither engine leaves the setting alone",
+          "[engine][engine-choice]") {
+    const ScopedEngineSetting setting(AudioEngineChoice::Magda);
+    const ScopedEngineVariable variable("nonsense");
+
+    CHECK(chosenAudioEngine() == AudioEngineChoice::Magda);
+}


### PR DESCRIPTION
Closes #2559. Part of #1897, and what #2557 needs before dual-engine ships to anybody.

`MAGDA_AUDIO_ENGINE` is the right thing for a developer switching a single run, and it is not a thing a user can be asked to do. The choice is now a setting, in the audio dialog, since which engine renders is an audio-device-level choice and that is where a user already goes to change one.

## Where it lands

`chosenAudioEngine()`, which is what #2567 built that seam for. It reads the variable, then the setting, then the default:

| variable | setting | runs on |
|---|---|---|
| `magda` | anything | magda::engine |
| `tracktion` | anything | Tracktion |
| unset or unrecognised | `magda` | magda::engine |
| unset or unrecognised | unset or unrecognised | Tracktion |

The variable still wins, so "does it still happen on the other engine" stays a one-run question. What it cannot do is win silently: where it is set, the note beside the control says so instead of leaving a combo box that decides nothing.

`settingWordFor` and `parseAudioEngine` are the only two conversions, so no caller compares the words by hand and the config file and the variable share one vocabulary. `nameOf` is left as it was, a log line rather than a value.

## In the dialog

Settings menu, Audio/MIDI Settings, the row under "Set as preferred devices" and above the MIDI and channel selectors:

```
[x] Set as preferred devices (auto-select on startup)
Audio Engine:   [ Tracktion Engine      v ]  Takes effect after a restart
```

The other entry is `MAGDA Engine (beta)`. The note reads `MAGDA_AUDIO_ENGINE overrides this for the current run` where the variable is set. Choosing writes `config.json` immediately, so closing with Escape keeps it.

## Where the engine is named

The splash and the about box both name it beside the version, and only where it is not the fork, so an ordinary startup looks unchanged:

```
Version 0.20.0 (magda::engine)
```

Both ask the engine object through `AudioEngine::engineName()` rather than calling `chosenAudioEngine()` again. The splash is told right after `createDefaultAudioEngine` returns. Calling the choice a second time answers "what will run next start", not "what is running": flip the setting, open About, and it would name an engine you are not on.

## Two things that would have made this silently not work

**The config was loaded too late.** `Config::getInstance().load()` sits inside `TracktionEngineWrapper::initialize()`, which runs *after* `createDefaultAudioEngine` has already chosen an engine. The setting would never have been seen. The factory loads it first now. Loading there rather than moving that call leaves every other caller of `initialize()` alone, and `load()` only reads the file into fields.

**The about box would have named the wrong engine.** See above: it asks the engine object, not the setting.

## The make targets

`run-magda` is gone, with the variable it existed to set. Its comment already said "until the choice becomes a setting (#2559)".

`run-magda-trace` is now `run-trace` and no longer sets `MAGDA_AUDIO_ENGINE` at all: it turns the MIDI trace on (#2568) and leaves the engine to the setting, so nothing in the repo overrides the dialog. The trace comes from the native engine, so it prints nothing on the fork, and the help line says so. Nothing else referenced either target.

## Also here

A doc note in `native-engine.md`, from testing Poly Synth on this engine: a note that is already sounding follows an edit, so changing its pitch changes the pitch under your fingers. It falls out of the publish path rather than being written for, and the fork cannot do it because by then the note is a MIDI message its plugin has been handed. Written down because nothing would catch it going away: the null-diff corpus pins renders, and a render never edits anything mid-note.

## Verification

- A fresh profile defaults to the fork; the setting decides when the variable says nothing; the variable wins over the setting both ways; a variable naming neither engine leaves the setting alone. Six cases in `tests/engine/test_audio_engine_choice.cpp`, including the config-file round trip, since the key is spelled twice and a mismatch would lose the choice without failing anything else.
- `make debug` clean, Catch2 3915 cases / 1.91M assertions pass, JUCE suite `All tests PASSED`.

https://claude.ai/code/session_01VomqgBSXsWYdyHyec9DvPi
