### PR TITLE
Apply a preset to the plugin the native engine is rendering

### DIFF
--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -105,8 +105,32 @@ std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
     return order;
 }
 
+/** @brief Suspends a plugin's processing for the lifetime of this object. */
+class ScopedSuspend {
+  public:
+    explicit ScopedSuspend(juce::AudioPluginInstance& instance) : instance_(instance) {
+        instance_.suspendProcessing(true);
+    }
+
+    ~ScopedSuspend() {
+        instance_.suspendProcessing(false);
+    }
+
+    ScopedSuspend(const ScopedSuspend&) = delete;
+    ScopedSuspend& operator=(const ScopedSuspend&) = delete;
+    ScopedSuspend(ScopedSuspend&&) = delete;
+    ScopedSuspend& operator=(ScopedSuspend&&) = delete;
+
+  private:
+    juce::AudioPluginInstance& instance_;
+};
+
 SavedStateOutcome applySavedPluginState(juce::AudioPluginInstance& instance,
                                         const DeviceInfo& device) {
+    // Stops a render block reaching the plugin while its state is half
+    // written.
+    const ScopedSuspend held(instance);
+
     const auto order = hostParameterOrder(instance);
 
     // The array first. A parameter the model does not describe keeps whatever
@@ -246,25 +270,20 @@ std::optional<ExternalPluginSnapshot> captureExternalPluginState(
     juce::MemoryBlock chunk;
     ExternalPluginSnapshot snapshot;
 
-    // Suspended across the whole read, the way the fork holds its processMutex
-    // across one. Everything here comes off a plugin that is not simultaneously
-    // processing: its chunk, the parameter values that have to agree with that
-    // chunk, and the portable preset beside them. Resuming between any two of
-    // those would let a block move the plugin underneath the rest of the read.
-    instance.suspendProcessing(true);
-
+    // One suspension for all three reads: the chunk, the parameters and the
+    // preset must describe the same moment.
     bool described = true;
-    try {
-        instance.getStateInformation(chunk);
-        snapshot.parameters = snapshotHostParameters(instance);
-        snapshot.portable = readVst3Preset(instance);
-    } catch (...) {
-        described = false;
-    }
+    {
+        const ScopedSuspend held(instance);
 
-    // Restored either way: a plugin left suspended by its own throw would render
-    // silence for the rest of the session.
-    instance.suspendProcessing(false);
+        try {
+            instance.getStateInformation(chunk);
+            snapshot.parameters = snapshotHostParameters(instance);
+            snapshot.portable = readVst3Preset(instance);
+        } catch (...) {
+            described = false;
+        }
+    }
 
     if (!described)
         return std::nullopt;

--- a/magda/daw/audio/plugins/engine/ControlExecutor.hpp
+++ b/magda/daw/audio/plugins/engine/ControlExecutor.hpp
@@ -171,32 +171,32 @@ class MessageThreadControlExecutor final : public ControlExecutor {
 
     bool run(Work work) override;
 
-    /// Runs what is queued, here, on the message thread. Refused from any
-    /// other: waiting for the message loop from a thread that is not it is
-    /// how a host becomes the reason it never gets there.
+    /**
+     * @brief Runs all queued work on the calling thread.
+     *
+     * Must be called from the message thread. From any other it does nothing,
+     * because blocking another thread on the message loop can deadlock.
+     */
     void drain() override;
 
     bool isCurrent() const override;
 
   private:
-    /// Shared with every post this executor has made, so that destroying it
-    /// turns them all into cancellations rather than calls into a plane that
-    /// has gone.
-    ///
-    /// The queue is the executor's rather than the message loop's, so that a
-    /// caller on the message thread can run what is waiting instead of
-    /// returning to the loop to have it run (#2581). Each post takes one item,
-    /// so a post whose item a drain already took finds nothing and is worth
-    /// nothing, which is the only way the two can disagree.
+    /**
+     * @brief State shared between the executor and every callback it posts.
+     *
+     * Outlives the executor, so a pending callback sees `cancelled` rather
+     * than a dangling pointer. Each callback takes at most one queued item,
+     * so one whose item drain() already took does nothing (#2581).
+     */
     struct Posted {
         std::atomic<bool> cancelled{false};
 
         std::mutex lock;
         std::deque<Work> queued;
 
-        /// Whether a piece of work is running on the message thread now.
-        /// What makes a nested drain a no-op rather than a second
-        /// transaction inside the first.
+        /// True while a work item is running. Stops drain() from starting a
+        /// second item inside the first.
         bool running = false;
     };
 
@@ -233,9 +233,12 @@ class SerialControlThread final : public ControlExecutor {
 
     bool run(Work work) override;
 
-    /// Waits for the worker to answer what is queued. From the worker itself
-    /// this is a nested drain and does nothing: the work asking is the work
-    /// that would have to finish first.
+    /**
+     * @brief Blocks until the worker thread has finished all queued work.
+     *
+     * Returns immediately when called from the worker thread, since that work
+     * would have to finish first.
+     */
     void drain() override;
 
     bool isCurrent() const override;
@@ -249,12 +252,11 @@ class SerialControlThread final : public ControlExecutor {
         std::deque<Work> queued;
         bool stopping = false;
 
-        /// Whether the worker is inside a piece of work, and what a waiter
-        /// watches alongside the queue: an empty queue with a block still
-        /// running is not an answered one.
+        /// True while the worker is inside a work item. drain() waits on this
+        /// as well as the queue.
         bool busy = false;
 
-        /// Notified whenever the worker finishes one.
+        /// Signalled each time the worker finishes a work item.
         std::condition_variable answered;
     };
 

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -110,6 +110,56 @@ bool LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
     });
 }
 
+bool LocalDeviceControlPlane::applyState(magda::engine::DeviceKey key, magda::DeviceInfo saved,
+                                         CaptureCallback completed) {
+    if (!completed || executor() == nullptr)
+        return false;
+
+    // Same threading and lifetime rules as captureState().
+    return executor()->run([devices = devices_, key, saved = std::move(saved),
+                            completed](ExecutionState state) mutable {
+        if (state == ExecutionState::Cancelled) {
+            completed(CaptureOutcome::failed("the control plane closed before this apply ran"));
+            return;
+        }
+
+        const auto registry = devices.lock();
+        if (!registry) {
+            completed(CaptureOutcome::failed("the runtime that owned " + describeKey(key) +
+                                             " is gone, so nothing was applied"));
+            return;
+        }
+
+        const auto device = registry->find(key);
+        if (device == nullptr) {
+            completed(CaptureOutcome::failed("no plugin is bound for " + describeKey(key) +
+                                             ", so there was nothing to apply it to"));
+            return;
+        }
+
+        if (device->applyState(saved) == magda::SavedStateOutcome::Failed) {
+            // setStateInformation() threw partway, so the plugin holds
+            // neither the old nor the new state. Reading it back would record
+            // that as the state somebody asked for.
+            completed(CaptureOutcome::failed("the plugin bound for " + describeKey(key) +
+                                             " could not take that patch"));
+            return;
+        }
+
+        // A state chunk can change parameters the written array did not
+        // list, so the model is updated from the plugin, not from the write.
+        auto snapshot = device->captureState();
+        if (!snapshot.has_value()) {
+            completed(CaptureOutcome::failed("the plugin bound for " + describeKey(key) +
+                                             " took the state and then would not describe "
+                                             "itself"));
+            return;
+        }
+
+        completed(CaptureOutcome::taken(std::move(*snapshot)));
+    });
+}
+
 bool commitCapturedState(const AssignmentRequest& request,
                          const magda::ExternalPluginSnapshot& snapshot,
                          const MutableDeviceLookup& device) {

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -128,6 +128,20 @@ class DeviceControlPlane {
      */
     virtual bool captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
 
+    /**
+     * @brief Write @p saved into the plugin at @p key, then read the plugin back.
+     *
+     * For a preset applied to a slot whose plugin is already loaded (#2573).
+     * @p saved is by value because the work runs after this returns.
+     *
+     * The callback receives the plugin's state after the write, not a success
+     * flag: a state chunk can change parameters the model's array does not
+     * list, and the caller must store the snapshot or the plan will send the
+     * stale array back on the next block.
+     */
+    virtual bool applyState(magda::engine::DeviceKey key, magda::DeviceInfo saved,
+                            CaptureCallback completed) = 0;
+
     /// Where this plane's work runs, for a host that has something else to
     /// put on the same thread.
     const std::shared_ptr<ControlExecutor>& executor() const {
@@ -185,6 +199,8 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
                             std::weak_ptr<const DeviceRegistry> devices);
 
     bool captureState(magda::engine::DeviceKey key, CaptureCallback completed) override;
+    bool applyState(magda::engine::DeviceKey key, magda::DeviceInfo saved,
+                    CaptureCallback completed) override;
 
   private:
     std::weak_ptr<const DeviceRegistry> devices_;

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -624,4 +624,10 @@ std::optional<magda::ExternalPluginSnapshot> EngineExternalDevice::captureState(
     return magda::captureExternalPluginState(*instance_);
 }
 
+magda::SavedStateOutcome EngineExternalDevice::applyState(const magda::DeviceInfo& saved) {
+    // The write itself, including the suspension, is shared with the fork in
+    // ExternalPluginState.hpp.
+    return magda::applySavedPluginState(*instance_, saved);
+}
+
 }  // namespace magda::daw::audio::engine_adapter

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -140,6 +140,15 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
      */
     std::optional<magda::ExternalPluginSnapshot> captureState();
 
+    /**
+     * @brief Write @p saved into the plugin: parameter array, then state chunk.
+     *
+     * Here rather than behind the instance pointer for the same reason as
+     * captureState() (#2573). Call on the control executor. A Failed return
+     * means the plugin threw partway through and must not be read back.
+     */
+    magda::SavedStateOutcome applyState(const magda::DeviceInfo& saved);
+
   private:
     class PlayHead;
 

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -506,6 +506,12 @@ struct DeviceInfo {
         return format != PluginFormat::Internal;
     }
 
+    /// Whether the plugin saved a state chunk. A preset without one carries
+    /// only its parameter values.
+    bool hasPluginChunk() const {
+        return pluginState.isNotEmpty();
+    }
+
     /// Anything upstream MIDI reaches: an instrument, a MIDI effect, or a plugin
     /// that declared a MIDI input.
     bool consumesMidi() const {

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -2027,38 +2027,10 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
     live->gainValue = std::pow(10.0f, presetDevice.gainDb / 20.0f);
     live->pluginState = stripPresetRuntimePluginState(presetDevice.pluginState);
 
-    // Push the new pluginState into the running plugin.
-    if (audioEngine_) {
-        if (auto* bridge = audioEngine_->getAudioBridge()) {
-            if (auto plugin = bridge->getPlugin(devicePath)) {
-                if (dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin.get()) != nullptr) {
-                    // Only when the preset carries a native state chunk: it is the
-                    // authoritative source for the entire voice. Re-assert it +
-                    // refresh TE's param cache, then re-derive live->parameters from
-                    // the plugin, so the preset's (possibly stale) saved parameter
-                    // array can't clobber the restored voice when the
-                    // devicePropertyChanged notification below drives
-                    // syncFromDeviceInfo. (Same hazard + helper as loadDeviceAsPlugin.)
-                    //
-                    // For a parameter-only preset (no chunk -- e.g. a plugin that
-                    // returns no state, or a legacy preset) we must NOT repopulate:
-                    // that would overwrite the preset's saved parameter values with
-                    // the plugin's current ones. Leave live->parameters as captured
-                    // and let the notification below apply them via syncFromDeviceInfo.
-                    if (live->pluginState.isNotEmpty()) {
-                        applyExternalPluginChunk(plugin.get(), live->pluginState);
-                        if (auto* proc = bridge->getDeviceProcessor(devicePath))
-                            proc->populateParameters(*live, DeviceProcessor::ValueSource::Engine);
-                    }
-                } else {
-                    namespace ta = daw::audio::tracktion_adapter;
-                    auto savedState = ta::devicePluginTreeFromState(live->pluginState);
-                    if (savedState.isValid())
-                        plugin->restorePluginStateFromValueTree(savedState);
-                }
-            }
-        }
-    }
+    // The rendering engine, not the bridge: only the live instance has the
+    // state (#2573). It may rewrite live->parameters.
+    if (audioEngine_ != nullptr)
+        audioEngine_->applyPluginStateAt(devicePath);
 
     // Notify listeners — devicePropertyChanged covers gain/macros/mods refresh
     // via the AudioBridge sync path, then push each parameter individually so

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -271,20 +271,20 @@ class AudioEngine : public AudioEngineListener {
     virtual TrackMeters& meters() = 0;
     virtual const TrackMeters& meters() const = 0;
 
-    // ===== What the live plugins hold =====
+    // ===== Plugin state =====
     //
-    // A project stores a plugin's own chunk, and only the instance that is
-    // rendering has one -- so which engine is rendering decides who is asked
-    // (#2581). Both of these are synchronous: the caller writes the project
-    // file, or copies the device, the moment they return.
+    // Only the rendering instance has an up to date state chunk, so these go
+    // to whichever engine is rendering (#2581). All three are synchronous:
+    // callers save the project or copy the device as soon as they return.
 
-    /** Read every live plugin's state back into the model. Before a save, and
-        before a duplicate that has to carry the source's live settings. */
+    /** @brief Read every live plugin's state back into the model. */
     virtual void captureAllPluginStates() = 0;
 
-    /** The same for the one device at @p devicePath, whose state would
-        otherwise be the state it was placed with. */
+    /** @brief The same for the one device at @p devicePath. */
     virtual void capturePluginStateAt(const ChainNodePath& devicePath) = 0;
+
+    /** @brief Write the model's state for @p devicePath into the plugin (#2573). */
+    virtual void applyPluginStateAt(const ChainNodePath& devicePath) = 0;
 
     // ===== MIDI Management =====
     virtual MidiBridge* getMidiBridge() = 0;

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -325,6 +325,13 @@ void MagdaAudioEngine::capturePluginStateAt(const ChainNodePath& devicePath) {
     if (host_ != nullptr)
         host_->captureExternalPluginStateAt(devicePath);
 }
+
+void MagdaAudioEngine::applyPluginStateAt(const ChainNodePath& devicePath) {
+    tracktion_->applyPluginStateAt(devicePath);
+
+    if (host_ != nullptr)
+        host_->applyExternalPluginStateAt(devicePath);
+}
 MidiBridge* MagdaAudioEngine::getMidiBridge() {
     return tracktion_->getMidiBridge();
 }

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -139,6 +139,7 @@ class MagdaAudioEngine final : public AudioEngine, public LiveMidiSink {
     }
     void captureAllPluginStates() override;
     void capturePluginStateAt(const ChainNodePath& devicePath) override;
+    void applyPluginStateAt(const ChainNodePath& devicePath) override;
     MidiBridge* getMidiBridge() override;
     const MidiBridge* getMidiBridge() const override;
     MagdaApi& getMagdaApi() override;

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -293,10 +293,10 @@ class TracktionEngineWrapper : public AudioEngine,
         return meters_;
     }
 
-    /// What this engine renders through are the bridge's own synced plugins,
-    /// so a capture is a flush of those (#2581).
+    /** @brief Read the bridge's plugins back into the model. They are what this renders. */
     void captureAllPluginStates() override;
     void capturePluginStateAt(const ChainNodePath& devicePath) override;
+    void applyPluginStateAt(const ChainNodePath& devicePath) override;
 
     /**
      * @brief Export capture pass for External FX / Instrument devices (#1623)

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -13,7 +13,9 @@
 #endif
 
 #include "../audio/AudioBridge.hpp"
+#include "../audio/plugin_manager/ExternalPluginStateUtil.hpp"
 #include "../audio/plugins/InternalPluginRegistry.hpp"
+#include "../audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "../audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
 #include "../core/AppPaths.hpp"
 #include "PluginMetadataStore.hpp"
@@ -821,6 +823,38 @@ void TracktionEngineWrapper::captureAllPluginStates() {
 void TracktionEngineWrapper::capturePluginStateAt(const ChainNodePath& devicePath) {
     if (audioBridge_ != nullptr)
         audioBridge_->getPluginManager().capturePluginState(devicePath);
+}
+
+void TracktionEngineWrapper::applyPluginStateAt(const ChainNodePath& devicePath) {
+    if (audioBridge_ == nullptr)
+        return;
+
+    auto* live = TrackManager::getInstance().getDeviceInChainByPath(devicePath);
+    if (live == nullptr)
+        return;
+
+    auto plugin = audioBridge_->getPlugin(devicePath);
+    if (plugin == nullptr)
+        return;
+
+    if (dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin.get()) == nullptr) {
+        namespace ta = daw::audio::tracktion_adapter;
+        if (const auto savedState = ta::devicePluginTreeFromState(live->pluginState);
+            savedState.isValid())
+            plugin->restorePluginStateFromValueTree(savedState);
+
+        return;
+    }
+
+    // A preset with no chunk must not repopulate: that would discard the
+    // parameter values it carried.
+    if (!live->hasPluginChunk())
+        return;
+
+    applyExternalPluginChunk(plugin.get(), live->pluginState);
+
+    if (auto* processor = audioBridge_->getDeviceProcessor(devicePath))
+        processor->populateParameters(*live, DeviceProcessor::ValueSource::Engine);
 }
 
 }  // namespace magda

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -115,16 +115,11 @@ DeviceInfo* modelDeviceAt(engine::DeviceKey key) {
 }
 
 /**
- * @brief The keys the engine knows the device at @p devicePath by, and its pads.
+ * @brief The keys for the device at @p devicePath and any device on its pads.
  *
- * A single-slot caller passes a Drum Grid's own path, because a pad's patch
- * rides along in the grid's state rather than having a path of its own
- * (#2207). The grid is a device this build holds, so reading only the key the
- * path names would read nothing and leave the pads' plugins behind.
- *
- * Inverted off the same walk the publish uses rather than rebuilt from the
- * path's own steps, so the two cannot come to disagree about which section a
- * device is in.
+ * Pad devices have no path of their own, so callers address a Drum Grid by
+ * the grid's path (#2207). Looked up through devicesIn(), the walk the
+ * publish uses, so both agree which chain section a device is in.
  */
 std::vector<engine::DeviceKey> keysOfDeviceAt(const ChainNodePath& devicePath) {
     auto& trackManager = TrackManager::getInstance();
@@ -152,9 +147,12 @@ std::vector<engine::DeviceKey> keysOfDeviceAt(const ChainNodePath& devicePath) {
     return found;
 }
 
-/// The external plugin behind whatever the store holds for a key, reached
-/// through the trace when one is wrapping it (#2568): a control operation
-/// addresses the device, and a diagnostic must not change the answer.
+/**
+ * @brief The EngineExternalDevice inside @p device, or null if it is not one.
+ *
+ * Unwraps TracingDevice first, so turning the trace on does not change the
+ * answer (#2568).
+ */
 adapter::EngineExternalDevice* externalIn(engine::EngineDevice& device) {
     if (auto* tracing = dynamic_cast<TracingDevice*>(&device))
         return externalIn(tracing->wrapped());
@@ -769,10 +767,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     /**
      * @brief Read every external plugin this renders back into the model.
      *
-     * A project keeps the chunk its plugins wrote, and the only instance that
-     * has one is the instance that rendered (#2581). The keys come off the
-     * model this publish was built from; a key nothing is bound to is a
-     * failure with a reason rather than an empty state written over a patch.
+     * A key with no plugin bound is logged and skipped, so a plugin that is
+     * still loading keeps its saved state (#2581).
      */
     void captureExternalPluginStates() {
         if (session_ == nullptr)
@@ -781,9 +777,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         for (const auto key : factory_.externalKeys())
             requestCapture(key);
 
-        // The caller writes the project file the moment this returns, so the
-        // reads have to have happened by then rather than at the next turn of
-        // the message loop.
+        // drain() rather than returning to the message loop: the caller
+        // writes the project file as soon as this returns.
         control_->drain();
     }
 
@@ -791,9 +786,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         if (session_ == nullptr)
             return;
 
-        // A chain is mostly devices this build holds, and those are asked of
-        // the fork. Reaching for one here would find no external plugin bound
-        // and report that as a state that could not be read.
+        // Internal devices are handled by the fork. Asking for one here
+        // would find no external plugin and log a spurious failure.
         auto asked = false;
         for (const auto key : keysOfDeviceAt(devicePath))
             if (factory_.isExternalKey(key)) {
@@ -806,19 +800,61 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     }
 
     /**
-     * @brief Ask for @p key's state, and write it down if it is still its own.
+     * @brief Write the model's state for @p devicePath into the plugin (#2573).
      *
-     * The completion carries its assignment and nothing else: it runs later
-     * than the call that queued it, and a completion holding this object would
-     * be one more thing that has to outlive a project closing
-     * (PluginAssignments.hpp).
+     * The plan sends the parameter array every block; the state chunk is
+     * otherwise only written when the instance is built.
+     */
+    void applyExternalPluginStateAt(const ChainNodePath& devicePath) {
+        if (session_ == nullptr)
+            return;
+
+        auto asked = false;
+        for (const auto key : keysOfDeviceAt(devicePath))
+            if (factory_.isExternalKey(key)) {
+                requestApply(key);
+                asked = true;
+            }
+
+        if (asked)
+            control_->drain();
+    }
+
+    /**
+     * @brief Write the model's state for @p key into its plugin, then read it back.
+     *
+     * The read-back is committed only if @p key still names the same plugin,
+     * since a slot can be given a different one while the work runs.
+     */
+    void requestApply(engine::DeviceKey key) {
+        const auto* saved = modelDeviceAt(key);
+        if (saved == nullptr)
+            return;
+
+        plane_.applyState(
+            key, *saved, [request = loader_.request(key)](adapter::CaptureOutcome held) {
+                if (!held.ok()) {
+                    if (request.isStillWanted())
+                        juce::Logger::writeToLog("[engine] not applied: " + held.failure());
+                    return;
+                }
+
+                adapter::commitCapturedState(request, held.snapshot(), modelDeviceAt);
+            });
+    }
+
+    /**
+     * @brief Read @p key's plugin and store the result on the model.
+     *
+     * The callback captures only its AssignmentRequest: it runs after this
+     * returns, and capturing `this` would tie it to a project that may close
+     * first (PluginAssignments.hpp).
      */
     void requestCapture(engine::DeviceKey key) {
         plane_.captureState(key, [request = loader_.request(key)](adapter::CaptureOutcome taken) {
             if (!taken.ok()) {
-                // Only for a slot that is still the one that was asked about.
-                // A device deleted or replaced while the read ran is a failure
-                // nobody is waiting to hear.
+                // A device deleted or replaced mid-read fails for a reason
+                // nobody needs reporting.
                 if (request.isStillWanted())
                     juce::Logger::writeToLog("[engine] not saved: " + taken.failure());
                 return;
@@ -976,6 +1012,10 @@ void EngineHost::captureExternalPluginStates() {
 
 void EngineHost::captureExternalPluginStateAt(const ChainNodePath& devicePath) {
     impl_->captureExternalPluginStateAt(devicePath);
+}
+
+void EngineHost::applyExternalPluginStateAt(const ChainNodePath& devicePath) {
+    impl_->applyExternalPluginStateAt(devicePath);
 }
 
 void EngineHost::play() {

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -99,22 +99,30 @@ class EngineHost {
     /// publish and stays bound to it. Message thread.
     void registerVirtualMidiSource(const juce::String& deviceId);
 
-    // ===== What the plugins hold =====
+    // ===== Plugin state =====
     //
-    // A project saves the chunk its plugins wrote, and only the instance that
-    // rendered has one (#2581). Both of these run on the message thread and
-    // return with the reads done, because a save writes the file the moment
-    // they do.
+    // All three run on the message thread and return once the plugin has been
+    // read or written, because a save writes the file immediately after.
 
-    /// Read every external plugin this is rendering back into the model.
+    /** @brief Read every external plugin this renders back into the model. */
     void captureExternalPluginStates();
 
-    /// The one at @p devicePath and anything on its pads, for a caller
-    /// flushing a single slot before it copies, removes or snapshots it. A
-    /// Drum Grid is passed by its own path because its pads ride along in its
-    /// state (#2207). Nothing for a path holding no external plugin this is
-    /// rendering.
+    /**
+     * @brief Read the plugin at @p devicePath, plus any on its pads.
+     *
+     * Callers use this before copying, removing or snapshotting one slot.
+     * Pass a Drum Grid's own path to reach its pads: pad plugins have no
+     * path of their own (#2207).
+     */
     void captureExternalPluginStateAt(const ChainNodePath& devicePath);
+
+    /**
+     * @brief Write the model's state for @p devicePath into the plugin (#2573).
+     *
+     * The model is then updated from the plugin, because a state chunk can
+     * change parameters the model's array does not list.
+     */
+    void applyExternalPluginStateAt(const ChainNodePath& devicePath);
 
     // ===== Transport =====
     //

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -100,16 +100,15 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
         trace_ = &trace;
     }
 
-    /// The keys this publish's model calls external plugins, in key order.
-    /// Off the one reading of the model @ref setModel took, so a caller
-    /// walking them is walking the same project the devices were built for
-    /// (#2581).
+    /**
+     * @brief Every key in the model that names an external plugin, in key order.
+     *
+     * Read from the model @ref setModel was given, so it matches the devices
+     * this factory built (#2581).
+     */
     std::vector<engine::DeviceKey> externalKeys() const;
 
-    /// Whether @p key is one of those. For a caller holding a single path
-    /// rather than a list: everything else in a chain is a device this build
-    /// holds, which has no chunk to read and nothing to say about not having
-    /// one (#2581).
+    /** @brief Whether @p key names an external plugin in the model. */
     bool isExternalKey(engine::DeviceKey key) const;
 
     /// Nothing the store holds belongs to the model any more: the project was

--- a/magda/daw/engine/host/EngineTrace.hpp
+++ b/magda/daw/engine/host/EngineTrace.hpp
@@ -105,9 +105,7 @@ class TracingDevice final : public magda::engine::EngineDevice {
 
     void process(magda::engine::DeviceBlock& block) override;
 
-    /// What this stands in front of. A control operation addresses the device
-    /// itself rather than the diagnostic around it, so a capture must not
-    /// answer differently with the trace on (#2581).
+    /** @brief The device this wraps, for callers that must reach past the trace. */
     EngineDevice& wrapped() const {
         return *device_;
     }

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -391,8 +391,12 @@ class EngineSession {
         return store_.meterTap(key);
     }
 
-    /// A lease on the device at @p key, for a host reaching one for something
-    /// that is not a block (#2581). On the publishing thread.
+    /**
+     * @brief The device at @p key, or null.
+     *
+     * Shared so a caller can hold it while a publish evicts it. Call on the
+     * publishing thread.
+     */
     std::shared_ptr<EngineDevice> device(DeviceKey key) const {
         return store_.device(key);
     }

--- a/tests/engine/test_control_executor_juce.cpp
+++ b/tests/engine/test_control_executor_juce.cpp
@@ -31,8 +31,7 @@ class ControlExecutorTest final : public juce::UnitTest {
     }
 
   private:
-    /// Lets the message loop deliver what the executor posted, the way a host
-    /// returning to its loop would.
+    /** @brief Lets the message loop deliver what the executor posted. */
     static void pumpMessageLoop() {
         juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
     }

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -535,6 +535,19 @@ adapter::CaptureOutcome capture(adapter::DeviceControlPlane& plane, magda::engin
     return answered.get();
 }
 
+/** @brief The same as capture(), for the write direction (#2573). */
+adapter::CaptureOutcome apply(adapter::DeviceControlPlane& plane, magda::engine::DeviceKey key,
+                              magda::DeviceInfo saved) {
+    std::promise<adapter::CaptureOutcome> answer;
+    auto answered = answer.get_future();
+
+    plane.applyState(key, std::move(saved), [&answer](adapter::CaptureOutcome outcome) {
+        answer.set_value(std::move(outcome));
+    });
+
+    return answered.get();
+}
+
 /// A registry over one device, which is what a runtime hands a plane (#2270).
 ///
 /// It owns the device, the way a runtime owns the ones it runs, and hands out a
@@ -2791,6 +2804,149 @@ TEST_CASE("A capture through the control plane answers with what the plugin hold
 
     magda::applyCapturedPluginState(model, answered.snapshot());
     CHECK(model.parameters[1].currentValue == Catch::Approx(0.4f));
+}
+
+TEST_CASE("A preset applied through the plane reaches the plugin", "[engine][external][control]") {
+    // #2573: the plan sends the parameter array every block, but the state
+    // chunk only reaches an instance when it is built, so a preset's chunk
+    // never arrives.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    const auto external = ownedExternalDevice(result);
+    REQUIRE(external != nullptr);
+
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    const auto registry = std::make_shared<const OneDeviceRegistry>(key, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
+
+    // A pluginState this instance has never been given.
+    auto preset = model;
+    {
+        auto plugged = std::make_unique<StubPlugin>(2, 2, 0);
+        plugged->tone->setValue(0.9f);
+
+        juce::MemoryBlock chunk;
+        plugged->getStateInformation(chunk);
+        preset.pluginState = chunk.toBase64Encoding();
+    }
+
+    REQUIRE(raw->tone->getValue() != Catch::Approx(0.9f));
+
+    const auto answered = apply(plane, key, preset);
+    REQUIRE(answered.ok());
+    CHECK(raw->tone->getValue() == Catch::Approx(0.9f));
+}
+
+TEST_CASE("An apply answers with what the plugin holds afterwards", "[engine][external][control]") {
+    // The answer must describe the plugin, not the preset that was sent:
+    // see applyState() in DeviceControl.hpp.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    const auto external = ownedExternalDevice(result);
+    REQUIRE(external != nullptr);
+
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    const auto registry = std::make_shared<const OneDeviceRegistry>(key, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
+
+    auto preset = model;
+    {
+        auto plugged = std::make_unique<StubPlugin>(2, 2, 0);
+        plugged->tone->setValue(0.6f);
+
+        juce::MemoryBlock chunk;
+        plugged->getStateInformation(chunk);
+        preset.pluginState = chunk.toBase64Encoding();
+    }
+
+    // Stale on purpose: the preset's array disagrees with its own chunk,
+    // which is what a preset written by another host looks like.
+    for (auto& parameter : preset.parameters)
+        parameter.currentValue = 0.0f;
+
+    const auto answered = apply(plane, key, preset);
+    REQUIRE(answered.ok());
+
+    magda::applyCapturedPluginState(preset, answered.snapshot());
+    CHECK(preset.parameters[1].currentValue == Catch::Approx(0.6f));
+}
+
+TEST_CASE("A plugin that throws taking a patch is a failure with a reason",
+          "[engine][external][control]") {
+    // setStateInformation() throws partway, so the plugin holds neither the
+    // old nor the new state. Reading it back would put that in the project.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    const auto external = ownedExternalDevice(result);
+    REQUIRE(external != nullptr);
+
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    const auto registry = std::make_shared<const OneDeviceRegistry>(key, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
+
+    raw->throwsOnState = true;
+
+    auto preset = model;
+    preset.pluginState = juce::MemoryBlock(4, true).toBase64Encoding();
+
+    const auto answered = apply(plane, key, preset);
+    CHECK_FALSE(answered.ok());
+    CHECK(answered.failure().contains("could not take that patch"));
+}
+
+TEST_CASE("An apply to a key with no device bound says so", "[engine][external][control]") {
+    const auto registry = std::make_shared<const EmptyRegistry>();
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
+
+    const auto answered = apply(plane, {magda::ChainSegment::PostFx, 12}, externalDevice());
+    CHECK_FALSE(answered.ok());
+    CHECK(answered.failure().contains("nothing to apply it to"));
+    CHECK(answered.failure().contains("12"));
+}
+
+TEST_CASE("An apply is not left holding the plugin suspended", "[engine][external][control]") {
+    // A plugin left suspended renders silence for the rest of the session,
+    // so every exit from the write has to resume it (ExternalPluginState.hpp).
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    const auto external = ownedExternalDevice(result);
+    REQUIRE(external != nullptr);
+
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    const auto registry = std::make_shared<const OneDeviceRegistry>(key, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
+
+    raw->throwsOnState = true;
+
+    auto preset = model;
+    preset.pluginState = juce::MemoryBlock(4, true).toBase64Encoding();
+
+    CHECK_FALSE(apply(plane, key, preset).ok());
+    CHECK_FALSE(raw->isSuspended());
 }
 
 TEST_CASE("A key with no device bound is a failure rather than an empty state",

--- a/tests/project/test_project_serialization.cpp
+++ b/tests/project/test_project_serialization.cpp
@@ -247,6 +247,8 @@ class ProjectBoundaryResetEngine : public AudioEngine {
 
     void capturePluginStateAt(const ChainNodePath&) override {}
 
+    void applyPluginStateAt(const ChainNodePath&) override {}
+
     MidiBridge* getMidiBridge() override {
         return nullptr;
     }


### PR DESCRIPTION
Closes #2573.

A preset written into the model reached the parameter array by way of the plan and reached
nothing else. An external instance is handed its chunk once, when it is built, so anything only
the chunk carries -- a sampler's loaded samples and key mappings, the current program, every
value the plugin never exposed -- stayed on the patch the project was loaded with.
`applyDevicePreset()` pushed it into the Tracktion instance by name, which is not the one making
sound under magda. A parameter-only preset happened to work; a chunk-carrying one silently did
not.

## The operation

`DeviceControlPlane::applyState()`, on the same `ControlExecutor` as the capture, so a write and
a read cannot be inside one plugin at once (#2268). Same weak registry, same lease, same
assignment boundary between the ask and the answer as #2581.

It applies and then reads the plugin back in the same turn, answering with that snapshot rather
than with a yes. A chunk moves parameters the array underneath it never mentioned, so a model
left holding the preset's own array would be published over the patch at the next block. The
answer is the same thing a save commits, through the same `commitCapturedState`.

A plugin that throws partway through taking a patch is a named failure, not a committed
snapshot: what it holds then is neither patch and no read would describe it.

## The suspension

`applySavedPluginState()` never suspended the instance, only the capture did. At a load the
plugin is not rendering and it cost nothing, but applied to a plugin that is, it is what keeps a
block from running through one halfway between two patches. Scoped, because that path has early
returns and a plugin left suspended renders silence for the rest of the session.

## The seam

`AudioEngine::applyPluginStateAt()`. The fork answers it with the chunk-and-repopulate logic that
used to sit inline in `applyDevicePreset`, moved across unchanged; `MagdaAudioEngine` asks both
engines in turn the way the capture does. `applyDevicePreset` no longer names an engine.

## Tests

Five cases in `test_engine_external_device.cpp`, on the existing plane harness: the preset
reaches the plugin, the answer carries what the plugin holds afterwards over a deliberately stale
array, a plugin that throws is a failure with a reason, an unbound key says so and names the
slot, and the throwing path does not leave the plugin suspended.

Catch2 3923 passed / 0 failed locally, full JUCE suite green.

Hardware verification still wants a real VST: load a project on magda, apply a preset that
carries a chunk, confirm it is audible, save and reload on either engine.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF
