### PR TITLE
Rebuild a device whose key has come to mean something else

### DIFF
--- a/docs/architecture/engine-device-factory.md
+++ b/docs/architecture/engine-device-factory.md
@@ -111,3 +111,14 @@ arrives — which is why the store re-asks rather than remembering a null
 `restoredParameters` into the model on the message thread and publishes a plan
 compiled from it: the corpus's two-pass compile, spread over as many message
 loop turns as the plugins take.
+
+### When a slot's instance is replaced
+
+The store keeps what it holds for a key it is asked for again, so nothing
+rebuilds a device in place unless the factory says the key means something
+else: `RuntimeStateFactory::devicesToRebuild()`, asked once per publish before
+anything is realised. `EngineRuntimeFactory` names a key whose plugin identity
+moved since the instance was built, and every key it holds when a project is
+cleared — DeviceIds restart at 1, so the next project's slots inherit them
+(#2572). The instance being replaced stays alive and unbound until the swap;
+`ExternalPluginLoader::forgetSlots` expires the loads in flight beside it.

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -227,11 +227,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     // ===== Following the model =====
 
     void tracksChanged() override {
-        // The only place a project teardown is visible. The publish this
-        // schedules is coalesced, and a load fills the next project in before
-        // it runs, so by then the model is already the new one -- while
-        // DeviceIds have started from 1 again, so every key the store holds
-        // names a different device (#2572).
+        // The only place a teardown is visible: the publish this schedules is
+        // coalesced, and the next project is loaded before it runs (#2572).
         if (modelHoldsNoDevices())
             factory_.forgetBuiltDevices();
 

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -227,6 +227,14 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     // ===== Following the model =====
 
     void tracksChanged() override {
+        // The only place a project teardown is visible. The publish this
+        // schedules is coalesced, and a load fills the next project in before
+        // it runs, so by then the model is already the new one -- while
+        // DeviceIds have started from 1 again, so every key the store holds
+        // names a different device (#2572).
+        if (modelHoldsNoDevices())
+            factory_.forgetBuiltDevices();
+
         wantPlan();
     }
     void trackDevicesChanged(TrackId) override {

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -227,8 +227,9 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     // ===== Following the model =====
 
     void tracksChanged() override {
-        // The only place a teardown is visible: the publish this schedules is
-        // coalesced, and the next project is loaded before it runs (#2572).
+        // Inferred, because nothing declares a teardown (#2576): the publish
+        // this schedules is coalesced, and the next project is loaded before
+        // it runs (#2572).
         if (modelHoldsNoDevices())
             factory_.forgetBuiltDevices();
 

--- a/magda/daw/engine/host/EngineProject.cpp
+++ b/magda/daw/engine/host/EngineProject.cpp
@@ -53,8 +53,7 @@ engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator) {
 bool modelHoldsNoDevices() {
     const auto& tracks = TrackManager::getInstance().getTracks();
 
-    // Tested first, so the walk only happens in the one state that can answer
-    // yes: every other publish is a project with tracks in it.
+    // First, so the walk only happens in the state that can answer yes.
     if (!tracks.empty())
         return false;
 

--- a/magda/daw/engine/host/EngineProject.cpp
+++ b/magda/daw/engine/host/EngineProject.cpp
@@ -1,7 +1,9 @@
 #include "EngineProject.hpp"
 
+#include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/SourcePool.hpp"
+#include "../../core/TrackManager.hpp"
 
 namespace magda::daw::engine_host {
 
@@ -46,6 +48,18 @@ engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator) {
                                 .numerator = numerator,
                                 .denominator = denominator,
                             }});
+}
+
+bool modelHoldsNoDevices() {
+    const auto& tracks = TrackManager::getInstance().getTracks();
+
+    // Tested first, so the walk only happens in the one state that can answer
+    // yes: every other publish is a project with tracks in it.
+    if (!tracks.empty())
+        return false;
+
+    const auto* master = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+    return master == nullptr || audio::engine_adapter::devicesIn(tracks, *master).empty();
 }
 
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineProject.hpp
+++ b/magda/daw/engine/host/EngineProject.hpp
@@ -35,4 +35,9 @@ std::vector<engine::ClipSourceInfo> clipSources();
 /// (#2554 moves that).
 engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator);
 
+/// Whether the model names a device anywhere, master included. What a project
+/// teardown looks like while it is happening: the next project's devices come
+/// up under the same keys, because DeviceIds start from 1 again (#2572).
+bool modelHoldsNoDevices();
+
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineProject.hpp
+++ b/magda/daw/engine/host/EngineProject.hpp
@@ -36,8 +36,7 @@ std::vector<engine::ClipSourceInfo> clipSources();
 engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator);
 
 /// Whether the model names a device anywhere, master included. What a project
-/// teardown looks like while it is happening: the next project's devices come
-/// up under the same keys, because DeviceIds start from 1 again (#2572).
+/// teardown looks like while it is happening (#2572).
 bool modelHoldsNoDevices();
 
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineProject.hpp
+++ b/magda/daw/engine/host/EngineProject.hpp
@@ -36,7 +36,7 @@ std::vector<engine::ClipSourceInfo> clipSources();
 engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator);
 
 /// Whether the model names a device anywhere, master included. What a project
-/// teardown looks like while it is happening (#2572).
+/// teardown looks like while it is happening, until one is declared (#2576).
 bool modelHoldsNoDevices();
 
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -12,11 +12,8 @@ namespace adapter = magda::daw::audio::engine_adapter;
 
 namespace {
 
-/// Which device a slot is asking for, as one string to compare. pluginId is
-/// what both catalogs dispatch on; the rest is the file an external plugin
-/// resolves to, and is empty for everything else. Nothing here is a display
-/// name or a role, so renaming a device or a load correcting one is not a slot
-/// asking for something else.
+/// Which device a slot asks for, as one string. No display name and no role,
+/// so a rename and a load's own correction are not a different device.
 juce::String deviceIdentityOf(const DeviceInfo& device) {
     return device.pluginId + "|" + device.uniqueId + "|" + device.fileOrIdentifier + "|" +
            device.getFormatString();
@@ -51,10 +48,8 @@ void EngineRuntimeFactory::setModel(const std::vector<TrackInfo>& tracks, const 
     for (const auto& [key, device] : adapter::devicesIn(tracks, master))
         devices_.emplace(key, *device);
 
-    // A slot whose plugin was replaced since the instance behind it was built
-    // (#2572). Nothing else can say so: the store keeps what it holds for a key
-    // it is asked for again. A key the model has dropped needs no rebuild --
-    // the store evicts that one on its own rule.
+    // A slot whose plugin changed since its instance was built (#2572). A key
+    // the model dropped needs no rebuild: the store evicts that one itself.
     for (auto entry = built_.begin(); entry != built_.end();) {
         const auto found = devices_.find(entry->first);
         if (found == devices_.end()) {
@@ -86,9 +81,8 @@ void EngineRuntimeFactory::forgetBuiltDevices() {
 }
 
 std::set<engine::DeviceKey> EngineRuntimeFactory::devicesToRebuild() {
-    // Forgotten as they are handed over, so a key the store could not realise
-    // this publish -- an external still opening -- is not asked for again
-    // against an instance that has already gone.
+    // So a key the store could not realise this publish -- an external still
+    // opening -- is not asked for again against an instance that has gone.
     for (const auto& key : rebuild_)
         built_.erase(key);
 
@@ -118,9 +112,8 @@ std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine:
     return nullptr;
 }
 
-/// Every device this factory hands over: recorded against the device it was
-/// built from, so a later publish can tell the key has come to mean something
-/// else, and through the trace when one is on.
+/// Every device this factory hands over, recorded against the model it came
+/// from and wrapped in the trace when one is on.
 std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::handOver(
     engine::DeviceKey key, const DeviceInfo& model, std::unique_ptr<engine::EngineDevice> device) {
     if (device == nullptr)

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -49,18 +49,13 @@ void EngineRuntimeFactory::setModel(const std::vector<TrackInfo>& tracks, const 
         devices_.emplace(key, *device);
 
     // A slot whose plugin changed since its instance was built (#2572). A key
-    // the model dropped needs no rebuild: the store evicts that one itself.
-    for (auto entry = built_.begin(); entry != built_.end();) {
-        const auto found = devices_.find(entry->first);
-        if (found == devices_.end()) {
-            entry = built_.erase(entry);
-            continue;
-        }
-
-        if (deviceIdentityOf(found->second) != entry->second)
-            rebuild_.insert(entry->first);
-
-        ++entry;
+    // the model has stopped naming is kept rather than dropped: the store
+    // evicts on a publish that succeeded, and a rejected one leaves it holding
+    // a device this would otherwise have forgotten.
+    for (const auto& [key, identity] : built_) {
+        const auto found = devices_.find(key);
+        if (found != devices_.end() && deviceIdentityOf(found->second) != identity)
+            rebuild_.insert(key);
     }
 
     // Before anything is asked for, so a device that has changed plugin since

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -1,5 +1,7 @@
 #include "EngineRuntimeFactory.hpp"
 
+#include <utility>
+
 #include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "clip/ClipAudioSource.hpp"
 #include "clip/ClipMidiSource.hpp"
@@ -7,6 +9,20 @@
 namespace magda::daw::engine_host {
 
 namespace adapter = magda::daw::audio::engine_adapter;
+
+namespace {
+
+/// Which device a slot is asking for, as one string to compare. pluginId is
+/// what both catalogs dispatch on; the rest is the file an external plugin
+/// resolves to, and is empty for everything else. Nothing here is a display
+/// name or a role, so renaming a device or a load correcting one is not a slot
+/// asking for something else.
+juce::String deviceIdentityOf(const DeviceInfo& device) {
+    return device.pluginId + "|" + device.uniqueId + "|" + device.fileOrIdentifier + "|" +
+           device.getFormatString();
+}
+
+}  // namespace
 
 EngineFileReaders::EngineFileReaders() {
     formats_.registerBasicFormats();
@@ -35,11 +51,48 @@ void EngineRuntimeFactory::setModel(const std::vector<TrackInfo>& tracks, const 
     for (const auto& [key, device] : adapter::devicesIn(tracks, master))
         devices_.emplace(key, *device);
 
+    // A slot whose plugin was replaced since the instance behind it was built
+    // (#2572). Nothing else can say so: the store keeps what it holds for a key
+    // it is asked for again. A key the model has dropped needs no rebuild --
+    // the store evicts that one on its own rule.
+    for (auto entry = built_.begin(); entry != built_.end();) {
+        const auto found = devices_.find(entry->first);
+        if (found == devices_.end()) {
+            entry = built_.erase(entry);
+            continue;
+        }
+
+        if (deviceIdentityOf(found->second) != entry->second)
+            rebuild_.insert(entry->first);
+
+        ++entry;
+    }
+
     // Before anything is asked for, so a device that has changed plugin since
     // the last publish has expired the load it had in flight by the time this
     // publish asks for one.
     if (externals_ != nullptr)
         externals_->syncAssignments(devices_);
+}
+
+void EngineRuntimeFactory::forgetBuiltDevices() {
+    for (const auto& [key, identity] : built_)
+        rebuild_.insert(key);
+
+    built_.clear();
+
+    if (externals_ != nullptr)
+        externals_->forgetSlots();
+}
+
+std::set<engine::DeviceKey> EngineRuntimeFactory::devicesToRebuild() {
+    // Forgotten as they are handed over, so a key the store could not realise
+    // this publish -- an external still opening -- is not asked for again
+    // against an instance that has already gone.
+    for (const auto& key : rebuild_)
+        built_.erase(key);
+
+    return std::exchange(rebuild_, {});
 }
 
 std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine::DeviceKey key) {
@@ -52,10 +105,11 @@ std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine:
     // is not ready: the loader answers null while it opens one, and the store
     // asks again at the next publish (#2566).
     if (adapter::isExternalDevice(found->second))
-        return traced(externals_ != nullptr ? externals_->device(key, found->second) : nullptr);
+        return handOver(key, found->second,
+                        externals_ != nullptr ? externals_->device(key, found->second) : nullptr);
 
     if (auto device = adapter::createEngineDevice(found->second))
-        return traced(std::move(device));
+        return handOver(key, found->second, std::move(device));
 
     // Said out loud once per publish rather than left as silence. A device the
     // app can build and the engine cannot is a project playing without part of
@@ -64,10 +118,17 @@ std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::createDevice(engine:
     return nullptr;
 }
 
-/// Every device this factory hands over, through the trace when one is on.
-std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::traced(
-    std::unique_ptr<engine::EngineDevice> device) {
-    if (device == nullptr || trace_ == nullptr)
+/// Every device this factory hands over: recorded against the device it was
+/// built from, so a later publish can tell the key has come to mean something
+/// else, and through the trace when one is on.
+std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::handOver(
+    engine::DeviceKey key, const DeviceInfo& model, std::unique_ptr<engine::EngineDevice> device) {
+    if (device == nullptr)
+        return nullptr;
+
+    built_[key] = deviceIdentityOf(model);
+
+    if (trace_ == nullptr)
         return device;
 
     return std::make_unique<TracingDevice>(std::move(device), *trace_);

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -119,7 +119,9 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
 
     std::map<engine::DeviceKey, DeviceInfo> devices_;
 
-    /// Which device each key's live instance was built from.
+    /// Which device each key's live instance was built from. Kept for a key
+    /// the model drops, since only a publish that succeeded evicts one; that
+    /// is an entry and a short string per DeviceKey ever realised.
     std::map<engine::DeviceKey, juce::String> built_;
 
     /// What the next publish must rebuild.

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "EngineTrace.hpp"
@@ -93,14 +94,26 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
         trace_ = &trace;
     }
 
+    /**
+     * @brief Nothing the store holds belongs to the model any more (#2572).
+     *
+     * A project was cleared, and DeviceIds start from 1 again, so every key
+     * that comes round names a different device. Called where the teardown is
+     * noticed rather than at the next publish, because by then the model is
+     * already the next project's.
+     */
+    void forgetBuiltDevices();
+
     std::unique_ptr<engine::EngineDevice> createDevice(engine::DeviceKey key) override;
+    std::set<engine::DeviceKey> devicesToRebuild() override;
     std::unique_ptr<engine::EngineAudioSource> createClipAudioSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineMidiSource> createClipMidiSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineAudioSource> createSessionAudioSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineMidiSource> createSessionMidiSource(TrackId trackId) override;
 
   private:
-    std::unique_ptr<engine::EngineDevice> traced(std::unique_ptr<engine::EngineDevice> device);
+    std::unique_ptr<engine::EngineDevice> handOver(engine::DeviceKey key, const DeviceInfo& model,
+                                                   std::unique_ptr<engine::EngineDevice> device);
     std::unique_ptr<engine::EngineAudioSource> audioSource(TrackId trackId,
                                                            engine::Section section);
     std::unique_ptr<engine::EngineMidiSource> midiSource(TrackId trackId, engine::Section section);
@@ -110,6 +123,15 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
     engine::LaunchHandleFeed* handles_ = nullptr;
 
     std::map<engine::DeviceKey, DeviceInfo> devices_;
+
+    /// Which device each key's live instance was built from, so a key that has
+    /// come to mean something else can be told from one that has not.
+    std::map<engine::DeviceKey, juce::String> built_;
+
+    /// What the next publish must rebuild, filled by setModel() and
+    /// forgetBuiltDevices() and taken by devicesToRebuild().
+    std::set<engine::DeviceKey> rebuild_;
+
     std::vector<juce::String> unbuilt_;
     EngineTrace* trace_ = nullptr;
     ExternalPluginLoader* externals_ = nullptr;

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -94,14 +94,9 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
         trace_ = &trace;
     }
 
-    /**
-     * @brief Nothing the store holds belongs to the model any more (#2572).
-     *
-     * A project was cleared, and DeviceIds start from 1 again, so every key
-     * that comes round names a different device. Called where the teardown is
-     * noticed rather than at the next publish, because by then the model is
-     * already the next project's.
-     */
+    /// Nothing the store holds belongs to the model any more: the project was
+    /// cleared and DeviceIds start from 1 again (#2572). Called at the
+    /// teardown, which the next publish is too late to see.
     void forgetBuiltDevices();
 
     std::unique_ptr<engine::EngineDevice> createDevice(engine::DeviceKey key) override;
@@ -124,12 +119,10 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
 
     std::map<engine::DeviceKey, DeviceInfo> devices_;
 
-    /// Which device each key's live instance was built from, so a key that has
-    /// come to mean something else can be told from one that has not.
+    /// Which device each key's live instance was built from.
     std::map<engine::DeviceKey, juce::String> built_;
 
-    /// What the next publish must rebuild, filled by setModel() and
-    /// forgetBuiltDevices() and taken by devicesToRebuild().
+    /// What the next publish must rebuild.
     std::set<engine::DeviceKey> rebuild_;
 
     std::vector<juce::String> unbuilt_;

--- a/magda/daw/engine/host/ExternalPluginLoader.cpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.cpp
@@ -62,11 +62,9 @@ void ExternalPluginLoader::syncAssignments(const std::map<engine::DeviceKey, Dev
             continue;
         }
 
-        // Every load in flight against the old assignment expires here. A
-        // device the store has already bound does not: it keeps what it holds
-        // for a key it is asked for again, so this reaches a slot whose plugin
-        // changed while its first load was still running, and #2572 is the
-        // other half.
+        // Every load in flight against the old assignment expires here. The
+        // instance the store has already bound is retired separately, by the
+        // rebuild the same identity change puts to it (#2572).
         assignments_.replaceAssignment(key);
         found->second = Slot{.identity = std::move(identity), .generation = ++generation_};
     }
@@ -80,6 +78,11 @@ void ExternalPluginLoader::syncAssignments(const std::map<engine::DeviceKey, Dev
         assignments_.release(slot->first);
         slot = slots_.erase(slot);
     }
+}
+
+void ExternalPluginLoader::forgetSlots() {
+    assignments_.releaseAll();
+    slots_.clear();
 }
 
 std::unique_ptr<engine::EngineDevice> ExternalPluginLoader::device(engine::DeviceKey key,

--- a/magda/daw/engine/host/ExternalPluginLoader.cpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.cpp
@@ -62,9 +62,8 @@ void ExternalPluginLoader::syncAssignments(const std::map<engine::DeviceKey, Dev
             continue;
         }
 
-        // Every load in flight against the old assignment expires here. The
-        // instance the store has already bound is retired separately, by the
-        // rebuild the same identity change puts to it (#2572).
+        // Every load in flight against the old assignment expires here; the
+        // bound instance is retired by the rebuild instead (#2572).
         assignments_.replaceAssignment(key);
         found->second = Slot{.identity = std::move(identity), .generation = ++generation_};
     }

--- a/magda/daw/engine/host/ExternalPluginLoader.hpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.hpp
@@ -83,6 +83,17 @@ class ExternalPluginLoader final {
      */
     std::unique_ptr<engine::EngineDevice> device(engine::DeviceKey key, const DeviceInfo& model);
 
+    /**
+     * @brief Every slot ends: the project was cleared (#2572).
+     *
+     * DeviceIds start from 1 again, so a load started for the project that has
+     * gone would complete onto whatever slot inherits its key -- a different
+     * plugin, and the old project's state restored over the new one's. The
+     * assignments go with them, which is what expires those loads
+     * (PluginAssignments.hpp).
+     */
+    void forgetSlots();
+
     /// How many plugins are loaded and waiting to be bound. For tests.
     std::size_t held() const;
 

--- a/magda/daw/engine/host/ExternalPluginLoader.hpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.hpp
@@ -83,15 +83,8 @@ class ExternalPluginLoader final {
      */
     std::unique_ptr<engine::EngineDevice> device(engine::DeviceKey key, const DeviceInfo& model);
 
-    /**
-     * @brief Every slot ends: the project was cleared (#2572).
-     *
-     * DeviceIds start from 1 again, so a load started for the project that has
-     * gone would complete onto whatever slot inherits its key -- a different
-     * plugin, and the old project's state restored over the new one's. The
-     * assignments go with them, which is what expires those loads
-     * (PluginAssignments.hpp).
-     */
+    /// Every slot ends: the project was cleared (#2572). The assignments go
+    /// with them, which expires the loads in flight against their keys.
     void forgetSlots();
 
     /// How many plugins are loaded and waiting to be bound. For tests.

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -104,6 +104,16 @@ template <typename Map, typename Ids> std::size_t eraseUnnamed(Map& map, const I
 }  // namespace
 
 PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderContext& context) {
+    // Keys the host says mean a different device now (#2572). Taken out before
+    // anything is realised, so realiseOne() asks the factory again rather than
+    // handing back what it holds; kept, because the plan still rendering is the
+    // one that named them.
+    for (const auto& key : factory_.devicesToRebuild())
+        if (const auto found = devices_.find(key); found != devices_.end()) {
+            retired_.push_back(std::move(found->second));
+            devices_.erase(found);
+        }
+
     // A context that has changed is the one case where something already
     // playing is touched, and it is only reachable with the audio device
     // stopped: nothing renders at a sample rate it was not prepared for.
@@ -293,6 +303,11 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
         return !keep.tracks.contains(entry.first.trackId) && !takes_.contains(entry.first);
     });
 
+    // The instances a rebuild took out of devices_. Here and nowhere earlier:
+    // until the swap, they were what the live plan named.
+    removed += retired_.size();
+    retired_.clear();
+
     return removed;
 }
 
@@ -475,9 +490,10 @@ ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {
 }
 
 std::size_t RuntimeStateStore::size() const {
-    return devices_.size() + clipAudio_.size() + clipMidi_.size() + sessionAudio_.size() +
-           sessionMidi_.size() + handles_.size() + audioInputs_.size() + midiInputs_.size() +
-           meters_.size() + valueTaps_.size() + takes_.size() + takeTaps_.size();
+    return devices_.size() + retired_.size() + clipAudio_.size() + clipMidi_.size() +
+           sessionAudio_.size() + sessionMidi_.size() + handles_.size() + audioInputs_.size() +
+           midiInputs_.size() + meters_.size() + valueTaps_.size() + takes_.size() +
+           takeTaps_.size();
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -104,10 +104,8 @@ template <typename Map, typename Ids> std::size_t eraseUnnamed(Map& map, const I
 }  // namespace
 
 PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderContext& context) {
-    // Keys the host says mean a different device now (#2572). Taken out before
-    // anything is realised, so realiseOne() asks the factory again rather than
-    // handing back what it holds; kept, because the plan still rendering is the
-    // one that named them.
+    // Out before anything is realised, so realiseOne() asks the factory again;
+    // kept, because the plan still rendering names them (#2572).
     for (const auto& key : factory_.devicesToRebuild())
         if (const auto found = devices_.find(key); found != devices_.end()) {
             retired_.push_back(std::move(found->second));
@@ -303,8 +301,7 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
         return !keep.tracks.contains(entry.first.trackId) && !takes_.contains(entry.first);
     });
 
-    // The instances a rebuild took out of devices_. Here and nowhere earlier:
-    // until the swap, they were what the live plan named.
+    // Not earlier: until the swap they were what the live plan named.
     removed += retired_.size();
     retired_.clear();
 

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -81,16 +81,8 @@ class RuntimeStateFactory {
     /**
      * @brief Keys whose device is no longer the one the store holds (#2572).
      *
-     * A slot's plugin replaced, or a DeviceId handed out again to a different
-     * device after a project was cleared. The store keeps what it holds for a
-     * key it is asked for again -- that is what stops a fader reorder
-     * rebuilding an instrument mid-note -- so nothing else can say a key has
-     * come to mean something new.
-     *
      * Asked once per publish, before anything is realised. The instance being
-     * replaced stays alive and unbound until the swap, on the same reading
-     * everything else here follows: the plan the audio thread is rendering
-     * still names it.
+     * replaced stays alive until the swap, since the live plan still names it.
      */
     virtual std::set<DeviceKey> devicesToRebuild() {
         return {};
@@ -380,8 +372,8 @@ class RuntimeStateStore {
 
     std::unordered_map<DeviceKey, std::unique_ptr<EngineDevice>, DeviceKeyHash> devices_;
 
-    /// Instances a rebuild took out of devices_, alive until releaseDeleted()
-    /// says the audio thread is out of the plan that named them (#2572).
+    /// Instances a rebuild took out of devices_, held until releaseDeleted()
+    /// (#2572).
     std::vector<std::unique_ptr<EngineDevice>> retired_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> clipAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> clipMidi_;

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -79,6 +79,24 @@ class RuntimeStateFactory {
     }
 
     /**
+     * @brief Keys whose device is no longer the one the store holds (#2572).
+     *
+     * A slot's plugin replaced, or a DeviceId handed out again to a different
+     * device after a project was cleared. The store keeps what it holds for a
+     * key it is asked for again -- that is what stops a fader reorder
+     * rebuilding an instrument mid-note -- so nothing else can say a key has
+     * come to mean something new.
+     *
+     * Asked once per publish, before anything is realised. The instance being
+     * replaced stays alive and unbound until the swap, on the same reading
+     * everything else here follows: the plan the audio thread is rendering
+     * still names it.
+     */
+    virtual std::set<DeviceKey> devicesToRebuild() {
+        return {};
+    }
+
+    /**
      * @brief The level tap behind one Meter op, or nullptr for one nobody reads.
      *
      * Declining is the ordinary answer, not a failure: a plan has a meter at
@@ -361,6 +379,10 @@ class RuntimeStateStore {
     bool hasContext_ = false;
 
     std::unordered_map<DeviceKey, std::unique_ptr<EngineDevice>, DeviceKeyHash> devices_;
+
+    /// Instances a rebuild took out of devices_, alive until releaseDeleted()
+    /// says the audio thread is out of the plan that named them (#2572).
+    std::vector<std::unique_ptr<EngineDevice>> retired_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> clipAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> clipMidi_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> sessionAudio_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -441,6 +441,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # The pass in flight, reported without a poll (#2463): its length off the
     # transport that stamped it, and its notes where the finished clip holds them.
     list(APPEND TEST_SOURCES engine/test_record_tap.cpp)
+    # A key that has come to mean a different device (#2572): the store is
+    # asked again for it, and the instance it replaces outlives the live plan.
+    list(APPEND TEST_SOURCES engine/test_runtime_state_rebuild.cpp)
     # A take carried across a plan swap (#2465): what an unrelated edit does to
     # a recording in flight, and what the three that end one leave behind.
     list(APPEND TEST_SOURCES AllocationWatch.cpp)

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -3328,6 +3328,44 @@ TEST_CASE("A slot that changed plugin while loading is not published onto",
     CHECK(published);
 }
 
+TEST_CASE("A load in flight when the project is cleared is not published onto",
+          "[engine][external][host]") {
+    // The same identity boundary from the other direction (#2572). A DeviceKey
+    // survives a project load, because DeviceIds start from 1 again, so an
+    // answer arriving afterwards would restore the old project's state onto
+    // whatever slot inherited the key.
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    LiveSlot slot;
+    slot.install();
+
+    bool published = false;
+    host::ExternalPluginLoader loader(
+        [&slot](magda::engine::DeviceKey) { return &slot.model; },
+        [&published](magda::engine::DeviceKey, const magda::DeviceInfo&,
+                     const std::vector<magda::RestoredParameter>&) { published = true; });
+
+    loader.setServices(&slot.formats, &slot.known);
+    loader.setContext(contextFor());
+    loader.syncAssignments({{slot.key(), slot.model}});
+    CHECK(loader.device(slot.key(), slot.model) == nullptr);
+
+    loader.forgetSlots();
+
+    dispatchPendingLoads();
+    CHECK_FALSE(published);
+    CHECK(loader.held() == 0);
+
+    // And the project that comes up next asks for itself, rather than
+    // inheriting a slot that has been spent or a load it never started.
+    loader.syncAssignments({{slot.key(), slot.model}});
+    CHECK(loader.device(slot.key(), slot.model) == nullptr);
+
+    dispatchPendingLoads();
+    CHECK(loader.device(slot.key(), slot.model) != nullptr);
+    CHECK(published);
+}
+
 TEST_CASE("A plugin the scan has not found yet is asked about again", "[engine][external][host]") {
     // A session opens before the scan finishes, and a project loaded then names
     // plugins nothing has heard of. Nothing was spent finding that out -- no

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -3330,10 +3330,9 @@ TEST_CASE("A slot that changed plugin while loading is not published onto",
 
 TEST_CASE("A load in flight when the project is cleared is not published onto",
           "[engine][external][host]") {
-    // The same identity boundary from the other direction (#2572). A DeviceKey
-    // survives a project load, because DeviceIds start from 1 again, so an
-    // answer arriving afterwards would restore the old project's state onto
-    // whatever slot inherited the key.
+    // The same identity boundary from the other direction (#2572): a DeviceKey
+    // survives a project load, so a late answer lands on the slot that
+    // inherited it.
     juce::ScopedJuceInitialiser_GUI juce;
 
     LiveSlot slot;
@@ -3356,8 +3355,7 @@ TEST_CASE("A load in flight when the project is cleared is not published onto",
     CHECK_FALSE(published);
     CHECK(loader.held() == 0);
 
-    // And the project that comes up next asks for itself, rather than
-    // inheriting a slot that has been spent or a load it never started.
+    // And the next project asks for itself rather than inheriting a spent slot.
     loader.syncAssignments({{slot.key(), slot.model}});
     CHECK(loader.device(slot.key(), slot.model) == nullptr);
 

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -364,7 +364,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
     }
 
     /// The key a track's first FX slot has.
-    static constexpr magda::engine::DeviceKey firstFxSlot() {
+    static magda::engine::DeviceKey firstFxSlot() {
         return magda::engine::DeviceKey{magda::ChainSegment::Fx, 1};
     }
 

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -11,6 +11,7 @@
 #include "exec/EngineSession.hpp"
 #include "exec/PlanValues.hpp"
 #include "io/PrefetchThread.hpp"
+#include "magda/daw/audio/plugins/compiled/MagdaChorusCompiledPlugin.hpp"
 #include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
@@ -59,6 +60,23 @@ magda::DeviceInfo polySynth(magda::DeviceId id) {
         info.currentValue = info.defaultValue;
         device.parameters.push_back(std::move(info));
     }
+
+    return device;
+}
+
+/// A compiled effect, for a case that needs a second kind of device rather
+/// than a second copy of the first.
+magda::DeviceInfo chorus(magda::DeviceId id) {
+    using Chorus = magda::daw::audio::compiled::MagdaChorusCompiledPlugin;
+
+    magda::DeviceInfo device;
+    device.id = id;
+    device.name = "Chorus";
+    device.pluginId = Chorus::xmlTypeName;
+    device.deviceType = magda::DeviceType::Effect;
+    device.format = magda::PluginFormat::Internal;
+    device.audioInputChannels = 2;
+    device.audioOutputChannels = 2;
 
     return device;
 }
@@ -142,6 +160,8 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::test::runWithCleanJuceState([this] { testLanesSplitBySection(); });
         magda::test::runWithCleanJuceState([this] { testMidiClipReachesAnInstrument(); });
         magda::test::runWithCleanJuceState([this] { testNoteMovedWhileRolling(); });
+        magda::test::runWithCleanJuceState([this] { testReplacedPluginIsRebuilt(); });
+        magda::test::runWithCleanJuceState([this] { testClearedProjectIsRebuilt(); });
     }
 
   private:
@@ -341,6 +361,75 @@ class EngineHostPublishTest final : public juce::UnitTest {
         expect(
             std::ranges::any_of(releases, [](const auto& release) { return release.note == 60; }),
             "The pitch it left is released rather than left hanging");
+    }
+
+    /// The one device the factory holds, at the key a track-level FX slot has.
+    static constexpr magda::engine::DeviceKey firstFxSlot() {
+        return magda::engine::DeviceKey{magda::ChainSegment::Fx, 1};
+    }
+
+    void testReplacedPluginIsRebuilt() {
+        beginTest("A slot whose plugin changed is a device the store must rebuild");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Instrument");
+        auto* track = trackManager.getTrack(trackId);
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(track != nullptr && master != nullptr, "The track and the master exist");
+        if (track == nullptr || master == nullptr)
+            return;
+
+        track->chain.fxChainElements.emplace_back(polySynth(1));
+
+        host::EngineRuntimeFactory factory;
+        factory.setModel(trackManager.getTracks(), *master);
+        expect(factory.devicesToRebuild().empty(), "Nothing has been built to rebuild");
+        expect(factory.createDevice(firstFxSlot()) != nullptr, "The catalog builds the synth");
+
+        // The retention contract, which is what a fader reorder relies on: the
+        // same model published again asks for nothing.
+        factory.setModel(trackManager.getTracks(), *master);
+        expect(factory.devicesToRebuild().empty(), "A device that did not change is kept");
+
+        // The same DeviceId, a different plugin. Within a project this is a
+        // slot's plugin being swapped; across one it is #2572, and the factory
+        // cannot tell the two apart because a DeviceKey does not say.
+        track->chain.fxChainElements[0] = chorus(1);
+        factory.setModel(trackManager.getTracks(), *master);
+
+        const auto rebuild = factory.devicesToRebuild();
+        expect(rebuild.size() == 1 && rebuild.contains(firstFxSlot()),
+               "The slot's new plugin is named for rebuild");
+    }
+
+    void testClearedProjectIsRebuilt() {
+        beginTest("A cleared project is every device it held named for rebuild");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Instrument");
+        auto* track = trackManager.getTrack(trackId);
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(track != nullptr && master != nullptr, "The track and the master exist");
+        if (track == nullptr || master == nullptr)
+            return;
+
+        track->chain.fxChainElements.emplace_back(polySynth(1));
+
+        host::EngineRuntimeFactory factory;
+        factory.setModel(trackManager.getTracks(), *master);
+        expect(factory.createDevice(firstFxSlot()) != nullptr, "The catalog builds the synth");
+        expect(!host::modelHoldsNoDevices(), "A project with a device in it is not a teardown");
+
+        // What a project load does before it restores anything, and the only
+        // moment the empty model is visible: the publish it schedules runs
+        // after the next project is already in place.
+        trackManager.clearAllTracks();
+        expect(host::modelHoldsNoDevices(), "A cleared project names no device anywhere");
+
+        factory.forgetBuiltDevices();
+        const auto rebuild = factory.devicesToRebuild();
+        expect(rebuild.size() == 1 && rebuild.contains(firstFxSlot()),
+               "Every device the store holds is the previous project's");
     }
 };
 

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -161,6 +161,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::test::runWithCleanJuceState([this] { testNoteMovedWhileRolling(); });
         magda::test::runWithCleanJuceState([this] { testReplacedPluginIsRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testClearedProjectIsRebuilt(); });
+        magda::test::runWithCleanJuceState([this] { testDroppedKeyIsStillRebuilt(); });
     }
 
   private:
@@ -426,6 +427,34 @@ class EngineHostPublishTest final : public juce::UnitTest {
         const auto rebuild = factory.devicesToRebuild();
         expect(rebuild.size() == 1 && rebuild.contains(firstFxSlot()),
                "Every device the store holds is the previous project's");
+    }
+
+    void testDroppedKeyIsStillRebuilt() {
+        beginTest("A key the model dropped is still one the store may hold");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Instrument");
+        auto* track = trackManager.getTrack(trackId);
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(track != nullptr && master != nullptr, "The track and the master exist");
+        if (track == nullptr || master == nullptr)
+            return;
+
+        track->chain.fxChainElements.emplace_back(polySynth(1));
+
+        host::EngineRuntimeFactory factory;
+        factory.setModel(trackManager.getTracks(), *master);
+        expect(factory.createDevice(firstFxSlot()) != nullptr, "The catalog builds the synth");
+
+        // The device deleted, and the publish that would have evicted it
+        // refused: the store only evicts after a swap, so it still holds one.
+        track->chain.fxChainElements.clear();
+        factory.setModel(trackManager.getTracks(), *master);
+
+        factory.forgetBuiltDevices();
+        const auto rebuild = factory.devicesToRebuild();
+        expect(rebuild.contains(firstFxSlot()),
+               "The key is named for rebuild rather than forgotten with the model");
     }
 };
 

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -64,8 +64,7 @@ magda::DeviceInfo polySynth(magda::DeviceId id) {
     return device;
 }
 
-/// A compiled effect, for a case that needs a second kind of device rather
-/// than a second copy of the first.
+/// A compiled effect, for a case that needs a second kind of device.
 magda::DeviceInfo chorus(magda::DeviceId id) {
     using Chorus = magda::daw::audio::compiled::MagdaChorusCompiledPlugin;
 
@@ -363,7 +362,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
             "The pitch it left is released rather than left hanging");
     }
 
-    /// The one device the factory holds, at the key a track-level FX slot has.
+    /// The key a track's first FX slot has.
     static constexpr magda::engine::DeviceKey firstFxSlot() {
         return magda::engine::DeviceKey{magda::ChainSegment::Fx, 1};
     }
@@ -386,14 +385,12 @@ class EngineHostPublishTest final : public juce::UnitTest {
         expect(factory.devicesToRebuild().empty(), "Nothing has been built to rebuild");
         expect(factory.createDevice(firstFxSlot()) != nullptr, "The catalog builds the synth");
 
-        // The retention contract, which is what a fader reorder relies on: the
-        // same model published again asks for nothing.
+        // The retention contract: the same model published again asks for nothing.
         factory.setModel(trackManager.getTracks(), *master);
         expect(factory.devicesToRebuild().empty(), "A device that did not change is kept");
 
-        // The same DeviceId, a different plugin. Within a project this is a
-        // slot's plugin being swapped; across one it is #2572, and the factory
-        // cannot tell the two apart because a DeviceKey does not say.
+        // The same DeviceId, a different plugin: a slot swapped within a
+        // project, and #2572 across one.
         track->chain.fxChainElements[0] = chorus(1);
         factory.setModel(trackManager.getTracks(), *master);
 
@@ -421,8 +418,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         expect(!host::modelHoldsNoDevices(), "A project with a device in it is not a teardown");
 
         // What a project load does before it restores anything, and the only
-        // moment the empty model is visible: the publish it schedules runs
-        // after the next project is already in place.
+        // moment the empty model is visible.
         trackManager.clearAllTracks();
         expect(host::modelHoldsNoDevices(), "A cleared project names no device anywhere");
 

--- a/tests/engine/test_runtime_state_rebuild.cpp
+++ b/tests/engine/test_runtime_state_rebuild.cpp
@@ -1,0 +1,179 @@
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "exec/RuntimeStateStore.hpp"
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file test_runtime_state_rebuild.cpp
+ * @brief A key that has come to mean a different device (#2572).
+ *
+ * The store keeps what it holds for a key it is asked for again, which is what
+ * stops a fader reorder rebuilding an instrument mid-note. DeviceIds are per
+ * section and reset to 1 when a project is cleared, so across a project load
+ * the same rule hands the next project the previous one's instances.
+ *
+ * devicesToRebuild() is the way out, and these cases are about the two halves
+ * of it: the factory is asked again for a key it names, and the instance it
+ * replaces stays alive until the plan that named it has stopped being live.
+ */
+
+using namespace magda;
+using namespace magda::engine;
+
+namespace {
+
+constexpr TrackId kTrack = 1;
+constexpr DeviceId kDevice = 1;
+
+const DeviceKey kKey{ChainSegment::Fx, kDevice};
+
+const RenderContext kContext{.sampleRate = 48000.0, .maxBlockSize = 64, .numChannels = 2};
+
+/// Says which of the factory's devices it is, and reports its own destruction:
+/// the claim is about which instance is bound and when the other one goes, and
+/// nothing it renders would say either.
+class ProbeDevice final : public EngineDevice {
+  public:
+    ProbeDevice(int which, int& alive) : which_(which), alive_(alive) {
+        ++alive_;
+    }
+
+    ~ProbeDevice() override {
+        --alive_;
+    }
+
+    void process(DeviceBlock&) override {}
+
+    int which() const {
+        return which_;
+    }
+
+  private:
+    int which_ = 0;
+    int& alive_;
+};
+
+/// Numbers every device it makes, so a rebuilt key is visible rather than
+/// merely non-null, and names for rebuild whatever a case last asked it to.
+class ProbeFactory final : public RuntimeStateFactory {
+  public:
+    std::unique_ptr<EngineDevice> createDevice(DeviceKey) override {
+        ++made;
+        return std::make_unique<ProbeDevice>(made, alive);
+    }
+
+    std::set<DeviceKey> devicesToRebuild() override {
+        return std::exchange(rebuild, {});
+    }
+
+    int made = 0;
+    int alive = 0;
+    std::set<DeviceKey> rebuild;
+};
+
+/// One Device op at kKey, which is all a lifetime case needs a plan for.
+RenderPlan planWithDevice() {
+    RenderPlan plan;
+    PlanOp op;
+    op.kind = OpKind::Device;
+    op.key.trackId = kTrack;
+    op.key.deviceId = kDevice;
+    op.key.segment = ChainSegment::Fx;
+    plan.ops.push_back(op);
+    return plan;
+}
+
+/// The device bound to kKey by @p bindings, or nullptr.
+const ProbeDevice* bound(const PlanBindings& bindings) {
+    const auto found = bindings.devices.find(kKey);
+    if (found == bindings.devices.end())
+        return nullptr;
+    return static_cast<const ProbeDevice*>(found->second);
+}
+
+/// Everything the model holds, which for these cases is kKey and its track.
+RuntimeStateIds namedIds() {
+    RuntimeStateIds ids;
+    ids.devices.insert(kKey);
+    ids.tracks.insert(kTrack);
+    return ids;
+}
+
+}  // namespace
+
+TEST_CASE("A key nothing names for rebuild keeps its device", "[engine][store][rebuild]") {
+    ProbeFactory factory;
+    RuntimeStateStore store(factory);
+
+    const auto plan = planWithDevice();
+
+    REQUIRE(bound(store.realise(plan, kContext))->which() == 1);
+    store.releaseDeleted(plan, namedIds(), nullptr);
+
+    // The retention contract, unchanged: the factory is asked once for the life
+    // of the key, whatever recompiles the plan around it.
+    CHECK(bound(store.realise(plan, kContext))->which() == 1);
+    CHECK(factory.made == 1);
+}
+
+TEST_CASE("A key named for rebuild is asked for again", "[engine][store][rebuild]") {
+    ProbeFactory factory;
+    RuntimeStateStore store(factory);
+
+    const auto plan = planWithDevice();
+
+    REQUIRE(bound(store.realise(plan, kContext))->which() == 1);
+    store.releaseDeleted(plan, namedIds(), nullptr);
+
+    factory.rebuild.insert(kKey);
+
+    CHECK(bound(store.realise(plan, kContext))->which() == 2);
+    CHECK(factory.made == 2);
+}
+
+TEST_CASE("A rebuilt device outlives the plan that named it", "[engine][store][rebuild]") {
+    ProbeFactory factory;
+    RuntimeStateStore store(factory);
+
+    const auto plan = planWithDevice();
+
+    REQUIRE(bound(store.realise(plan, kContext))->which() == 1);
+    store.releaseDeleted(plan, namedIds(), nullptr);
+
+    factory.rebuild.insert(kKey);
+    store.realise(plan, kContext);
+
+    // Both, because the plan the audio thread is rendering still names the
+    // first: realise() prepares a plan that has not been published yet.
+    CHECK(factory.alive == 2);
+
+    // The swap has happened by the time this is called, so the one it replaced
+    // is unreachable and goes here.
+    store.releaseDeleted(plan, namedIds(), nullptr);
+    CHECK(factory.alive == 1);
+}
+
+TEST_CASE("A rebuild the plan does not name still replaces the device",
+          "[engine][store][rebuild]") {
+    ProbeFactory factory;
+    RuntimeStateStore store(factory);
+
+    const auto plan = planWithDevice();
+
+    REQUIRE(bound(store.realise(plan, kContext))->which() == 1);
+    store.releaseDeleted(plan, namedIds(), nullptr);
+
+    // A publish whose plan has no Device op -- a bypassed device, a chain
+    // powered off -- retires the instance without building one, so the key
+    // comes back to a device made from the model it names now.
+    factory.rebuild.insert(kKey);
+    store.realise(RenderPlan{}, kContext);
+    store.releaseDeleted(RenderPlan{}, namedIds(), nullptr);
+    CHECK(factory.alive == 0);
+
+    CHECK(bound(store.realise(plan, kContext))->which() == 2);
+}

--- a/tests/engine/test_runtime_state_rebuild.cpp
+++ b/tests/engine/test_runtime_state_rebuild.cpp
@@ -11,14 +11,8 @@
  * @file test_runtime_state_rebuild.cpp
  * @brief A key that has come to mean a different device (#2572).
  *
- * The store keeps what it holds for a key it is asked for again, which is what
- * stops a fader reorder rebuilding an instrument mid-note. DeviceIds are per
- * section and reset to 1 when a project is cleared, so across a project load
- * the same rule hands the next project the previous one's instances.
- *
- * devicesToRebuild() is the way out, and these cases are about the two halves
- * of it: the factory is asked again for a key it names, and the instance it
- * replaces stays alive until the plan that named it has stopped being live.
+ * Two halves: the factory is asked again for a key it names for rebuild, and
+ * the instance it replaces outlives the plan that named it.
  */
 
 using namespace magda;
@@ -33,9 +27,7 @@ const DeviceKey kKey{ChainSegment::Fx, kDevice};
 
 const RenderContext kContext{.sampleRate = 48000.0, .maxBlockSize = 64, .numChannels = 2};
 
-/// Says which of the factory's devices it is, and reports its own destruction:
-/// the claim is about which instance is bound and when the other one goes, and
-/// nothing it renders would say either.
+/// Says which of the factory's devices it is, and reports its own destruction.
 class ProbeDevice final : public EngineDevice {
   public:
     ProbeDevice(int which, int& alive) : which_(which), alive_(alive) {
@@ -57,8 +49,7 @@ class ProbeDevice final : public EngineDevice {
     int& alive_;
 };
 
-/// Numbers every device it makes, so a rebuilt key is visible rather than
-/// merely non-null, and names for rebuild whatever a case last asked it to.
+/// Numbers every device it makes, and names for rebuild whatever a case asked.
 class ProbeFactory final : public RuntimeStateFactory {
   public:
     std::unique_ptr<EngineDevice> createDevice(DeviceKey) override {
@@ -75,7 +66,7 @@ class ProbeFactory final : public RuntimeStateFactory {
     std::set<DeviceKey> rebuild;
 };
 
-/// One Device op at kKey, which is all a lifetime case needs a plan for.
+/// One Device op at kKey.
 RenderPlan planWithDevice() {
     RenderPlan plan;
     PlanOp op;
@@ -95,7 +86,7 @@ const ProbeDevice* bound(const PlanBindings& bindings) {
     return static_cast<const ProbeDevice*>(found->second);
 }
 
-/// Everything the model holds, which for these cases is kKey and its track.
+/// Everything the model holds.
 RuntimeStateIds namedIds() {
     RuntimeStateIds ids;
     ids.devices.insert(kKey);
@@ -114,8 +105,7 @@ TEST_CASE("A key nothing names for rebuild keeps its device", "[engine][store][r
     REQUIRE(bound(store.realise(plan, kContext))->which() == 1);
     store.releaseDeleted(plan, namedIds(), nullptr);
 
-    // The retention contract, unchanged: the factory is asked once for the life
-    // of the key, whatever recompiles the plan around it.
+    // The retention contract, unchanged.
     CHECK(bound(store.realise(plan, kContext))->which() == 1);
     CHECK(factory.made == 1);
 }
@@ -147,12 +137,10 @@ TEST_CASE("A rebuilt device outlives the plan that named it", "[engine][store][r
     factory.rebuild.insert(kKey);
     store.realise(plan, kContext);
 
-    // Both, because the plan the audio thread is rendering still names the
-    // first: realise() prepares a plan that has not been published yet.
+    // Both: realise() prepares a plan that has not been published yet.
     CHECK(factory.alive == 2);
 
-    // The swap has happened by the time this is called, so the one it replaced
-    // is unreachable and goes here.
+    // The swap has happened by now, so the one it replaced goes here.
     store.releaseDeleted(plan, namedIds(), nullptr);
     CHECK(factory.alive == 1);
 }
@@ -167,9 +155,8 @@ TEST_CASE("A rebuild the plan does not name still replaces the device",
     REQUIRE(bound(store.realise(plan, kContext))->which() == 1);
     store.releaseDeleted(plan, namedIds(), nullptr);
 
-    // A publish whose plan has no Device op -- a bypassed device, a chain
-    // powered off -- retires the instance without building one, so the key
-    // comes back to a device made from the model it names now.
+    // A plan with no Device op -- bypassed, chain powered off -- retires the
+    // instance without building one.
     factory.rebuild.insert(kKey);
     store.realise(RenderPlan{}, kContext);
     store.releaseDeleted(RenderPlan{}, namedIds(), nullptr);


### PR DESCRIPTION
Fixes #2572: opening project B rendered project A's devices.

## What was wrong

`RuntimeStateStore` keeps what it holds for a key it is asked for again — the
rule that stops a fader reorder rebuilding an instrument mid-note. `DeviceId`s
are per section and restart at 1 when a project is cleared, so a `DeviceKey` is
unique within a project and collides across two of them. Eviction did not
cover it either: `EngineHost::tracksChanged()` only sets a flag, and the load
populates the next project synchronously, so by the time the publish runs the
model is already project B and the store never sees the empty one.

## The fix

`RuntimeStateFactory::devicesToRebuild()`, asked once per publish before
anything is realised. The store moves those instances out of `devices_` into a
retired list and destroys them in `releaseDeleted()` — until the swap they are
what the live plan names, so nothing may be freed earlier.

`EngineRuntimeFactory` answers it from two facts:

- **A slot's plugin changed.** It records the plugin identity every device was
  built from as it hands one over, and diffs that in `setModel()`. Identity is
  `pluginId | uniqueId | fileOrIdentifier | format` — nothing a rename or a
  load's own correction touches.
- **The project was cleared.** `EngineHost::tracksChanged()` is the only place
  the empty model is visible, so it calls `forgetBuiltDevices()` there, which
  names every key the factory has built. `modelHoldsNoDevices()` moved to
  `EngineProject` so it is testable; it tests the tracks first, so the device
  walk only happens in the one state that can answer yes.

`ExternalPluginLoader::forgetSlots()` goes with the second: a load started for
the project that has gone would otherwise complete onto whatever slot inherits
its key, restoring the old project's state over the new one's.
`PluginAssignments::releaseAll()` was written for exactly this and had no
caller.

The identity diff alone would not have been enough — two projects with the
same plugin at the same key match on identity, and the instance carries the
first project's `pluginState`, which is baked in at construction.

## Tests

- `tests/engine/test_runtime_state_rebuild.cpp` (new): the probe from the
  issue. A key nothing names keeps its device; a key named for rebuild is
  asked for again; the replaced instance is alive through `realise()` and gone
  after `releaseDeleted()`; a rebuild works even when the new plan has no
  Device op.
- `test_engine_host_publish_juce.cpp`: a slot whose plugin changed is named for
  rebuild, the same model published twice is not, and a real
  `clearAllTracks()` names everything.
- `test_engine_external_device.cpp`: a load in flight when the project is
  cleared is not published onto, and the next project gets an instance of its
  own.

Each verified negatively — the fix reverted, the test fails.

Full `magda_tests` and `magda_juce_tests` green locally; the null-diff corpus
is 65 ok with the same nine inherited FAILs.

Not driven by hand: the repro is two real projects opened in sequence, which
needs a click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN