### PR TITLE
Declare a project teardown instead of inferring it

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -159,6 +159,7 @@ AudioBridge::AudioBridge(te::Engine& engine, te::Edit& edit)
 
     // Register as TrackManager listener
     TrackManager::getInstance().addListener(this);
+    ProjectManager::getInstance().addListener(this);
 
     // Hook into ModulatorEngine's per-tick callback so that after the visual
     // sim updates each ModInfo, we overlay TE's authoritative LFO phase +
@@ -204,6 +205,7 @@ AudioBridge::~AudioBridge() {
         stopTimer();
 
         // Now safe to remove listeners as timer is stopped and shutdown flag is set
+        ProjectManager::getInstance().removeListener(this);
         TrackManager::getInstance().removeListener(this);
         // Note: ClipManager listener removed by ClipSynchronizer destructor
 
@@ -291,6 +293,24 @@ void AudioBridge::resetTestState() {
     automationPlayback_.clearAllLanes();
     trackController_.clearAllMappings();
     pluginManager_.clearAllMappings();
+}
+
+// =============================================================================
+// ProjectManagerListener implementation
+// =============================================================================
+
+/**
+ * @brief Drop the TE tracks and plugins the outgoing project was synced into
+ *
+ * The plugin sync is additive and keyed by chain path, and ids restart at 1 in
+ * every project: a device left mapped is one the next sync skips creating, and
+ * it becomes a husk with no editor and no processing.
+ */
+void AudioBridge::projectTeardown() {
+    for (auto trackId : trackController_.getAllTrackIds()) {
+        pluginManager_.cleanupTrackPlugins(trackId);
+        trackController_.removeAudioTrack(trackId);
+    }
 }
 
 // =============================================================================

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -11,6 +11,7 @@
 #include "../core/DeviceInfo.hpp"
 #include "../core/TrackManager.hpp"
 #include "../core/TypeIds.hpp"
+#include "../project/ProjectManager.hpp"
 #include "AudioBridgeMixer.hpp"
 #include "DeviceMeteringManager.hpp"
 #include "ExternalInsertDeviceEnablement.hpp"
@@ -55,7 +56,10 @@ class SessionMonitorPlugin;
  * - UI thread: Receives TrackManager/ClipManager notifications, updates mappings
  * - Audio thread: Reads mappings, processes parameter changes, pushes metering
  */
-class AudioBridge : public TrackManagerListener, public ClipManagerListener, public juce::Timer {
+class AudioBridge : public TrackManagerListener,
+                    public ClipManagerListener,
+                    public ProjectManagerListener,
+                    public juce::Timer {
   public:
     /**
      * @brief Construct AudioBridge with Tracktion Engine references
@@ -66,6 +70,12 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
     ~AudioBridge() override;
 
     void resetTestState();
+
+    // =========================================================================
+    // ProjectManagerListener implementation
+    // =========================================================================
+
+    void projectTeardown() override;
 
     // =========================================================================
     // TrackManagerListener implementation

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -67,6 +67,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         ${CMAKE_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/magda/daw
         ${CMAKE_SOURCE_DIR}/magda/daw/audio
+        # ProjectInfo.hpp reaches the configured version.hpp, and the host
+        # follows the project lifecycle (#2576).
+        ${CMAKE_BINARY_DIR}/magda/daw/generated
     )
 
     # magda_engine is added after magda/daw, so this names it before it exists.

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -11,6 +11,7 @@
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/TrackManager.hpp"
+#include "../../project/ProjectManager.hpp"
 #include "EngineProject.hpp"
 #include "EngineRuntimeFactory.hpp"
 #include "EngineTrace.hpp"
@@ -54,7 +55,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                                 private juce::AsyncUpdater,
                                 private juce::Timer,
                                 private TrackManagerListener,
-                                private ClipManagerListener {
+                                private ClipManagerListener,
+                                private ProjectManagerListener {
     Impl()
         : loader_([this](engine::DeviceKey key) { return modelDevice(key); },
                   [this](engine::DeviceKey key, const DeviceInfo& resolved,
@@ -161,6 +163,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         devices_ = &devices;
         TrackManager::getInstance().addListener(this);
         ClipManager::getInstance().addListener(this);
+        ProjectManager::getInstance().addListener(this);
         devices_->addAudioCallback(this);
     }
 
@@ -172,6 +175,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         // through, and removeAudioCallback returns only once the audio thread
         // is out of here.
         devices_->removeAudioCallback(this);
+        ProjectManager::getInstance().removeListener(this);
         ClipManager::getInstance().removeListener(this);
         TrackManager::getInstance().removeListener(this);
         devices_ = nullptr;
@@ -264,13 +268,14 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
 
     // ===== Following the model =====
 
-    void tracksChanged() override {
-        // Inferred, because nothing declares a teardown (#2576): the publish
-        // this schedules is coalesced, and the next project is loaded before
-        // it runs (#2572).
-        if (modelHoldsNoDevices())
-            factory_.forgetBuiltDevices();
+    /// Nothing the store holds outlives the project it was built for: track
+    /// and device ids restart at 1 in the next one, so its keys would collide
+    /// with devices that are already gone (#2572).
+    void projectTeardown() override {
+        factory_.forgetBuiltDevices();
+    }
 
+    void tracksChanged() override {
         wantPlan();
     }
     void trackDevicesChanged(TrackId) override {

--- a/magda/daw/engine/host/EngineProject.cpp
+++ b/magda/daw/engine/host/EngineProject.cpp
@@ -1,9 +1,7 @@
 #include "EngineProject.hpp"
 
-#include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/SourcePool.hpp"
-#include "../../core/TrackManager.hpp"
 
 namespace magda::daw::engine_host {
 
@@ -48,17 +46,6 @@ engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator) {
                                 .numerator = numerator,
                                 .denominator = denominator,
                             }});
-}
-
-bool modelHoldsNoDevices() {
-    const auto& tracks = TrackManager::getInstance().getTracks();
-
-    // First, so the walk only happens in the state that can answer yes.
-    if (!tracks.empty())
-        return false;
-
-    const auto* master = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
-    return master == nullptr || audio::engine_adapter::devicesIn(tracks, *master).empty();
 }
 
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineProject.hpp
+++ b/magda/daw/engine/host/EngineProject.hpp
@@ -35,8 +35,4 @@ std::vector<engine::ClipSourceInfo> clipSources();
 /// (#2554 moves that).
 engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator);
 
-/// Whether the model names a device anywhere, master included. What a project
-/// teardown looks like while it is happening, until one is declared (#2576).
-bool modelHoldsNoDevices();
-
 }  // namespace magda::daw::engine_host

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -295,7 +295,7 @@ bool ProjectManager::newProject() {
         return false;
     }
 
-    resetTransportForProjectBoundary();
+    beginProjectTeardown();
 
     // Clear all project content from singleton managers. Source ids are
     // project-scoped like clip ids, so the pool empties here rather than in
@@ -457,7 +457,7 @@ bool ProjectManager::loadProject(const juce::File& file,
         return false;
     }
 
-    resetTransportForProjectBoundary();
+    beginProjectTeardown();
 
     // Set tempo/time sig/loop on the audio engine BEFORE committing tracks & clips,
     // so that audio engine clip sync uses the correct BPM.
@@ -570,7 +570,7 @@ void ProjectManager::importDawProjectAsync(
                             return;
                         }
 
-                        resetTransportForProjectBoundary();
+                        beginProjectTeardown();
 
                         if (onBeforeCommit)
                             onBeforeCommit(staged->info);
@@ -660,7 +660,7 @@ void ProjectManager::loadProjectAsync(
                     return;
                 }
 
-                resetTransportForProjectBoundary();
+                beginProjectTeardown();
 
                 // Set tempo/time sig/loop BEFORE committing tracks & clips,
                 // so that audio engine clip sync uses the correct BPM.
@@ -713,7 +713,7 @@ bool ProjectManager::closeProject() {
 
     deleteAutosaveFile();
 
-    resetTransportForProjectBoundary();
+    beginProjectTeardown();
 
     // Clear all project content from singleton managers. Source ids are
     // project-scoped like clip ids, so the pool empties here rather than in
@@ -850,6 +850,16 @@ void ProjectManager::addListener(ProjectManagerListener* listener) {
 
 void ProjectManager::removeListener(ProjectManagerListener* listener) {
     listeners_.erase(std::remove(listeners_.begin(), listeners_.end(), listener), listeners_.end());
+}
+
+void ProjectManager::beginProjectTeardown() {
+    // The transport first: a listener about to drop what it built for this
+    // project should not be dropping it out from under a running render.
+    resetTransportForProjectBoundary();
+
+    for (auto* listener : listeners_) {
+        listener->projectTeardown();
+    }
 }
 
 void ProjectManager::notifyProjectOpened() {

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -21,6 +21,17 @@ class ProjectManagerListener {
     virtual ~ProjectManagerListener() = default;
 
     /**
+     * @brief Called when the current project's runtime is over
+     *
+     * Fired by every path that replaces the project - load, import, new,
+     * close - after the transport has stopped and before the model is
+     * cleared. A listener that has to drop what it built for the outgoing
+     * project does it here rather than inferring the gap from an empty model
+     * (#2576).
+     */
+    virtual void projectTeardown() {}
+
+    /**
      * @brief Called when a project is opened or created
      */
     virtual void projectOpened(const ProjectInfo& info) {
@@ -361,6 +372,12 @@ class ProjectManager {
     void endUndoableMutation();
     void setUndoHistoryDirty(bool dirty);
     void refreshDirtyState();
+
+    /// Stop the transport and declare the current project's runtime over.
+    /// Every path that replaces the project goes through here, before it
+    /// clears the model.
+    void beginProjectTeardown();
+
     void notifyProjectOpened();
     void notifyProjectSaved();
     void notifyProjectClosed();

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -803,19 +803,9 @@ void ProjectSerializer::commitStagedData(std::vector<TrackInfo>& stagedTracks,
         clipManager.clearAllClips();
         automationManager.clearAll();
 
-        // Tear down the previous project's tracks OUTSIDE the restore batch, so
-        // clearAllTracks()'s notifyTracksChanged() fires immediately and runs
-        // AudioBridge::syncAll() against an empty track set. That removes the old
-        // TE AudioTracks and their synced plugins. If the clear is coalesced into
-        // the restore batch below, syncAll only ever sees the FINAL state, so the
-        // additive, path-keyed plugin sync finds Track[N] > Device[M] still
-        // present -- track/device IDs reset to 1 every project, so the paths
-        // collide across projects -- and skips recreating the plugin (it only
-        // creates devices whose path is absent). The device then becomes a dead
-        // husk: no editor, no processing. This is the "open A, open B, open A
-        // again -> VST has no UI and does nothing" bug. clearAllTracks fires a
-        // single teardown notification, so it does not reintroduce the O(N^2)
-        // fan-out the restore batch guards against.
+        // Drop the previous project's tracks. What listened for the runtime gap
+        // here now hears ProjectManagerListener::projectTeardown() instead
+        // (#2576), so this is a plain clear rather than a signal.
         trackManager.clearAllTracks();
 
         // Restore tracks in their own batch that closes BEFORE clips are

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ set(TEST_SOURCES
     project/test_project_document_adapters.cpp
     # Unsaved-changes tracking across the undo stack and project boundaries
     project/test_project_dirty_tracking.cpp
+    project/test_project_teardown.cpp
     clips/test_session_clip_playback.cpp
     devices/test_sidechain_triggers.cpp
     devices/test_sidechain_device.cpp

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -403,7 +403,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
     }
 
     void testClearedProjectIsRebuilt() {
-        beginTest("A cleared project is every device it held named for rebuild");
+        beginTest("A torn-down project is every device it held named for rebuild");
 
         auto& trackManager = magda::TrackManager::getInstance();
         const auto trackId = trackManager.createTrack("Instrument");
@@ -418,14 +418,11 @@ class EngineHostPublishTest final : public juce::UnitTest {
         host::EngineRuntimeFactory factory;
         factory.setModel(trackManager.getTracks(), *master);
         expect(factory.createDevice(firstFxSlot()) != nullptr, "The catalog builds the synth");
-        expect(!host::modelHoldsNoDevices(), "A project with a device in it is not a teardown");
 
-        // What a project load does before it restores anything, and the only
-        // moment the empty model is visible.
-        trackManager.clearAllTracks();
-        expect(host::modelHoldsNoDevices(), "A cleared project names no device anywhere");
-
+        // What EngineHost does on a declared project teardown (#2576), while
+        // the outgoing project is still the model.
         factory.forgetBuiltDevices();
+
         const auto rebuild = factory.devicesToRebuild();
         expect(rebuild.size() == 1 && rebuild.contains(firstFxSlot()),
                "Every device the store holds is the previous project's");

--- a/tests/project/test_project_teardown.cpp
+++ b/tests/project/test_project_teardown.cpp
@@ -1,0 +1,159 @@
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/project/ProjectManager.hpp"
+
+// The gap between one project's runtime ending and the next one's model
+// arriving (#2576): every path that replaces the project declares it, and
+// declares it while the outgoing project is still the one in the model.
+
+namespace {
+
+using magda::ProjectManager;
+using magda::TrackManager;
+
+/// What each listener callback was, in the order it arrived. The order is the
+/// point: a teardown after the restore would be a listener tearing down the
+/// project that just arrived.
+class LifecycleLog final : public magda::ProjectManagerListener {
+  public:
+    LifecycleLog() {
+        ProjectManager::getInstance().addListener(this);
+    }
+
+    ~LifecycleLog() override {
+        ProjectManager::getInstance().removeListener(this);
+    }
+
+    LifecycleLog(const LifecycleLog&) = delete;
+    LifecycleLog& operator=(const LifecycleLog&) = delete;
+
+    void projectTeardown() override {
+        events.emplace_back("teardown");
+        tracksAtTeardown.push_back(
+            static_cast<int>(TrackManager::getInstance().getTracks().size()));
+    }
+
+    void projectOpened(const magda::ProjectInfo&) override {
+        events.emplace_back("opened");
+    }
+
+    void projectClosed() override {
+        events.emplace_back("closed");
+    }
+
+    std::vector<juce::String> events;
+    std::vector<int> tracksAtTeardown;
+};
+
+juce::File tempProjectFile() {
+    auto envTmp = juce::SystemStats::getEnvironmentVariable("TMPDIR", {});
+    auto root = envTmp.isNotEmpty() ? juce::File(envTmp)
+                                    : juce::File::getSpecialLocation(juce::File::tempDirectory);
+    root.createDirectory();
+    return root.getNonexistentChildFile("teardown", ".mgd");
+}
+
+/// saveProjectAs wraps the file in a directory named after the project.
+juce::File wrappedPath(const juce::File& file) {
+    const auto name = file.getFileNameWithoutExtension();
+    return file.getParentDirectory().getChildFile(name).getChildFile(file.getFileName());
+}
+
+struct ProjectFixture {
+    ProjectFixture() {
+        TrackManager::getInstance().clearAllTracks();
+    }
+
+    ~ProjectFixture() {
+        for (const auto& dir : dirs)
+            dir.deleteRecursively();
+        for (const auto& file : files)
+            file.deleteFile();
+
+        TrackManager::getInstance().clearAllTracks();
+    }
+
+    ProjectFixture(const ProjectFixture&) = delete;
+    ProjectFixture& operator=(const ProjectFixture&) = delete;
+
+    juce::File newTempProject() {
+        auto file = tempProjectFile();
+        files.push_back(file);
+        dirs.push_back(file.getParentDirectory().getChildFile(file.getFileNameWithoutExtension()));
+        return file;
+    }
+
+    std::vector<juce::File> files;
+    std::vector<juce::File> dirs;
+};
+
+}  // namespace
+
+TEST_CASE("A new project declares the previous one's teardown", "[project][teardown]") {
+    ProjectFixture fixture;
+    auto& projectManager = ProjectManager::getInstance();
+
+    projectManager.newProject();
+    TrackManager::getInstance().createTrack("Instrument");
+
+    LifecycleLog log;
+    REQUIRE(projectManager.newProject());
+
+    REQUIRE(log.events == std::vector<juce::String>{"teardown", "opened"});
+    REQUIRE(log.tracksAtTeardown == std::vector<int>{1});
+}
+
+TEST_CASE("Closing a project declares its teardown", "[project][teardown]") {
+    ProjectFixture fixture;
+    auto& projectManager = ProjectManager::getInstance();
+
+    projectManager.newProject();
+    TrackManager::getInstance().createTrack("Instrument");
+
+    LifecycleLog log;
+    REQUIRE(projectManager.closeProject());
+
+    REQUIRE(log.events == std::vector<juce::String>{"teardown", "closed"});
+    REQUIRE(log.tracksAtTeardown == std::vector<int>{1});
+}
+
+TEST_CASE("Loading declares the teardown before the restore", "[project][teardown]") {
+    ProjectFixture fixture;
+    auto& projectManager = ProjectManager::getInstance();
+
+    projectManager.newProject();
+    TrackManager::getInstance().createTrack("Saved");
+
+    const auto file = fixture.newTempProject();
+    REQUIRE(projectManager.saveProjectAs(file));
+
+    // A second project, so the load has something of its own to tear down.
+    projectManager.newProject();
+    TrackManager::getInstance().createTrack("Outgoing");
+    TrackManager::getInstance().createTrack("Also outgoing");
+
+    LifecycleLog log;
+    REQUIRE(projectManager.loadProject(wrappedPath(file)));
+
+    REQUIRE(log.events == std::vector<juce::String>{"teardown", "opened"});
+
+    // Two, not zero: the outgoing project is still the model when the teardown
+    // is declared, which is what lets a listener walk what it has to drop.
+    REQUIRE(log.tracksAtTeardown == std::vector<int>{2});
+}
+
+TEST_CASE("A load that never stages declares no teardown", "[project][teardown]") {
+    ProjectFixture fixture;
+    auto& projectManager = ProjectManager::getInstance();
+
+    projectManager.newProject();
+    TrackManager::getInstance().createTrack("Instrument");
+
+    LifecycleLog log;
+    REQUIRE_FALSE(projectManager.loadProject(juce::File("/nonexistent/project.mgd")));
+
+    REQUIRE(log.events.empty());
+    REQUIRE(TrackManager::getInstance().getTracks().size() == 1);
+}


### PR DESCRIPTION
Opening a project ends the previous one's runtime, and nothing said so. Both subsystems that needed to see the gap inferred it from `TrackManager`'s "tracks changed" firing over an empty model: `AudioBridge` relied on `ProjectSerializer` calling `clearAllTracks()` outside the restore batch, and `EngineHost` (since #2572) asked `modelHoldsNoDevices()`. Coalescing that one clear into a batch, a change that reads as a free performance win, would have broken both silently.

## What changed

`ProjectManagerListener::projectTeardown()` fires from every path that replaces the project - `newProject`, `closeProject`, `loadProject`, `importDawProject` - through a new `beginProjectTeardown()`. It runs after the transport stops and before the model is cleared, so the outgoing project is still there for a listener to walk.

- `AudioBridge` listens, and drops the TE tracks and mapped plugins it built for the outgoing project. The plugin sync is additive and keyed by chain path, and track and device ids restart at 1 in every project, so a device left mapped is one the next sync skips creating: a husk with no editor and no processing.
- `EngineHost` listens instead of watching `tracksChanged()`, and `modelHoldsNoDevices()` in `EngineProject` is gone.
- `ProjectSerializer`'s clear-outside-the-batch arrangement stops being load-bearing, and the comment guarding it becomes a pointer rather than a warning.

## Tests

`tests/project/test_project_teardown.cpp` pins that new, close and load each declare the teardown, that it arrives before `projectOpened`, that the outgoing project is still the model when it does (two tracks, not zero), and that a load which never stages declares nothing. `test_engine_host_publish_juce.cpp` now exercises the declared teardown rather than the empty-model inference.

Full Catch2 suite (3929 cases) and `magda_juce_tests` green locally, debug app links.

Closes #2576

https://claude.ai/code/session_01XVQQ9Q3oi8xDKx7Gi8pa68