### PR TITLE
Feed the app's meters from the native engine

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -1278,6 +1278,15 @@ void AudioBridge::timerCallback() {
     // Update metering from level measurers (runs at 30 FPS on message thread).
     // (Skipped entirely during an offline render by the early return above, so
     // the live meters don't twitch to the render's audio either.)
+    //
+    // Skipped whole when another engine renders (#2570): these taps sit in a
+    // graph nothing plays through, so all of them read silence.
+    if (!meteringFedElsewhere_)
+        updateMetersFromGraph();
+}
+
+/// What the fork's own graph taps say, pushed to everything that draws a meter.
+void AudioBridge::updateMetersFromGraph() {
     trackController_.withTrackMapping(
         [this](const std::map<TrackId, te::AudioTrack*>& trackMapping) {
             refreshInputMeterClients(trackMapping);

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -654,6 +654,19 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
         return deviceMetering_;
     }
 
+    /// Another engine fills the meters, so this one stops polling graph taps
+    /// nothing renders through (#2570). Set once, before the first tick.
+    void setMeteringFedElsewhere(bool fedElsewhere) {
+        meteringFedElsewhere_ = fedElsewhere;
+    }
+
+    /// What the master strip shows, for a caller that metered it itself. The
+    /// metering buffer cannot hold it: MASTER_TRACK_ID is negative (#2570).
+    void setMasterPeak(float peakL, float peakR) {
+        masterPeakL_.store(peakL, std::memory_order_relaxed);
+        masterPeakR_.store(peakR, std::memory_order_relaxed);
+    }
+
     /**
      * @brief Get master channel peak level (left)
      * @return Peak level as linear gain
@@ -821,6 +834,10 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
     // =========================================================================
 
   private:
+    /// The fork's own graph taps, read on the timer and pushed to every meter
+    /// ring. Skipped whole when another engine feeds them (#2570).
+    void updateMetersFromGraph();
+
     // Timer callback for metering updates (runs on message thread)
     void timerCallback() override;
     void refreshInputMeterClients(const std::map<TrackId, te::AudioTrack*>& trackMapping);
@@ -874,6 +891,9 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
 
     // Per-device metering (LevelMeasurer per device, polled on timer)
     DeviceMeteringManager deviceMetering_;
+
+    // Message thread only, like the timer that reads it (#2570).
+    bool meteringFedElsewhere_ = false;
 
     // Master channel metering (lock-free atomics for thread safety)
     std::atomic<float> masterPeakL_{0.0f};

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -3,6 +3,7 @@
 #include <set>
 #include <string>
 
+#include "../audio/AudioBridge.hpp"
 #include "../core/UndoManager.hpp"  // complete type for the unique_ptr this forwards
 #include "TracktionEngineWrapper.hpp"
 #include "host/EngineHost.hpp"
@@ -22,6 +23,34 @@ MagdaAudioEngine::MagdaAudioEngine(AudioEngineOptions options) {
     // things without first asking whether it exists. It renders nothing until
     // start() puts it on a device.
     host_ = std::make_unique<daw::engine_host::EngineHost>();
+}
+
+/**
+ * @brief Point the host's meters at the fork's rings (#2570).
+ *
+ * The only side holding both an engine that measures and a bridge that
+ * publishes. Three rings because they are three readers of one measurement,
+ * which is why the fork pushes to all three too.
+ */
+void MagdaAudioEngine::meterInto(AudioBridge* bridge) {
+    if (bridge == nullptr)
+        return;
+
+    bridge->setMeteringFedElsewhere(true);
+
+    host_->meterInto([bridge](TrackId trackId, float peakL, float peakR) {
+        // No ring can hold it: MASTER_TRACK_ID is negative, and the master
+        // strip reads the bridge directly.
+        if (trackId == MASTER_TRACK_ID) {
+            bridge->setMasterPeak(peakL, peakR);
+            return;
+        }
+
+        const MeterData data{.peakL = peakL, .peakR = peakR};
+        bridge->getMeteringBuffer().pushLevels(trackId, data);
+        bridge->getRecordingMeteringBuffer().pushLevels(trackId, data);
+        bridge->getRemoteMeteringBuffer().pushLevels(trackId, data);
+    });
 }
 
 void MagdaAudioEngine::reportUnwired(const char* method, const char* issue) const {
@@ -47,6 +76,8 @@ bool MagdaAudioEngine::initialize() {
     // Before the device, so the first publish can already load the plugins a
     // project names rather than going without them until the second (#2566).
     host_->setPluginServices(fork_->getPluginFormatManager(), fork_->getKnownPluginList());
+
+    meterInto(tracktion_->getAudioBridge());
 
     // After the fork, because the device is its to open: the settings UI, the
     // channel lists and the driver choice are all still on that side, and two

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -189,6 +189,10 @@ class MagdaAudioEngine final : public AudioEngine {
   private:
     /// Whatever has not moved to magda::engine yet, said once per method
     /// rather than answered with silence.
+    /// Where the host's levels go, and the fork told to stop measuring what it
+    /// no longer renders (#2570). Once, in initialize().
+    void meterInto(AudioBridge* bridge);
+
     void reportUnwired(const char* method, const char* issue) const;
 
     /// The loop as one value, from the fork that still holds both halves.

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -109,6 +109,13 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
             return;
 
         const auto levels = tap->read();
+
+        // A meter reading nothing and a meter nothing reads look identical from
+        // a still mixer, so the trace says which (#2570).
+        if (EngineTrace::enabled() && levels.loudest() > 0.0f)
+            EngineTrace::print("meter: track " + juce::String(trackId) + " peak " +
+                               juce::String(levels.loudest(), 4));
+
         meters_(trackId, levels.peak[0], levels.peak[1]);
     }
 

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -32,6 +32,9 @@ namespace {
 /// and a narrow device is a declared width rather than a smaller buffer.
 constexpr int kChannels = 2;
 
+/// 30 fps, which is what the fork's own metering timer runs at.
+constexpr int kMeterIntervalMs = 33;
+
 /// Anything a publish could not honour, named by the half that reported it.
 void report(const juce::String& what, const std::vector<std::string>& messages) {
     for (const auto& message : messages)
@@ -60,6 +63,10 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                   }) {
         factory_.loadExternalsWith(loader_);
 
+        // A tap read late loses nothing, since the peak is held until
+        // something takes it, so this is how smooth a meter looks.
+        startTimer(kMeterIntervalMs);
+
         if (!EngineTrace::enabled())
             return;
 
@@ -67,18 +74,42 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         // write to it on this thread and the devices write to it on the audio
         // thread, and reading them in order is the whole point.
         factory_.traceInto(trace_);
-        startTimer(100);
         EngineTrace::print("MIDI trace on. Publishes and what reached each device, in order.");
     }
 
     ~Impl() override {
+        stopTimer();
         detach();
     }
 
-    /// The audio thread's side of the trace, on the thread allowed to print it.
+    /// The meters, and the audio thread's side of the trace.
     void timerCallback() override {
+        publishMeters();
+
         for (const auto& line : trace_.drain())
             EngineTrace::print(line);
+    }
+
+    /// What every track's output tap has held since the last tick (#2570).
+    /// Walked off the model, and the one reader: LevelTap::read is
+    /// destructive.
+    void publishMeters() {
+        if (session_ == nullptr || meters_ == nullptr)
+            return;
+
+        for (const auto& track : TrackManager::getInstance().getTracks())
+            publishMeter(track.id);
+
+        publishMeter(MASTER_TRACK_ID);
+    }
+
+    void publishMeter(TrackId trackId) {
+        auto* tap = session_->meterTap(engine::trackMeterKey(trackId));
+        if (tap == nullptr)
+            return;
+
+        const auto levels = tap->read();
+        meters_(trackId, levels.peak[0], levels.peak[1]);
     }
 
     /// Where the transport was when the model moved, in the same stream as the
@@ -529,6 +560,9 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
 
     std::vector<juce::String> unbuilt_;
     EngineTrace trace_;
+
+    /// Where the levels go. Null until a caller asks (#2570).
+    EngineHost::MeterSink meters_;
 };
 
 EngineHost::EngineHost() : impl_(std::make_unique<Impl>()) {}
@@ -542,6 +576,10 @@ void EngineHost::start(juce::AudioDeviceManager& devices) {
 void EngineHost::setPluginServices(juce::AudioPluginFormatManager& formats,
                                    const juce::KnownPluginList& knownPlugins) {
     impl_->loader_.setServices(&formats, &knownPlugins);
+}
+
+void EngineHost::meterInto(MeterSink sink) {
+    impl_->meters_ = std::move(sink);
 }
 
 void EngineHost::stop() {

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+
+#include "../../core/TypeIds.hpp"
 
 namespace juce {
 class AudioDeviceManager;
@@ -57,6 +60,16 @@ class EngineHost {
      */
     void setPluginServices(juce::AudioPluginFormatManager& formats,
                            const juce::KnownPluginList& knownPlugins);
+
+    /**
+     * @brief Where the levels this renders go (#2570).
+     *
+     * On the message thread at meter rate, per track and for the master, with
+     * the peak since the last call. Set before @ref start; without one nothing
+     * reads the taps, which costs only the meters.
+     */
+    using MeterSink = std::function<void(TrackId trackId, float peakL, float peakR)>;
+    void meterInto(MeterSink sink);
 
     /// Take the callback back off the device and stop following the model.
     /// Safe to call twice, and called by the destructor.

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -122,6 +122,15 @@ std::unique_ptr<engine::EngineDevice> EngineRuntimeFactory::handOver(
     return std::make_unique<TracingDevice>(std::move(device), *trace_);
 }
 
+/// A track's output level, and nothing else (#2570): the per-slot meters read
+/// through DeviceMeteringManager and a monitored input's through #1895.
+std::unique_ptr<engine::LevelTap> EngineRuntimeFactory::createMeter(const engine::OpKey& key) {
+    if (key.role != engine::OpRole::TrackMeter)
+        return nullptr;
+
+    return std::make_unique<engine::LevelTap>();
+}
+
 std::unique_ptr<engine::EngineAudioSource> EngineRuntimeFactory::createClipAudioSource(
     TrackId trackId) {
     return audioSource(trackId, engine::Section::Arrangement);

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -101,6 +101,7 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
 
     std::unique_ptr<engine::EngineDevice> createDevice(engine::DeviceKey key) override;
     std::set<engine::DeviceKey> devicesToRebuild() override;
+    std::unique_ptr<engine::LevelTap> createMeter(const engine::OpKey& key) override;
     std::unique_ptr<engine::EngineAudioSource> createClipAudioSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineMidiSource> createClipMidiSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineAudioSource> createSessionAudioSource(TrackId trackId) override;

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -386,6 +386,11 @@ class EngineSession {
         return store_.valueTap(key);
     }
 
+    /// The level behind one Meter op (#2570).
+    LevelTap* meterTap(const OpKey& key) const {
+        return store_.meterTap(key);
+    }
+
     /// Values the live plan found somewhere to publish from -- not the
     /// number of taps the store holds, since a key the parameter table does
     /// not carry has a tap that is never written through. On the publishing

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -486,6 +486,11 @@ ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {
     return found == valueTaps_.end() ? nullptr : found->second.get();
 }
 
+LevelTap* RuntimeStateStore::meterTap(const OpKey& key) const {
+    const auto found = meters_.find(key);
+    return found == meters_.end() ? nullptr : found->second.get();
+}
+
 std::size_t RuntimeStateStore::size() const {
     return devices_.size() + retired_.size() + clipAudio_.size() + clipMidi_.size() +
            sessionAudio_.size() + sessionMidi_.size() + handles_.size() + audioInputs_.size() +

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -267,6 +267,14 @@ class RuntimeStateStore {
     ValueTap* valueTap(const ParamKey& key) const;
 
     /**
+     * @brief The tap the Meter op at @p key writes to, or nullptr (#2570).
+     *
+     * Null for a meter the factory declined and for an op no plan has named.
+     * One reader, since LevelTap::read is destructive.
+     */
+    LevelTap* meterTap(const OpKey& key) const;
+
+    /**
      * @brief Make a handle for every slot @p clips names, publish them, and
      *        retire the ones the snapshot has stopped naming.
      *

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -1490,9 +1490,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
 
     emitSends(false, out);
 
-    const OpKey meterKey{track.id,          INVALID_RACK_ID,    INVALID_CHAIN_ID,
-                         INVALID_DEVICE_ID, OpRole::TrackMeter, 0};
-    out = PortRef{addOp(OpKind::Meter, meterKey, {out}, {SignalKind::Audio}), 0};
+    out = PortRef{addOp(OpKind::Meter, trackMeterKey(track.id), {out}, {SignalKind::Audio}), 0};
     trackSidechainTap_[track.id] = out;
 
     const OpKey muteKey{track.id,          INVALID_RACK_ID,   INVALID_CHAIN_ID,

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -343,6 +343,13 @@ struct OpKey {
     bool operator<(const OpKey& o) const;
 };
 
+/// The key of the Meter op at @p trackId's output. One definition, because a
+/// host looking a meter up under a key one field out reads nothing (#2570).
+inline OpKey trackMeterKey(TrackId trackId) {
+    return OpKey{trackId,           INVALID_RACK_ID,    INVALID_CHAIN_ID,
+                 INVALID_DEVICE_ID, OpRole::TrackMeter, 0};
+}
+
 /** A reference to one output port of an earlier op. */
 struct PortRef {
     OpId op = INVALID_OP_ID;

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -162,6 +162,8 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::test::runWithCleanJuceState([this] { testReplacedPluginIsRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testClearedProjectIsRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testDroppedKeyIsStillRebuilt(); });
+        magda::test::runWithCleanJuceState([this] { testMetersReadWhatWasRendered(); });
+        magda::test::runWithCleanJuceState([this] { testOnlyTrackMetersAreTapped(); });
     }
 
   private:
@@ -427,6 +429,92 @@ class EngineHostPublishTest final : public juce::UnitTest {
         const auto rebuild = factory.devicesToRebuild();
         expect(rebuild.size() == 1 && rebuild.contains(firstFxSlot()),
                "Every device the store holds is the previous project's");
+    }
+
+    void testMetersReadWhatWasRendered() {
+        beginTest("A track's meter and the master's read what the engine rendered");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Instrument");
+        auto* track = trackManager.getTrack(trackId);
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(track != nullptr && master != nullptr, "The track and the master exist");
+        if (track == nullptr || master == nullptr)
+            return;
+
+        track->chain.fxChainElements.emplace_back(polySynth(1));
+
+        auto& clips = magda::ClipManager::getInstance();
+        const auto clipId = clips.createMidiClipBeats(trackId, 0.0, 4.0);
+        expect(clips.addMidiNote(clipId, magda::MidiNote{.noteNumber = 60,
+                                                         .velocity = 100,
+                                                         .startBeat = 0.0,
+                                                         .lengthBeats = 2.0}),
+               "The clip holds a note");
+
+        const auto& tracks = trackManager.getTracks();
+        const magda::engine::RenderContext context{.sampleRate = 44100.0, .maxBlockSize = 512};
+        const auto tempo = host::tempoMapAt(120.0, 4, 4);
+
+        host::EngineFileReaders files;
+        magda::engine::PrefetchThread reader(false);
+        host::EngineRuntimeFactory factory;
+        factory.setModel(tracks, *master);
+
+        magda::engine::ClipVoicePool voices(files, reader, context);
+        magda::engine::EngineSession session(factory, nullptr, &voices);
+        factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed());
+
+        const auto plan = std::make_shared<const magda::engine::RenderPlan>(
+            magda::engine::compileRenderPlan(tracks, *master));
+
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(*plan, tracks, *master, values);
+        expect(session
+                   .publish(plan, context, magda::engine::collectRuntimeStateIds(tracks, *master),
+                            std::move(values))
+                   .published,
+               "The plan is published");
+
+        session.publishClips(
+            std::make_shared<const magda::engine::ClipSnapshot>(magda::engine::compileClipSnapshot(
+                host::clipLanesFor(tracks), host::clipSources(), tempo)));
+        session.publishTransport({.tempo = tempo, .request = {.generation = 1, .playing = true}});
+
+        juce::AudioBuffer<float> output(2, context.maxBlockSize);
+        for (auto block = 0; block < 43; ++block)
+            session.process(context.maxBlockSize, output);
+
+        // The key the host asks under has to be the one the compiler emitted,
+        // which a null here is the only symptom of.
+        auto* trackTap = session.meterTap(magda::engine::trackMeterKey(trackId));
+        auto* masterTap = session.meterTap(magda::engine::trackMeterKey(magda::MASTER_TRACK_ID));
+        expect(trackTap != nullptr && masterTap != nullptr, "Both meters are bound");
+        if (trackTap == nullptr || masterTap == nullptr)
+            return;
+
+        expect(trackTap->read().loudest() > 0.0f, "The track's meter read the note");
+        expect(masterTap->read().loudest() > 0.0f, "The master's meter read it too");
+
+        // Destructive, which is what stops the frame rate deciding how much of
+        // the signal a meter ever sees.
+        expect(trackTap->read().loudest() == 0.0f, "A second read takes nothing twice");
+    }
+
+    void testOnlyTrackMetersAreTapped() {
+        beginTest("A meter nobody collects is declined");
+
+        host::EngineRuntimeFactory factory;
+
+        magda::engine::OpKey deviceMeter;
+        deviceMeter.trackId = 1;
+        deviceMeter.deviceId = 1;
+        deviceMeter.role = magda::engine::OpRole::DeviceMeter;
+
+        expect(factory.createMeter(magda::engine::trackMeterKey(1)) != nullptr,
+               "A track's output level is read");
+        expect(factory.createMeter(deviceMeter) == nullptr,
+               "A device slot's is not: the chain UI reads DeviceMeteringManager");
     }
 
     void testDroppedKeyIsStillRebuilt() {


### PR DESCRIPTION
Fixes #2570: every meter in the app was dead under `MAGDA_AUDIO_ENGINE=magda`.

`EngineRuntimeFactory` never overrode `RuntimeStateFactory::createMeter`, so it
returned the base `nullptr` and the plan's Meter ops — one at every track,
every device slot and the master — stood behind nothing.

## The wiring

- **`EngineRuntimeFactory::createMeter`** answers `OpRole::TrackMeter` and
  declines the rest. A device slot's meter reads through
  `DeviceMeteringManager` and a monitored input's is #1895, so a tap made for
  either would be one nobody collects.
- **`RuntimeStateStore::meterTap`** and an `EngineSession` forwarder, mirroring
  the existing `valueTap` pair.
- **`trackMeterKey(TrackId)`** in `RenderPlan.hpp`, used by the compiler and by
  the host. A meter looked up under a key one field out is silently a meter
  that reads nothing, so there is one definition rather than two.
- **`EngineHost`** reads every track and the master on a 30 fps timer into a
  `MeterSink`. The timer already existed for the MIDI trace and now always
  runs. One reader, because `LevelTap::read` is destructive.
- **`MagdaAudioEngine`** supplies the sink — the only side holding both an
  engine that measures and a bridge that publishes. It pushes into the fork's
  three metering rings (the same three the fork itself pushes to: mixer,
  recording, remote API) and calls `setMasterPeak` for `MASTER_TRACK_ID`, whose
  id is negative and so cannot go in a ring.

The UI needs no changes: `MixerView`, `TrackHeadersPanel` and `SessionView`
already read those rings, and the master strip already reads
`getMasterPeakL/R`.

## The fork has to stand down

`AudioBridge::setMeteringFedElsewhere` skips the fork's own metering poll for
the session. Its graph taps sit in a playback context nothing renders through,
so they all read silence — and pushing that into the same ring the native
engine writes to would take every meter to zero every other frame. The block
moved into `updateMetersFromGraph()` so the skip is one condition.

## Tests

In `test_engine_host_publish_juce.cpp`:

- a project of a Poly Synth and a MIDI clip is rendered, then the track's meter
  and the master's both report a level, and a second read reports nothing —
  which is what stops the frame rate deciding how much of the signal a meter
  sees. A wrong `trackMeterKey` shows up here as a null tap.
- `createMeter` answers a `TrackMeter` key and declines a `DeviceMeter` one.

Verified negatively: with `createMeter` back to `nullptr`, both fail.

Full `magda_tests` (3907 passed / 13 skipped) and `magda_juce_tests` green.

Not driven by hand — meters are a display, and I cannot click through the app.
Worth a look at the mixer under `MAGDA_AUDIO_ENGINE=magda` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN