### PR TITLE
Capture a native instance's plugin state on save

### DIFF
--- a/magda/daw/audio/plugins/engine/ControlExecutor.cpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.cpp
@@ -18,16 +18,79 @@ bool MessageThreadControlExecutor::run(Work work) {
     if (!work)
         return false;
 
-    // Posted even from the message thread itself. Running it here would let a
+    // Queued even from the message thread itself. Running it here would let a
     // nested operation into a plugin the outer one has open, and would put it
     // ahead of everything already waiting (ControlExecutor.hpp).
     //
-    // The flag travels with the post rather than being read off this object: by
-    // the time it arrives, this executor may be gone, and what the call needs
-    // to know is whether it still means anything rather than who it came from.
-    return juce::MessageManager::callAsync([work = std::move(work), posted = posted_]() mutable {
-        work(posted->cancelled ? ExecutionState::Cancelled : ExecutionState::Ran);
-    });
+    // The post carries the shared state rather than this object: by the time it
+    // arrives, this executor may be gone, and what the call needs is the queue
+    // and the cancelled flag rather than whoever queued it.
+    const std::scoped_lock held(posted_->lock);
+    posted_->queued.push_back(std::move(work));
+
+    if (juce::MessageManager::callAsync([posted = posted_] { pump(*posted); }))
+        return true;
+
+    // No message loop to post to, so nothing will ever answer this. Taken back
+    // out rather than left queued for a drain that may never come: a refusal
+    // says the caller still owes whatever it owed.
+    posted_->queued.pop_back();
+    return false;
+}
+
+void MessageThreadControlExecutor::pump(Posted& posted) {
+    Work work;
+
+    {
+        const std::scoped_lock held(posted.lock);
+
+        // A post whose item a drain already took, or one arriving inside work
+        // that is still running. Both are worth nothing, and the item a
+        // running drain is about to reach is the drain's.
+        if (posted.running || posted.queued.empty())
+            return;
+
+        work = std::move(posted.queued.front());
+        posted.queued.pop_front();
+        posted.running = true;
+    }
+
+    work(posted.cancelled ? ExecutionState::Cancelled : ExecutionState::Ran);
+
+    const std::scoped_lock held(posted.lock);
+    posted.running = false;
+}
+
+void MessageThreadControlExecutor::drain() {
+    // The work belongs on the message thread, so a caller on another one
+    // could only wait for it -- and a thread waiting on the message loop is
+    // usually the reason the loop is not getting there.
+    if (!isCurrent()) {
+        jassertfalse;
+        return;
+    }
+
+    // One at a time, re-reading the queue between: work is entitled to queue
+    // more of itself, and this is where that lands rather than in a snapshot
+    // taken before it ran.
+    for (;;) {
+        Work work;
+
+        {
+            const std::scoped_lock held(posted_->lock);
+            if (posted_->running || posted_->queued.empty())
+                return;
+
+            work = std::move(posted_->queued.front());
+            posted_->queued.pop_front();
+            posted_->running = true;
+        }
+
+        work(posted_->cancelled ? ExecutionState::Cancelled : ExecutionState::Ran);
+
+        const std::scoped_lock held(posted_->lock);
+        posted_->running = false;
+    }
 }
 
 bool MessageThreadControlExecutor::isCurrent() const {
@@ -61,12 +124,22 @@ SerialControlThread::SerialControlThread() : shared_(std::make_shared<Shared>())
 
                 work = std::move(shared->queued.front());
                 shared->queued.pop_front();
+                shared->busy = true;
             }
 
             // Outside the lock, because the work is what takes the time and
             // because it is entitled to queue more of itself -- which run()
             // refuses once stopping, so a drain cannot feed itself.
             work(state);
+
+            {
+                const std::scoped_lock held(shared->lock);
+                shared->busy = false;
+            }
+
+            // What a waiter is watching: an empty queue with a block still
+            // running is not an answered one.
+            shared->answered.notify_all();
         }
     });
 }
@@ -111,6 +184,22 @@ bool SerialControlThread::run(Work work) {
 
     shared_->wake.notify_one();
     return true;
+}
+
+void SerialControlThread::drain() {
+    // The worker asking for its own queue to empty is the work that would have
+    // to finish first, so there is nothing to wait for and nothing to run: a
+    // nested drain, which the header says does nothing.
+    if (isCurrent())
+        return;
+
+    // The worker's own state rather than this object's: a completion running
+    // here is entitled to destroy the executor, and a waiter holding only
+    // `this` would be waiting on something gone.
+    const auto shared = shared_;
+
+    std::unique_lock<std::mutex> held(shared->lock);
+    shared->answered.wait(held, [&shared] { return shared->queued.empty() && !shared->busy; });
 }
 
 bool SerialControlThread::isCurrent() const {

--- a/magda/daw/audio/plugins/engine/ControlExecutor.hpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.hpp
@@ -129,6 +129,20 @@ class ControlExecutor {
      */
     virtual bool run(Work work) = 0;
 
+    /**
+     * @brief Return once the work queued before this call has been answered.
+     *
+     * What a caller that cannot come back later needs: a project save reads
+     * every plugin's state and then writes the file, in one call on one
+     * thread (#2581). Whether that means running the work here or waiting for
+     * the thread that will is the implementation's business.
+     *
+     * Nothing happens inside a piece of work already running here. That is
+     * the nesting run() refuses: the outer operation still has its plugin
+     * open, and draining into it would let a second transaction in.
+     */
+    virtual void drain() = 0;
+
     /// Whether the calling thread is this executor's own.
     virtual bool isCurrent() const = 0;
 };
@@ -156,15 +170,37 @@ class MessageThreadControlExecutor final : public ControlExecutor {
     ~MessageThreadControlExecutor() override;
 
     bool run(Work work) override;
+
+    /// Runs what is queued, here, on the message thread. Refused from any
+    /// other: waiting for the message loop from a thread that is not it is
+    /// how a host becomes the reason it never gets there.
+    void drain() override;
+
     bool isCurrent() const override;
 
   private:
     /// Shared with every post this executor has made, so that destroying it
     /// turns them all into cancellations rather than calls into a plane that
     /// has gone.
+    ///
+    /// The queue is the executor's rather than the message loop's, so that a
+    /// caller on the message thread can run what is waiting instead of
+    /// returning to the loop to have it run (#2581). Each post takes one item,
+    /// so a post whose item a drain already took finds nothing and is worth
+    /// nothing, which is the only way the two can disagree.
     struct Posted {
         std::atomic<bool> cancelled{false};
+
+        std::mutex lock;
+        std::deque<Work> queued;
+
+        /// Whether a piece of work is running on the message thread now.
+        /// What makes a nested drain a no-op rather than a second
+        /// transaction inside the first.
+        bool running = false;
     };
+
+    static void pump(Posted& posted);
 
     std::shared_ptr<Posted> posted_;
 };
@@ -196,6 +232,12 @@ class SerialControlThread final : public ControlExecutor {
     ~SerialControlThread() override;
 
     bool run(Work work) override;
+
+    /// Waits for the worker to answer what is queued. From the worker itself
+    /// this is a nested drain and does nothing: the work asking is the work
+    /// that would have to finish first.
+    void drain() override;
+
     bool isCurrent() const override;
 
   private:
@@ -206,6 +248,14 @@ class SerialControlThread final : public ControlExecutor {
         std::condition_variable wake;
         std::deque<Work> queued;
         bool stopping = false;
+
+        /// Whether the worker is inside a piece of work, and what a waiter
+        /// watches alongside the queue: an empty queue with a block still
+        /// running is not an answered one.
+        bool busy = false;
+
+        /// Notified whenever the worker finishes one.
+        std::condition_variable answered;
     };
 
     std::shared_ptr<Shared> shared_;

--- a/magda/daw/core/PadCommands.cpp
+++ b/magda/daw/core/PadCommands.cpp
@@ -21,8 +21,7 @@ namespace {
 void capturePadPluginStates(const ChainNodePath& gridPath) {
     auto& tm = TrackManager::getInstance();
     if (auto* engine = tm.getAudioEngine())
-        if (auto* bridge = engine->getAudioBridge())
-            bridge->getPluginManager().capturePluginState(gridPath);
+        engine->capturePluginStateAt(gridPath);
 }
 
 PadRack snapshotPads(const ChainNodePath& gridPath) {

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -323,11 +323,8 @@ void DuplicateTrackCommand::execute() {
     // Capture current plugin state so the duplicate gets the source's live settings.
     // Skipped when we're stripping the FX chain anyway — nothing to carry over.
     if (duplicateDevices_) {
-        if (auto* engine = trackManager.getAudioEngine()) {
-            if (auto* bridge = engine->getAudioBridge()) {
-                bridge->captureAllPluginStates();
-            }
-        }
+        if (auto* engine = trackManager.getAudioEngine())
+            engine->captureAllPluginStates();
     }
 
     duplicatedTrackId_ = trackManager.duplicateTrack(sourceTrackId_, duplicateDevices_);
@@ -885,10 +882,8 @@ namespace {
 
 void capturePluginStateAt(const ChainNodePath& devicePath) {
     auto& tm = TrackManager::getInstance();
-    if (auto* engine = tm.getAudioEngine()) {
-        if (auto* bridge = engine->getAudioBridge())
-            bridge->getPluginManager().capturePluginState(devicePath);
-    }
+    if (auto* engine = tm.getAudioEngine())
+        engine->capturePluginStateAt(devicePath);
 }
 
 /// Flush every live plugin under @p chainPath into the model before it is taken

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "../audio/midi/RecordingNoteQueue.hpp"
+#include "../core/ChainNodePath.hpp"
 #include "../core/ClipTypes.hpp"
 #include "../core/ParameterDetector.hpp"
 #include "../core/TempoMap.hpp"
@@ -263,6 +264,21 @@ class AudioEngine : public AudioEngineListener {
     // ===== Audio Management =====
     virtual AudioBridge* getAudioBridge() = 0;
     virtual const AudioBridge* getAudioBridge() const = 0;
+
+    // ===== What the live plugins hold =====
+    //
+    // A project stores a plugin's own chunk, and only the instance that is
+    // rendering has one -- so which engine is rendering decides who is asked
+    // (#2581). Both of these are synchronous: the caller writes the project
+    // file, or copies the device, the moment they return.
+
+    /** Read every live plugin's state back into the model. Before a save, and
+        before a duplicate that has to carry the source's live settings. */
+    virtual void captureAllPluginStates() = 0;
+
+    /** The same for the one device at @p devicePath, whose state would
+        otherwise be the state it was placed with. */
+    virtual void capturePluginStateAt(const ChainNodePath& devicePath) = 0;
 
     // ===== MIDI Management =====
     virtual MidiBridge* getMidiBridge() = 0;

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -268,6 +268,29 @@ AudioBridge* MagdaAudioEngine::getAudioBridge() {
 const AudioBridge* MagdaAudioEngine::getAudioBridge() const {
     return tracktion_->getAudioBridge();
 }
+
+/**
+ * @brief Both engines, in that order (#2581).
+ *
+ * The fork first, because a MAGDA device's state is captured nowhere else and
+ * its synced plugin is still where that is read from. The instances this
+ * renders through go over the top: for an external plugin the fork holds a
+ * parallel copy that never heard a note, and the chunk that copy writes is the
+ * one the project was loaded with.
+ */
+void MagdaAudioEngine::captureAllPluginStates() {
+    tracktion_->captureAllPluginStates();
+
+    if (host_ != nullptr)
+        host_->captureExternalPluginStates();
+}
+
+void MagdaAudioEngine::capturePluginStateAt(const ChainNodePath& devicePath) {
+    tracktion_->capturePluginStateAt(devicePath);
+
+    if (host_ != nullptr)
+        host_->captureExternalPluginStateAt(devicePath);
+}
 MidiBridge* MagdaAudioEngine::getMidiBridge() {
     return tracktion_->getMidiBridge();
 }

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -128,6 +128,8 @@ class MagdaAudioEngine final : public AudioEngine {
     void setMidiDevicesReadyCallback(std::function<void()> callback) override;
     AudioBridge* getAudioBridge() override;
     const AudioBridge* getAudioBridge() const override;
+    void captureAllPluginStates() override;
+    void capturePluginStateAt(const ChainNodePath& devicePath) override;
     MidiBridge* getMidiBridge() override;
     const MidiBridge* getMidiBridge() const override;
     MagdaApi& getMagdaApi() override;

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -268,6 +268,11 @@ class TracktionEngineWrapper : public AudioEngine,
         return audioBridge_.get();
     }
 
+    /// What this engine renders through are the bridge's own synced plugins,
+    /// so a capture is a flush of those (#2581).
+    void captureAllPluginStates() override;
+    void capturePluginStateAt(const ChainNodePath& devicePath) override;
+
     /**
      * @brief Export capture pass for External FX / Instrument devices (#1623)
      * @return Pointer to the service, or nullptr when unavailable (headless)

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -413,10 +413,14 @@ void TracktionEngineWrapper::createEditAndBridges() {
     // Wire up state capture before project save
     auto* bridge = audioBridge_.get();
     ProjectManager::getInstance().onBeforeSave = [bridge]() {
-        if (bridge) {
-            bridge->captureAllPluginStates();
+        // Asked of whichever engine is rendering: only the instance that
+        // rendered holds the chunk a project saves (#2581). The warp markers
+        // stay the bridge's, being the fork's own clip state.
+        if (auto* engine = TrackManager::getInstance().getAudioEngine())
+            engine->captureAllPluginStates();
+
+        if (bridge != nullptr)
             bridge->captureWarpMarkerStates();
-        }
 
         // Capture zoom/scroll state
         if (auto* tc = TimelineController::getCurrent()) {

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -12,6 +12,7 @@
     #include <sys/mount.h>
 #endif
 
+#include "../audio/AudioBridge.hpp"
 #include "../audio/plugins/InternalPluginRegistry.hpp"
 #include "../audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
 #include "../core/AppPaths.hpp"
@@ -805,6 +806,16 @@ bool TracktionEngineWrapper::upsertGrooveTemplate(const GrooveTemplateData& data
 juce::StringArray TracktionEngineWrapper::getGrooveTemplateNames() const {
     return engine_ != nullptr ? engine_->getGrooveTemplateManager().getTemplateNames()
                               : juce::StringArray{};
+}
+
+void TracktionEngineWrapper::captureAllPluginStates() {
+    if (audioBridge_ != nullptr)
+        audioBridge_->captureAllPluginStates();
+}
+
+void TracktionEngineWrapper::capturePluginStateAt(const ChainNodePath& devicePath) {
+    if (audioBridge_ != nullptr)
+        audioBridge_->getPluginManager().capturePluginState(devicePath);
 }
 
 }  // namespace magda

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -4,8 +4,8 @@
 
 #include <algorithm>
 #include <atomic>
-#include <optional>
 #include <ranges>
+#include <set>
 
 #include "../../audio/plugin_manager/ExternalPluginState.hpp"
 #include "../../audio/plugins/engine/ControlExecutor.hpp"
@@ -13,6 +13,7 @@
 #include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "../../audio/plugins/engine/EngineExternalDevice.hpp"
 #include "../../core/AutomationManager.hpp"
+#include "../../core/ChainWalk.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../project/ProjectManager.hpp"
@@ -72,26 +73,39 @@ DeviceInfo* modelDeviceAt(engine::DeviceKey key) {
     return found;
 }
 
-/// The key the engine knows a device by, from the path the app knows it by.
-/// Inverted off the same walk the publish uses rather than rebuilt from the
-/// path's own steps, so the two cannot come to disagree about which section a
-/// device is in.
-std::optional<engine::DeviceKey> keyOfDeviceAt(const ChainNodePath& devicePath) {
-    const auto* target = TrackManager::getInstance().getDeviceInChainByPath(devicePath);
+/**
+ * @brief The keys the engine knows the device at @p devicePath by, and its pads.
+ *
+ * A single-slot caller passes a Drum Grid's own path, because a pad's patch
+ * rides along in the grid's state rather than having a path of its own
+ * (#2207). The grid is a device this build holds, so reading only the key the
+ * path names would read nothing and leave the pads' plugins behind.
+ *
+ * Inverted off the same walk the publish uses rather than rebuilt from the
+ * path's own steps, so the two cannot come to disagree about which section a
+ * device is in.
+ */
+std::vector<engine::DeviceKey> keysOfDeviceAt(const ChainNodePath& devicePath) {
+    auto& trackManager = TrackManager::getInstance();
+
+    const auto* target = trackManager.getDeviceInChainByPath(devicePath);
     if (target == nullptr)
-        return std::nullopt;
+        return {};
 
-    std::optional<engine::DeviceKey> found;
+    std::set<const DeviceInfo*> subtree{target};
+    if (target->pads)
+        for (const auto& pad : target->pads->chains)
+            chain_walk::forEachDevice(pad.elements, devicePath, chain_walk::Pads::Enter,
+                                      [&subtree](const DeviceInfo& device, const ChainNodePath&) {
+                                          subtree.insert(&device);
+                                      });
 
-    TrackManager::getInstance().forEachTrackIncludingMaster([&found, target](TrackInfo& track) {
-        if (found.has_value())
-            return;
+    std::vector<engine::DeviceKey> found;
 
+    trackManager.forEachTrackIncludingMaster([&found, &subtree](TrackInfo& track) {
         for (const auto& [key, device] : adapter::devicesIn(track))
-            if (device == target) {
-                found = key;
-                return;
-            }
+            if (subtree.contains(device))
+                found.push_back(key);
     });
 
     return found;
@@ -624,16 +638,18 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         if (session_ == nullptr)
             return;
 
-        const auto key = keyOfDeviceAt(devicePath);
-
         // A chain is mostly devices this build holds, and those are asked of
         // the fork. Reaching for one here would find no external plugin bound
         // and report that as a state that could not be read.
-        if (!key.has_value() || !factory_.isExternalKey(*key))
-            return;
+        auto asked = false;
+        for (const auto key : keysOfDeviceAt(devicePath))
+            if (factory_.isExternalKey(key)) {
+                requestCapture(key);
+                asked = true;
+            }
 
-        requestCapture(*key);
-        control_->drain();
+        if (asked)
+            control_->drain();
     }
 
     /**

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -4,10 +4,14 @@
 
 #include <algorithm>
 #include <atomic>
+#include <optional>
 #include <ranges>
 
 #include "../../audio/plugin_manager/ExternalPluginState.hpp"
+#include "../../audio/plugins/engine/ControlExecutor.hpp"
+#include "../../audio/plugins/engine/DeviceControl.hpp"
 #include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
+#include "../../audio/plugins/engine/EngineExternalDevice.hpp"
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/TrackManager.hpp"
@@ -41,6 +45,102 @@ void report(const juce::String& what, const std::vector<std::string>& messages) 
     for (const auto& message : messages)
         juce::Logger::writeToLog("[engine] " + what + ": " + juce::String(message));
 }
+
+/**
+ * @brief The model's own DeviceInfo at @p key, or null.
+ *
+ * Read when it is asked for rather than from a publish's copy: a plugin load
+ * takes seconds, and what the model holds when one finishes is what its state
+ * has to be restored onto. Per track because TrackManager hands out mutable
+ * tracks but not a mutable project.
+ *
+ * A free function rather than a member, so that an asynchronous operation
+ * writing a model carries nothing but its own request (PluginAssignments.hpp).
+ */
+DeviceInfo* modelDeviceAt(engine::DeviceKey key) {
+    DeviceInfo* found = nullptr;
+
+    TrackManager::getInstance().forEachTrackIncludingMaster([&found, key](TrackInfo& track) {
+        if (found != nullptr)
+            return;
+
+        const auto devices = adapter::devicesIn(track);
+        if (const auto device = devices.find(key); device != devices.end())
+            found = device->second;
+    });
+
+    return found;
+}
+
+/// The key the engine knows a device by, from the path the app knows it by.
+/// Inverted off the same walk the publish uses rather than rebuilt from the
+/// path's own steps, so the two cannot come to disagree about which section a
+/// device is in.
+std::optional<engine::DeviceKey> keyOfDeviceAt(const ChainNodePath& devicePath) {
+    const auto* target = TrackManager::getInstance().getDeviceInChainByPath(devicePath);
+    if (target == nullptr)
+        return std::nullopt;
+
+    std::optional<engine::DeviceKey> found;
+
+    TrackManager::getInstance().forEachTrackIncludingMaster([&found, target](TrackInfo& track) {
+        if (found.has_value())
+            return;
+
+        for (const auto& [key, device] : adapter::devicesIn(track))
+            if (device == target) {
+                found = key;
+                return;
+            }
+    });
+
+    return found;
+}
+
+/// The external plugin behind whatever the store holds for a key, reached
+/// through the trace when one is wrapping it (#2568): a control operation
+/// addresses the device, and a diagnostic must not change the answer.
+adapter::EngineExternalDevice* externalIn(engine::EngineDevice& device) {
+    if (auto* tracing = dynamic_cast<TracingDevice*>(&device))
+        return externalIn(tracing->wrapped());
+
+    return dynamic_cast<adapter::EngineExternalDevice*>(&device);
+}
+
+/**
+ * @brief The external devices the live session holds (#2581).
+ *
+ * Owned by the host and held weakly by the plane, which is what makes a
+ * capture outliving the project answer "the runtime is gone" rather than
+ * reach for a session that has been destroyed.
+ */
+class SessionDevices final : public adapter::DeviceRegistry {
+  public:
+    using LiveSession = std::function<const engine::EngineSession*()>;
+
+    explicit SessionDevices(LiveSession session) : session_(std::move(session)) {}
+
+    std::shared_ptr<adapter::EngineExternalDevice> find(engine::DeviceKey key) const override {
+        const auto* session = session_ ? session_() : nullptr;
+        if (session == nullptr)
+            return nullptr;
+
+        auto held = session->device(key);
+        if (held == nullptr)
+            return nullptr;
+
+        auto* external = externalIn(*held);
+        if (external == nullptr)
+            return nullptr;
+
+        // Aliased onto the store's own lease, so what holds the instance open
+        // is the thing that owns it rather than a second count beside it.
+        return {std::move(held), external};
+    }
+
+  private:
+    LiveSession session_;
+};
 
 }  // namespace
 
@@ -462,27 +562,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                                          automation.getClips());
     }
 
-    /**
-     * @brief The model's own DeviceInfo at @p key, or null.
-     *
-     * Read when it is asked for rather than from the publish's copy: a plugin
-     * load takes seconds, and what the model holds when one finishes is what
-     * its state has to be restored onto. Per track because TrackManager hands
-     * out mutable tracks but not a mutable project.
-     */
     DeviceInfo* modelDevice(engine::DeviceKey key) {
-        DeviceInfo* found = nullptr;
-
-        TrackManager::getInstance().forEachTrackIncludingMaster([&found, key](TrackInfo& track) {
-            if (found != nullptr)
-                return;
-
-            const auto devices = adapter::devicesIn(track);
-            if (const auto device = devices.find(key); device != devices.end())
-                found = device->second;
-        });
-
-        return found;
+        return modelDeviceAt(key);
     }
 
     /**
@@ -516,6 +597,68 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         wantPlan();
     }
 
+    // ===== What the plugins hold =====
+
+    /**
+     * @brief Read every external plugin this renders back into the model.
+     *
+     * A project keeps the chunk its plugins wrote, and the only instance that
+     * has one is the instance that rendered (#2581). The keys come off the
+     * model this publish was built from; a key nothing is bound to is a
+     * failure with a reason rather than an empty state written over a patch.
+     */
+    void captureExternalPluginStates() {
+        if (session_ == nullptr)
+            return;
+
+        for (const auto key : factory_.externalKeys())
+            requestCapture(key);
+
+        // The caller writes the project file the moment this returns, so the
+        // reads have to have happened by then rather than at the next turn of
+        // the message loop.
+        control_->drain();
+    }
+
+    void captureExternalPluginStateAt(const ChainNodePath& devicePath) {
+        if (session_ == nullptr)
+            return;
+
+        const auto key = keyOfDeviceAt(devicePath);
+
+        // A chain is mostly devices this build holds, and those are asked of
+        // the fork. Reaching for one here would find no external plugin bound
+        // and report that as a state that could not be read.
+        if (!key.has_value() || !factory_.isExternalKey(*key))
+            return;
+
+        requestCapture(*key);
+        control_->drain();
+    }
+
+    /**
+     * @brief Ask for @p key's state, and write it down if it is still its own.
+     *
+     * The completion carries its assignment and nothing else: it runs later
+     * than the call that queued it, and a completion holding this object would
+     * be one more thing that has to outlive a project closing
+     * (PluginAssignments.hpp).
+     */
+    void requestCapture(engine::DeviceKey key) {
+        plane_.captureState(key, [request = loader_.request(key)](adapter::CaptureOutcome taken) {
+            if (!taken.ok()) {
+                // Only for a slot that is still the one that was asked about.
+                // A device deleted or replaced while the read ran is a failure
+                // nobody is waiting to hear.
+                if (request.isStillWanted())
+                    juce::Logger::writeToLog("[engine] not saved: " + taken.failure());
+                return;
+            }
+
+            adapter::commitCapturedState(request, taken.snapshot(), modelDeviceAt);
+        });
+    }
+
     /// Devices the model names and no catalog could build. Named rather than
     /// counted, and only when the set changes: a line per publish would bury
     /// everything else.
@@ -536,6 +679,21 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     /// gated on the assignment table this owns, and a table that has gone is a
     /// load nobody is waiting for.
     ExternalPluginLoader loader_;
+
+    /// Where everything that is not a block runs (#2270). The message thread,
+    /// which is where a plugin's editor lives and where the model a completion
+    /// writes is edited from.
+    std::shared_ptr<adapter::ControlExecutor> control_ =
+        std::make_shared<adapter::MessageThreadControlExecutor>();
+
+    /// Held by shared_ptr because the plane holds it weakly: a capture whose
+    /// project closed first finds no registry, which is the answer rather than
+    /// a session that has gone.
+    std::shared_ptr<SessionDevices> sessionDevices_ =
+        std::make_shared<SessionDevices>([this] { return session_.get(); });
+
+    /// After both, since it is built from them.
+    adapter::LocalDeviceControlPlane plane_{control_, sessionDevices_};
 
     juce::AudioDeviceManager* devices_ = nullptr;
     engine::RenderContext context_{};
@@ -596,6 +754,14 @@ void EngineHost::meterInto(MeterSink sink) {
 
 void EngineHost::stop() {
     impl_->detach();
+}
+
+void EngineHost::captureExternalPluginStates() {
+    impl_->captureExternalPluginStates();
+}
+
+void EngineHost::captureExternalPluginStateAt(const ChainNodePath& devicePath) {
+    impl_->captureExternalPluginStateAt(devicePath);
 }
 
 void EngineHost::play() {

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 
+#include "../../core/ChainNodePath.hpp"
 #include "../../core/TypeIds.hpp"
 
 namespace juce {
@@ -74,6 +75,21 @@ class EngineHost {
     /// Take the callback back off the device and stop following the model.
     /// Safe to call twice, and called by the destructor.
     void stop();
+
+    // ===== What the plugins hold =====
+    //
+    // A project saves the chunk its plugins wrote, and only the instance that
+    // rendered has one (#2581). Both of these run on the message thread and
+    // return with the reads done, because a save writes the file the moment
+    // they do.
+
+    /// Read every external plugin this is rendering back into the model.
+    void captureExternalPluginStates();
+
+    /// The one at @p devicePath, for a caller flushing a single slot before it
+    /// copies, removes or snapshots it. Nothing for a path that is not an
+    /// external plugin this is rendering.
+    void captureExternalPluginStateAt(const ChainNodePath& devicePath);
 
     // ===== Transport =====
     //

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -86,9 +86,11 @@ class EngineHost {
     /// Read every external plugin this is rendering back into the model.
     void captureExternalPluginStates();
 
-    /// The one at @p devicePath, for a caller flushing a single slot before it
-    /// copies, removes or snapshots it. Nothing for a path that is not an
-    /// external plugin this is rendering.
+    /// The one at @p devicePath and anything on its pads, for a caller
+    /// flushing a single slot before it copies, removes or snapshots it. A
+    /// Drum Grid is passed by its own path because its pads ride along in its
+    /// state (#2207). Nothing for a path holding no external plugin this is
+    /// rendering.
     void captureExternalPluginStateAt(const ChainNodePath& devicePath);
 
     // ===== Transport =====

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -65,6 +65,21 @@ void EngineRuntimeFactory::setModel(const std::vector<TrackInfo>& tracks, const 
         externals_->syncAssignments(devices_);
 }
 
+std::vector<engine::DeviceKey> EngineRuntimeFactory::externalKeys() const {
+    std::vector<engine::DeviceKey> keys;
+
+    for (const auto& [key, device] : devices_)
+        if (adapter::isExternalDevice(device))
+            keys.push_back(key);
+
+    return keys;
+}
+
+bool EngineRuntimeFactory::isExternalKey(engine::DeviceKey key) const {
+    const auto found = devices_.find(key);
+    return found != devices_.end() && adapter::isExternalDevice(found->second);
+}
+
 void EngineRuntimeFactory::forgetBuiltDevices() {
     for (const auto& [key, identity] : built_)
         rebuild_.insert(key);

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -94,6 +94,18 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
         trace_ = &trace;
     }
 
+    /// The keys this publish's model calls external plugins, in key order.
+    /// Off the one reading of the model @ref setModel took, so a caller
+    /// walking them is walking the same project the devices were built for
+    /// (#2581).
+    std::vector<engine::DeviceKey> externalKeys() const;
+
+    /// Whether @p key is one of those. For a caller holding a single path
+    /// rather than a list: everything else in a chain is a device this build
+    /// holds, which has no chunk to read and nothing to say about not having
+    /// one (#2581).
+    bool isExternalKey(engine::DeviceKey key) const;
+
     /// Nothing the store holds belongs to the model any more: the project was
     /// cleared and DeviceIds start from 1 again (#2572). Called at the
     /// teardown, which the next publish is too late to see.

--- a/magda/daw/engine/host/EngineTrace.hpp
+++ b/magda/daw/engine/host/EngineTrace.hpp
@@ -105,6 +105,13 @@ class TracingDevice final : public magda::engine::EngineDevice {
 
     void process(magda::engine::DeviceBlock& block) override;
 
+    /// What this stands in front of. A control operation addresses the device
+    /// itself rather than the diagnostic around it, so a capture must not
+    /// answer differently with the trace on (#2581).
+    EngineDevice& wrapped() const {
+        return *device_;
+    }
+
   private:
     std::unique_ptr<EngineDevice> device_;
     EngineTrace& trace_;

--- a/magda/daw/engine/host/ExternalPluginLoader.cpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.cpp
@@ -79,6 +79,11 @@ void ExternalPluginLoader::syncAssignments(const std::map<engine::DeviceKey, Dev
     }
 }
 
+audio::engine_adapter::AssignmentRequest ExternalPluginLoader::request(
+    engine::DeviceKey key) const {
+    return assignments_.request(key);
+}
+
 void ExternalPluginLoader::forgetSlots() {
     assignments_.releaseAll();
     slots_.clear();

--- a/magda/daw/engine/host/ExternalPluginLoader.hpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.hpp
@@ -83,6 +83,17 @@ class ExternalPluginLoader final {
      */
     std::unique_ptr<engine::EngineDevice> device(engine::DeviceKey key, const DeviceInfo& model);
 
+    /**
+     * @brief What to remember about @p key while an operation on it runs.
+     *
+     * The same token the load path carries, for the other direction: a state
+     * capture asks at completion whether the slot it read is still the slot it
+     * is about to be written onto (#2581). An unregistered key yields an
+     * already-expired request, so a capture against a slot this loader never
+     * held is refused rather than committed.
+     */
+    audio::engine_adapter::AssignmentRequest request(engine::DeviceKey key) const;
+
     /// Every slot ends: the project was cleared (#2572). The assignments go
     /// with them, which expires the loads in flight against their keys.
     void forgetSlots();

--- a/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
+++ b/magda/daw/ui/components/chain/slot/DevicePresetMenu.cpp
@@ -190,8 +190,8 @@ void showMagdaPresetMenu(juce::Component* targetComponent, const juce::String& p
 std::optional<magda::DeviceInfo> snapshotDeviceForPreset(const magda::DeviceInfo& fallbackDevice,
                                                          const magda::ChainNodePath& nodePath) {
     auto& trackManager = magda::TrackManager::getInstance();
-    if (auto* bridge = getAudioBridge())
-        bridge->getPluginManager().capturePluginState(nodePath);
+    if (auto* engine = trackManager.getAudioEngine())
+        engine->capturePluginStateAt(nodePath);
 
     if (auto* live = trackManager.getDeviceInChainByPath(nodePath))
         return *live;

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -391,6 +391,12 @@ class EngineSession {
         return store_.meterTap(key);
     }
 
+    /// A lease on the device at @p key, for a host reaching one for something
+    /// that is not a block (#2581). On the publishing thread.
+    std::shared_ptr<EngineDevice> device(DeviceKey key) const {
+        return store_.device(key);
+    }
+
     /// Values the live plan found somewhere to publish from -- not the
     /// number of taps the store holds, since a key the parameter table does
     /// not carry has a tap that is never written through. On the publishing

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -491,6 +491,11 @@ LevelTap* RuntimeStateStore::meterTap(const OpKey& key) const {
     return found == meters_.end() ? nullptr : found->second.get();
 }
 
+std::shared_ptr<EngineDevice> RuntimeStateStore::device(DeviceKey key) const {
+    const auto found = devices_.find(key);
+    return found == devices_.end() ? nullptr : found->second;
+}
+
 std::size_t RuntimeStateStore::size() const {
     return devices_.size() + retired_.size() + clipAudio_.size() + clipMidi_.size() +
            sessionAudio_.size() + sessionMidi_.size() + handles_.size() + audioInputs_.size() +

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -361,6 +361,16 @@ class RuntimeStateStore {
      */
     const LaunchTap* launchTap(const SlotKey& key) const;
 
+    /**
+     * @brief A lease on the device at @p key, or nothing (#2581).
+     *
+     * What lets a host reach a device for something that is not a block: the
+     * lease carries the instance rather than pointing at it, so a publish that
+     * evicts it partway through a state read does not take it away. On the
+     * publishing thread, which is the only thread this map is written from.
+     */
+    std::shared_ptr<EngineDevice> device(DeviceKey key) const;
+
     /// @brief Objects currently owned, for tests and diagnostics.
     std::size_t size() const;
 
@@ -378,11 +388,14 @@ class RuntimeStateStore {
     RenderContext context_;
     bool hasContext_ = false;
 
-    std::unordered_map<DeviceKey, std::unique_ptr<EngineDevice>, DeviceKeyHash> devices_;
+    /// Shared rather than owned outright, so that a control operation can hold
+    /// the device it is reading across a publish that drops it (#2581). The
+    /// store is still the only thing that creates or evicts one.
+    std::unordered_map<DeviceKey, std::shared_ptr<EngineDevice>, DeviceKeyHash> devices_;
 
     /// Instances a rebuild took out of devices_, held until releaseDeleted()
     /// (#2572).
-    std::vector<std::unique_ptr<EngineDevice>> retired_;
+    std::vector<std::shared_ptr<EngineDevice>> retired_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> clipAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> clipMidi_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> sessionAudio_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -825,6 +825,10 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         # magda_tests because it reads TrackManager and ClipManager, and those
         # are the singletons a running MAGDA keeps its model in.
         engine/test_engine_host_publish_juce.cpp
+
+        # The message-thread half of the control executor (#2581). Here because
+        # magda_tests has no message loop to run it on.
+        engine/test_control_executor_juce.cpp
     )
 endif()
 

--- a/tests/engine/test_control_executor.cpp
+++ b/tests/engine/test_control_executor.cpp
@@ -190,3 +190,43 @@ TEST_CASE("An executor destroyed by its own work does not wait for itself", "[en
     // process with it.
     SUCCEED();
 }
+
+TEST_CASE("A drain returns once what was queued has been answered", "[engine][control]") {
+    // What a project save needs: it reads every plugin's state and then writes
+    // the file, in one call (#2581), so "queued" is not good enough.
+    adapter::SerialControlThread executor;
+
+    std::atomic<int> answered{0};
+
+    for (int item = 0; item < 8; ++item)
+        REQUIRE(executor.run([&answered](ExecutionState state) {
+            if (state != ExecutionState::Ran)
+                return;
+
+            // Slow enough that a drain returning early would be visible rather
+            // than a race that usually passes.
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            ++answered;
+        }));
+
+    executor.drain();
+
+    CHECK(answered.load() == 8);
+}
+
+TEST_CASE("A drain from inside the work it would wait for does nothing", "[engine][control]") {
+    // The work asking is the work that would have to finish first, so a drain
+    // that waited here would be waiting for itself. Nesting is what run()
+    // refuses for the same reason -- a second transaction inside the first.
+    adapter::SerialControlThread executor;
+
+    std::promise<void> ran;
+    auto finished = ran.get_future();
+
+    REQUIRE(executor.run([&executor, &ran](ExecutionState) {
+        executor.drain();
+        ran.set_value();
+    }));
+
+    REQUIRE(finished.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+}

--- a/tests/engine/test_control_executor_juce.cpp
+++ b/tests/engine/test_control_executor_juce.cpp
@@ -1,0 +1,122 @@
+#include <juce_events/juce_events.h>
+
+#include <vector>
+
+#include "magda/daw/audio/plugins/engine/ControlExecutor.hpp"
+
+/**
+ * The message-thread executor, which magda_tests has no thread to run (#2270).
+ *
+ * Its queue is its own rather than the message loop's, so that a caller already
+ * on the message thread can run what is waiting instead of returning to the
+ * loop to have it run -- which is what a project save needs, since it writes
+ * the file the moment the reads are done (#2581).
+ */
+
+namespace {
+
+namespace adapter = magda::daw::audio::engine_adapter;
+
+using adapter::ExecutionState;
+
+class ControlExecutorTest final : public juce::UnitTest {
+  public:
+    ControlExecutorTest() : juce::UnitTest("Message Thread Control Executor", "magda") {}
+
+    void runTest() override {
+        testDrainRunsWhatIsQueued();
+        testPostRunsWhatADrainDidNotTake();
+        testNestedDrainDoesNothing();
+        testDrainKeepsTheOrder();
+    }
+
+  private:
+    /// Lets the message loop deliver what the executor posted, the way a host
+    /// returning to its loop would.
+    static void pumpMessageLoop() {
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+    }
+
+    void testDrainRunsWhatIsQueued() {
+        beginTest("A drain runs what is queued before it returns");
+
+        adapter::MessageThreadControlExecutor executor;
+
+        auto ran = 0;
+        for (auto item = 0; item < 4; ++item)
+            expect(executor.run([&ran](ExecutionState state) {
+                if (state == ExecutionState::Ran)
+                    ++ran;
+            }));
+
+        expect(ran == 0, "Nothing runs where it was asked for, including here");
+
+        executor.drain();
+        expect(ran == 4, "All four have been answered by the time the drain returns");
+    }
+
+    void testPostRunsWhatADrainDidNotTake() {
+        beginTest("Work nobody drains still runs on the message loop");
+
+        adapter::MessageThreadControlExecutor executor;
+
+        auto ran = 0;
+        expect(executor.run([&ran](ExecutionState state) {
+            if (state == ExecutionState::Ran)
+                ++ran;
+        }));
+
+        pumpMessageLoop();
+        expect(ran == 1, "The post the executor made is what runs it");
+
+        // The post for an item a drain already took finds nothing rather than
+        // running something twice.
+        pumpMessageLoop();
+        expect(ran == 1, "And it runs once");
+    }
+
+    void testNestedDrainDoesNothing() {
+        beginTest("A drain from inside work is not a second transaction");
+
+        adapter::MessageThreadControlExecutor executor;
+
+        std::vector<int> order;
+
+        expect(executor.run([&executor, &order](ExecutionState) {
+            order.push_back(1);
+
+            // The outer operation still has its plugin open, so the item queued
+            // below must not run inside this one.
+            executor.run([&order](ExecutionState) { order.push_back(3); });
+            executor.drain();
+
+            order.push_back(2);
+        }));
+
+        executor.drain();
+
+        // 3 last: the nested drain did nothing, and the outer one reached the
+        // item once the work that queued it had ended.
+        expect(order == std::vector<int>{1, 2, 3}, "The nested item ran after the work that "
+                                                   "queued it, not inside it");
+    }
+
+    void testDrainKeepsTheOrder() {
+        beginTest("A drain answers in the order the work was accepted");
+
+        adapter::MessageThreadControlExecutor executor;
+
+        std::vector<int> order;
+        for (auto item = 0; item < 6; ++item)
+            expect(executor.run([&order, item](ExecutionState) { order.push_back(item); }));
+
+        executor.drain();
+
+        expect(order == std::vector<int>{0, 1, 2, 3, 4, 5},
+               "One at a time, in the order it arrived");
+    }
+};
+
+ControlExecutorTest controlExecutorTest;
+
+}  // namespace

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -160,6 +160,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::test::runWithCleanJuceState([this] { testMidiClipReachesAnInstrument(); });
         magda::test::runWithCleanJuceState([this] { testNoteMovedWhileRolling(); });
         magda::test::runWithCleanJuceState([this] { testReplacedPluginIsRebuilt(); });
+        magda::test::runWithCleanJuceState([this] { testExternalKeysNamesOnlyExternals(); });
         magda::test::runWithCleanJuceState([this] { testClearedProjectIsRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testDroppedKeyIsStillRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testMetersReadWhatWasRendered(); });
@@ -400,6 +401,43 @@ class EngineHostPublishTest final : public juce::UnitTest {
         const auto rebuild = factory.devicesToRebuild();
         expect(rebuild.size() == 1 && rebuild.contains(firstFxSlot()),
                "The slot's new plugin is named for rebuild");
+    }
+
+    void testExternalKeysNamesOnlyExternals() {
+        beginTest("The keys a save asks about are the model's external plugins");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Instrument");
+        trackManager.addDeviceToTrack(trackId, polySynth(magda::DeviceId{1}));
+
+        // A plugin that is a file on this machine rather than a class this
+        // build holds, which is the whole of what makes it external.
+        auto external = polySynth(magda::DeviceId{2});
+        external.name = "Some VST";
+        external.format = magda::PluginFormat::VST3;
+        trackManager.addDeviceToTrack(trackId, external);
+
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(master != nullptr, "The master track is there to publish");
+
+        host::EngineRuntimeFactory factory;
+        factory.setModel(trackManager.getTracks(), *master);
+
+        const auto keys = factory.externalKeys();
+        expect(keys.size() == 1, "The compiled synth is not one of these");
+        expect(keys.front() == engine::DeviceKey{magda::ChainSegment::Fx, magda::DeviceId{2}},
+               "And the VST is");
+
+        // What a single-slot capture asks before it reaches for a plugin: the
+        // compiled synth has no chunk, and asking about one would report the
+        // absence as a state that could not be read.
+        expect(factory.isExternalKey(keys.front()), "The VST is one by key too");
+        expect(
+            !factory.isExternalKey(engine::DeviceKey{magda::ChainSegment::Fx, magda::DeviceId{1}}),
+            "The compiled synth is not");
+        expect(
+            !factory.isExternalKey(engine::DeviceKey{magda::ChainSegment::Fx, magda::DeviceId{99}}),
+            "And neither is a key the model does not carry");
     }
 
     void testClearedProjectIsRebuilt() {

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -161,6 +161,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::test::runWithCleanJuceState([this] { testNoteMovedWhileRolling(); });
         magda::test::runWithCleanJuceState([this] { testReplacedPluginIsRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testExternalKeysNamesOnlyExternals(); });
+        magda::test::runWithCleanJuceState([this] { testPadPluginIsItsOwnKey(); });
         magda::test::runWithCleanJuceState([this] { testClearedProjectIsRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testDroppedKeyIsStillRebuilt(); });
         magda::test::runWithCleanJuceState([this] { testMetersReadWhatWasRendered(); });
@@ -438,6 +439,53 @@ class EngineHostPublishTest final : public juce::UnitTest {
         expect(
             !factory.isExternalKey(engine::DeviceKey{magda::ChainSegment::Fx, magda::DeviceId{99}}),
             "And neither is a key the model does not carry");
+    }
+
+    void testPadPluginIsItsOwnKey() {
+        beginTest("A plugin on a Drum Grid's pad is an external key of its own");
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        const auto trackId = trackManager.createTrack("Drums");
+
+        auto grid = polySynth(magda::DeviceId{1});
+        grid.name = "Drum Grid";
+
+        auto pads = std::make_unique<magda::RackInfo>();
+        pads->id = 1;
+        {
+            magda::ChainInfo pad;
+            pad.id = 1;
+
+            auto sampler = polySynth(magda::DeviceId{2});
+            sampler.name = "Padded VST";
+            sampler.format = magda::PluginFormat::VST3;
+            pad.elements.emplace_back(std::move(sampler));
+
+            pads->chains.push_back(std::move(pad));
+        }
+        grid.pads.reset(std::move(pads));
+
+        trackManager.addDeviceToTrack(trackId, grid);
+
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(master != nullptr, "The master track is there to publish");
+
+        host::EngineRuntimeFactory factory;
+        factory.setModel(trackManager.getTracks(), *master);
+
+        // A pad's patch rides along in the grid's own state (#2207), so a
+        // single-slot capture is handed the grid's path. The plugin with a
+        // chunk to read is the one on the pad, and it is a device of its own
+        // here rather than something the grid's key stands for.
+        const auto padKey = engine::DeviceKey{magda::ChainSegment::Fx, magda::DeviceId{2}};
+
+        const auto keys = factory.externalKeys();
+        expect(keys.size() == 1, "The grid itself is a device this build holds");
+        expect(keys.front() == padKey, "And the pad's plugin is the external one");
+        expect(factory.isExternalKey(padKey), "Asked by key too");
+        expect(
+            !factory.isExternalKey(engine::DeviceKey{magda::ChainSegment::Fx, magda::DeviceId{1}}),
+            "The grid is not one");
     }
 
     void testClearedProjectIsRebuilt() {

--- a/tests/project/test_project_serialization.cpp
+++ b/tests/project/test_project_serialization.cpp
@@ -234,6 +234,10 @@ class ProjectBoundaryResetEngine : public AudioEngine {
         return nullptr;
     }
 
+    void captureAllPluginStates() override {}
+
+    void capturePluginStateAt(const ChainNodePath&) override {}
+
     MidiBridge* getMidiBridge() override {
         return nullptr;
     }


### PR DESCRIPTION
Closes #2581.

A project saved while the native engine held an external plugin wrote the chunk the plugin was loaded with rather than the one the instance holds now. The save hook only knew `AudioBridge::captureAllPluginStates()`, which reads the fork's parallel instances, and `EngineExternalDevice::captureState()` had no caller.

## Asked of whichever engine is rendering

`AudioEngine` grows `captureAllPluginStates()` and `capturePluginStateAt()`. The fork answers them from the bridge as before. `MagdaAudioEngine` asks both in turn: the fork first, since a MAGDA device's state is captured nowhere else and its synced plugin is still where that is read from, then the instances it renders through over the top.

The four capture sites the issue named go through the engine instead of reaching for the bridge: `TrackCommands.cpp:327` and `:889`, `PadCommands.cpp:24`, `DevicePresetMenu.cpp:193`. The save hook in `TracktionEngineWrapperInit.cpp` asks the engine and keeps the warp markers on the bridge, those being the fork's own clip state.

The `FaustUI.cpp` capture calls stay on the bridge. They are paired with bridge-only `refreshDeviceParameters` on Faust devices, which the native path has no chunk to read for.

## The host half

`EngineHost` walks the publish's external keys through `LocalDeviceControlPlane`, checks the assignment between the read and the commit as #2270 states, and writes each snapshot back into the model with `applyCapturedPluginState()`. A key nothing is bound to is logged with its reason rather than committed as an empty state over a patch, so a plugin that is not installed on this machine keeps whatever the project was loaded with.

A single-slot capture asks `EngineRuntimeFactory::isExternalKey()` first. `capturePluginStatesUnder` walks every device in a chain, and without that guard a chain of compiled devices would report each one as a state that could not be read.

`SessionDevices` is held weakly by the plane, so a capture that outlives its project answers "the runtime is gone" rather than reaching a session that has been destroyed. `RuntimeStateStore` hands out a device as a shared lease, so a capture can hold what it is reading across a publish that drops it.

## drain()

Both entry points return with the reads done, because a save writes the file the moment they do. `ControlExecutor::drain()` is what makes that true: the message thread runs its own queue in place rather than returning to the loop, and the serial thread waits for its worker. A drain from inside running work does nothing, which is the nesting `run()` already refuses for the same reason. The message-thread queue is the executor's own now, so each post takes one item and a post whose item a drain already took finds nothing.

## Tests

- `test_control_executor_juce.cpp`, new: a drain runs what is queued, work nobody drains still runs once on the loop, a nested drain is not a second transaction, and a drain answers in order. In the JUCE target because `magda_tests` has no message loop.
- `test_control_executor.cpp`: the same two contracts for the serial thread.
- `test_engine_host_publish_juce.cpp`: `externalKeys()` names only the model's external plugins, and `isExternalKey()` refuses a compiled device and a key the model does not carry.

Catch2 3918 passed / 0 failed locally, full JUCE suite green, including `test_external_plugin_state_restore_juce.cpp`.

Branched off `dev/0.20.0` at f344b8a19, so it does not include #2584. Asking both engines in turn is correct on either side of that merge.

Hardware verification still wants a real VST: load a project with an external plugin on magda, change something only the chunk carries, save, reload on either engine.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF
