### PR TITLE
Open a plugin's editor onto the instance that renders it

### DIFF
--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -350,14 +350,13 @@ bool DeviceApiLive::openDeviceEditor(const ChainNodePath& devicePath) {
     if (getDevice(devicePath) == nullptr)
         return false;
     auto* engine = TrackManager::getInstance().getAudioEngine();
-    auto* bridge = engine != nullptr ? engine->getAudioBridge() : nullptr;
-    if (bridge == nullptr)
+    if (engine == nullptr)
         return false;
-    bridge->showPluginWindow(devicePath);
-    // showPluginWindow is best-effort — an analysis device or a plugin with no
-    // native editor shows nothing — so report what actually happened rather
-    // than that the request was heard.
-    return bridge->isPluginWindowOpen(devicePath);
+
+    // Best-effort — an analysis device or a plugin with no native editor shows
+    // nothing — so report what actually happened rather than that the request
+    // was heard. Asked of whichever engine renders the instance (#2580).
+    return engine->showDeviceEditor(devicePath);
 }
 
 }  // namespace magda

--- a/magda/daw/audio/plugins/engine/DeviceControl.cpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.cpp
@@ -110,6 +110,73 @@ bool LocalDeviceControlPlane::captureState(magda::engine::DeviceKey key,
     });
 }
 
+EditorOutcome EditorOutcome::showing(bool isShowing) {
+    EditorOutcome outcome;
+    outcome.showing_ = isShowing;
+    return outcome;
+}
+
+EditorOutcome EditorOutcome::failed(juce::String reason) {
+    EditorOutcome outcome;
+
+    // Never empty, or ok() would read a failure as an answer.
+    outcome.failure_ = reason.isNotEmpty()
+                           ? std::move(reason)
+                           : juce::String("the editor request failed for no stated reason");
+    return outcome;
+}
+
+bool LocalDeviceControlPlane::editorWindow(magda::engine::DeviceKey key, EditorAction action,
+                                           EditorCallback completed) {
+    if (!completed || executor() == nullptr)
+        return false;
+
+    // The same shape as a capture, on the same executor and for the same
+    // reason: opening an editor reaches into the plugin, and two things inside
+    // one plugin at once is what the plane exists to prevent (#2268).
+    return executor()->run([devices = devices_, key, action,
+                            completed](ExecutionState state) mutable {
+        if (state == ExecutionState::Cancelled) {
+            completed(EditorOutcome::failed("the control plane closed before this ran"));
+            return;
+        }
+
+        const auto registry = devices.lock();
+        if (!registry) {
+            completed(
+                EditorOutcome::failed("the runtime that owned " + describeKey(key) + " is gone"));
+            return;
+        }
+
+        const auto device = registry->find(key);
+        if (device == nullptr) {
+            completed(EditorOutcome::failed("no plugin is bound for " + describeKey(key)));
+            return;
+        }
+
+        switch (action) {
+            case EditorAction::Show:
+                device->showEditor();
+                break;
+            case EditorAction::Hide:
+                device->hideEditor();
+                break;
+            case EditorAction::Toggle:
+                if (device->isEditorOpen())
+                    device->hideEditor();
+                else
+                    device->showEditor();
+                break;
+            case EditorAction::Query:
+                break;
+        }
+
+        // What it is now, whatever was asked: a show that found no editor
+        // to open answers the same way a query would.
+        completed(EditorOutcome::showing(device->isEditorOpen()));
+    });
+}
+
 bool commitCapturedState(const AssignmentRequest& request,
                          const magda::ExternalPluginSnapshot& snapshot,
                          const MutableDeviceLookup& device) {

--- a/magda/daw/audio/plugins/engine/DeviceControl.hpp
+++ b/magda/daw/audio/plugins/engine/DeviceControl.hpp
@@ -85,6 +85,52 @@ class CaptureOutcome {
 };
 
 /**
+ * @brief What an editor request came back with: its window, or why not (#2580).
+ *
+ * "Showing" rather than "shown", because the answer is the same question the
+ * caller would ask next: a toggle reports what the slot's light should read,
+ * and a plugin with no editor of its own reports not showing rather than a
+ * failure -- there is nothing wrong, there is just nothing to open.
+ */
+class EditorOutcome {
+  public:
+    /// Whether the plugin's window is on screen now.
+    static EditorOutcome showing(bool isShowing);
+
+    /// Why there is no answer: the device, its runtime, or the plane has gone.
+    static EditorOutcome failed(juce::String reason);
+
+    bool ok() const {
+        return failure_.isEmpty();
+    }
+
+    bool isShowing() const {
+        return showing_;
+    }
+
+    /// Why nothing was asked. Empty when ok().
+    const juce::String& failure() const {
+        return failure_;
+    }
+
+  private:
+    EditorOutcome() = default;
+
+    bool showing_ = false;
+    juce::String failure_;
+};
+
+/// What to do with a device's editor window (#2580).
+enum class EditorAction {
+    Show,
+    Hide,
+    Toggle,
+
+    /// Ask without touching it, which is what a slot redrawing wants.
+    Query,
+};
+
+/**
  * @brief Where a host asks a device for anything that is not a block.
  *
  * One implementation runs the plugin in this process; another asks a process
@@ -127,6 +173,23 @@ class DeviceControlPlane {
      * there when it runs, or held weakly and checked.
      */
     virtual bool captureState(magda::engine::DeviceKey key, CaptureCallback completed) = 0;
+
+    /// What an editor request is answered with, on this plane's executor.
+    using EditorCallback = std::function<void(EditorOutcome)>;
+
+    /**
+     * @brief Show, hide, toggle or ask after the editor of the device at @p key.
+     *
+     * The same contract @ref captureState has, for the same reasons: asked
+     * from any thread, answered on the executor, and serialised against every
+     * other operation on that plugin -- an editor being built is one more
+     * thing that must not overlap a state read.
+     *
+     * The executor is the message thread's, which is where a window may be
+     * opened at all.
+     */
+    virtual bool editorWindow(magda::engine::DeviceKey key, EditorAction action,
+                              EditorCallback completed) = 0;
 
     /// Where this plane's work runs, for a host that has something else to
     /// put on the same thread.
@@ -185,6 +248,8 @@ class LocalDeviceControlPlane final : public DeviceControlPlane {
                             std::weak_ptr<const DeviceRegistry> devices);
 
     bool captureState(magda::engine::DeviceKey key, CaptureCallback completed) override;
+    bool editorWindow(magda::engine::DeviceKey key, EditorAction action,
+                      EditorCallback completed) override;
 
   private:
     std::weak_ptr<const DeviceRegistry> devices_;

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -1,8 +1,11 @@
 #include "plugins/engine/EngineExternalDevice.hpp"
 
+#include <juce_gui_basics/juce_gui_basics.h>
+
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <functional>
 #include <utility>
 
 #include "core/ParameterUtils.hpp"
@@ -78,6 +81,46 @@ void clearNonFinite(juce::AudioBuffer<float>& audio, int numSamples) {
  * block that produced the answer, and some do. The worst that can do here is
  * report a stale position, which is what the fork does too.
  */
+/**
+ * @brief The plugin's editor in a window of its own (#2580).
+ *
+ * A DocumentWindow rather than the fork's `te::PluginWindowState`, which is
+ * built around a te::Plugin this side does not have. What it owes the device
+ * is the close button: JUCE deletes nothing itself, so the window tells its
+ * owner and the owner destroys it, which is also what makes "is it open" a
+ * question about a pointer rather than about a flag somebody has to maintain.
+ */
+class EngineExternalDevice::EditorWindow final : public juce::DocumentWindow {
+  public:
+    EditorWindow(juce::AudioPluginInstance& plugin, std::function<void()> closed)
+        : juce::DocumentWindow(plugin.getName(), juce::Colours::black,
+                               juce::DocumentWindow::closeButton),
+          closed_(std::move(closed)) {
+        setUsingNativeTitleBar(true);
+        setContentOwned(plugin.createEditorIfNeeded(), true);
+        setResizable(plugin.getActiveEditor() != nullptr && plugin.getActiveEditor()->isResizable(),
+                     false);
+        centreWithSize(getWidth(), getHeight());
+        setVisible(true);
+    }
+
+    /// The editor goes before the window it sits in, and while the plugin is
+    /// still there to be told it has gone.
+    ~EditorWindow() override {
+        clearContentComponent();
+    }
+
+    void closeButtonPressed() override {
+        // Not delete-this: the owner holds this by unique_ptr, and a window
+        // that freed itself would leave it dangling until the next question.
+        if (closed_)
+            closed_();
+    }
+
+  private:
+    std::function<void()> closed_;
+};
+
 class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
   public:
     void setBlock(const magda::engine::BlockInfo& block, double sampleRate) {
@@ -212,6 +255,13 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
 }
 
 EngineExternalDevice::~EngineExternalDevice() {
+    // Before anything else: the editor is the plugin's own component, and it
+    // has to go while the plugin is still there to take it back (#2580). A
+    // window open here means this device is being destroyed on the thread its
+    // window was opened from, which is the message thread or nothing.
+    jassert(editor_ == nullptr || juce::MessageManager::existsAndIsCurrentThread());
+    editor_.reset();
+
     // The playhead outlives nothing: the instance is told to forget it before
     // either is destroyed, because JUCE leaves the pointer where it was and a
     // plugin asking after the fact would read freed memory. The fork does the
@@ -612,6 +662,27 @@ void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
 
     if (block.midiOut != nullptr)
         writeMidiOut(*block.midiOut, numSamples);
+}
+
+bool EngineExternalDevice::showEditor() {
+    if (editor_ != nullptr) {
+        editor_->toFront(true);
+        return true;
+    }
+
+    if (!instance_->hasEditor())
+        return false;
+
+    editor_ = std::make_unique<EditorWindow>(*instance_, [this] { hideEditor(); });
+    return true;
+}
+
+void EngineExternalDevice::hideEditor() {
+    editor_.reset();
+}
+
+bool EngineExternalDevice::isEditorOpen() const {
+    return editor_ != nullptr;
 }
 
 std::optional<magda::ExternalPluginSnapshot> EngineExternalDevice::captureState() {

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -140,8 +140,25 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
      */
     std::optional<magda::ExternalPluginSnapshot> captureState();
 
+    // ===== The plugin's own window (#2580) =====
+    //
+    // Here rather than through an accessor, for the reason the instance has no
+    // accessor at all: the editor is the plugin's, and the object that owns the
+    // instance is the only one allowed to reach it. Message thread, serialised
+    // against everything else this device is asked (DeviceControl.hpp).
+
+    /// Open the plugin's editor, or bring it to the front. False for a plugin
+    /// that has no editor of its own, which is what a generic one would hide.
+    bool showEditor();
+
+    /// Close it. Silent for a plugin whose window is not open.
+    void hideEditor();
+
+    bool isEditorOpen() const;
+
   private:
     class PlayHead;
+    class EditorWindow;
 
     void writeParameters(const magda::engine::DeviceParams& params);
 
@@ -163,6 +180,11 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     std::unique_ptr<juce::AudioPluginInstance> instance_;
     std::unique_ptr<PlayHead> playHead_;
+
+    /// The plugin's window while it is open, and null while it is not: closing
+    /// it from its own title bar is what destroys it, so this is also the
+    /// answer to whether it is showing.
+    std::unique_ptr<EditorWindow> editor_;
 
     /**
      * @brief What the plan's parameter slot at this index addresses.

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -286,6 +286,18 @@ class AudioEngine : public AudioEngineListener {
         otherwise be the state it was placed with. */
     virtual void capturePluginStateAt(const ChainNodePath& devicePath) = 0;
 
+    // ===== The plugins' own windows (#2580) =====
+    //
+    // A plugin's editor belongs to the instance that renders, so which engine
+    // is rendering decides whose window opens -- the same split as the state
+    // above. Message thread, and each answers whether the window is showing
+    // afterwards, which is what the slot draws.
+
+    virtual bool showDeviceEditor(const ChainNodePath& devicePath) = 0;
+    virtual bool hideDeviceEditor(const ChainNodePath& devicePath) = 0;
+    virtual bool toggleDeviceEditor(const ChainNodePath& devicePath) = 0;
+    virtual bool isDeviceEditorOpen(const ChainNodePath& devicePath) const = 0;
+
     // ===== MIDI Management =====
     virtual MidiBridge* getMidiBridge() = 0;
     virtual const MidiBridge* getMidiBridge() const = 0;

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -325,6 +325,20 @@ void MagdaAudioEngine::capturePluginStateAt(const ChainNodePath& devicePath) {
     if (host_ != nullptr)
         host_->captureExternalPluginStateAt(devicePath);
 }
+// The window that opens is onto the instance this renders through, which is
+// the host's; the fork holds no copy of it any more (#2580).
+bool MagdaAudioEngine::showDeviceEditor(const ChainNodePath& devicePath) {
+    return host_->showDeviceEditor(devicePath);
+}
+bool MagdaAudioEngine::hideDeviceEditor(const ChainNodePath& devicePath) {
+    return host_->hideDeviceEditor(devicePath);
+}
+bool MagdaAudioEngine::toggleDeviceEditor(const ChainNodePath& devicePath) {
+    return host_->toggleDeviceEditor(devicePath);
+}
+bool MagdaAudioEngine::isDeviceEditorOpen(const ChainNodePath& devicePath) const {
+    return host_->isDeviceEditorOpen(devicePath);
+}
 MidiBridge* MagdaAudioEngine::getMidiBridge() {
     return tracktion_->getMidiBridge();
 }

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -139,6 +139,10 @@ class MagdaAudioEngine final : public AudioEngine, public LiveMidiSink {
     }
     void captureAllPluginStates() override;
     void capturePluginStateAt(const ChainNodePath& devicePath) override;
+    bool showDeviceEditor(const ChainNodePath& devicePath) override;
+    bool hideDeviceEditor(const ChainNodePath& devicePath) override;
+    bool toggleDeviceEditor(const ChainNodePath& devicePath) override;
+    bool isDeviceEditorOpen(const ChainNodePath& devicePath) const override;
     MidiBridge* getMidiBridge() override;
     const MidiBridge* getMidiBridge() const override;
     MagdaApi& getMagdaApi() override;

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -294,9 +294,14 @@ class TracktionEngineWrapper : public AudioEngine,
     }
 
     /// What this engine renders through are the bridge's own synced plugins,
-    /// so a capture is a flush of those (#2581).
+    /// so a capture is a flush of those (#2581), and the window that opens is
+    /// onto one of them (#2580).
     void captureAllPluginStates() override;
     void capturePluginStateAt(const ChainNodePath& devicePath) override;
+    bool showDeviceEditor(const ChainNodePath& devicePath) override;
+    bool hideDeviceEditor(const ChainNodePath& devicePath) override;
+    bool toggleDeviceEditor(const ChainNodePath& devicePath) override;
+    bool isDeviceEditorOpen(const ChainNodePath& devicePath) const override;
 
     /**
      * @brief Export capture pass for External FX / Instrument devices (#1623)

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -823,4 +823,32 @@ void TracktionEngineWrapper::capturePluginStateAt(const ChainNodePath& devicePat
         audioBridge_->getPluginManager().capturePluginState(devicePath);
 }
 
+bool TracktionEngineWrapper::showDeviceEditor(const ChainNodePath& devicePath) {
+    if (audioBridge_ == nullptr)
+        return false;
+
+    audioBridge_->showPluginWindow(devicePath);
+    return audioBridge_->isPluginWindowOpen(devicePath);
+}
+
+bool TracktionEngineWrapper::hideDeviceEditor(const ChainNodePath& devicePath) {
+    if (audioBridge_ == nullptr)
+        return false;
+
+    // The bridge has no hide of its own: a toggle on a window that is open is
+    // what closes it, and a window that is not open needs nothing.
+    if (audioBridge_->isPluginWindowOpen(devicePath))
+        audioBridge_->togglePluginWindow(devicePath);
+
+    return audioBridge_->isPluginWindowOpen(devicePath);
+}
+
+bool TracktionEngineWrapper::toggleDeviceEditor(const ChainNodePath& devicePath) {
+    return audioBridge_ != nullptr && audioBridge_->togglePluginWindow(devicePath);
+}
+
+bool TracktionEngineWrapper::isDeviceEditorOpen(const ChainNodePath& devicePath) const {
+    return audioBridge_ != nullptr && audioBridge_->isPluginWindowOpen(devicePath);
+}
+
 }  // namespace magda

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <optional>
 #include <ranges>
 #include <set>
 #include <span>
@@ -126,10 +127,20 @@ DeviceInfo* modelDeviceAt(engine::DeviceKey key) {
  * path's own steps, so the two cannot come to disagree about which section a
  * device is in.
  */
-std::vector<engine::DeviceKey> keysOfDeviceAt(const ChainNodePath& devicePath) {
-    auto& trackManager = TrackManager::getInstance();
+std::vector<engine::DeviceKey> keysOfDevices(const std::set<const DeviceInfo*>& wanted) {
+    std::vector<engine::DeviceKey> found;
 
-    const auto* target = trackManager.getDeviceInChainByPath(devicePath);
+    TrackManager::getInstance().forEachTrackIncludingMaster([&found, &wanted](TrackInfo& track) {
+        for (const auto& [key, device] : adapter::devicesIn(track))
+            if (wanted.contains(device))
+                found.push_back(key);
+    });
+
+    return found;
+}
+
+std::vector<engine::DeviceKey> keysOfDeviceAt(const ChainNodePath& devicePath) {
+    const auto* target = TrackManager::getInstance().getDeviceInChainByPath(devicePath);
     if (target == nullptr)
         return {};
 
@@ -141,15 +152,22 @@ std::vector<engine::DeviceKey> keysOfDeviceAt(const ChainNodePath& devicePath) {
                                           subtree.insert(&device);
                                       });
 
-    std::vector<engine::DeviceKey> found;
+    return keysOfDevices(subtree);
+}
 
-    trackManager.forEachTrackIncludingMaster([&found, &subtree](TrackInfo& track) {
-        for (const auto& [key, device] : adapter::devicesIn(track))
-            if (subtree.contains(device))
-                found.push_back(key);
-    });
+/// The one device @p devicePath names, without the pads a capture also takes:
+/// a pad's patch rides along in the grid's state, but its editor is its own
+/// and is not what a click on the grid asked for (#2580).
+std::optional<engine::DeviceKey> keyOfDeviceAt(const ChainNodePath& devicePath) {
+    const auto* target = TrackManager::getInstance().getDeviceInChainByPath(devicePath);
+    if (target == nullptr)
+        return std::nullopt;
 
-    return found;
+    const auto keys = keysOfDevices({target});
+    if (keys.empty())
+        return std::nullopt;
+
+    return keys.front();
 }
 
 /// The external plugin behind whatever the store holds for a key, reached
@@ -787,6 +805,41 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         control_->drain();
     }
 
+    /**
+     * @brief The editor of the device at @p devicePath, and what it is now (#2580).
+     *
+     * Synchronous, because every caller is a click that has to know what it
+     * did: the slot's light reads the answer, and the drain is what makes the
+     * plane's answer arrive before this returns rather than on the next
+     * message. What it drains is the message thread's own queue, so the
+     * window is opened on the thread a window may be opened on.
+     */
+    bool deviceEditor(const ChainNodePath& devicePath, adapter::EditorAction action) {
+        const auto key = keyOfDeviceAt(devicePath);
+        if (!key.has_value() || !factory_.isExternalKey(*key))
+            return false;
+
+        auto showing = false;
+        const auto asked = plane_.editorWindow(*key, action, [&showing](adapter::EditorOutcome it) {
+            // Named rather than swallowed: a person clicking a plugin's slot
+            // and getting nothing has no other way to find out why.
+            if (!it.ok()) {
+                juce::Logger::writeToLog("[engine] editor: " + it.failure());
+                return;
+            }
+
+            showing = it.isShowing();
+        });
+
+        if (!asked)
+            return false;
+
+        // The completion above writes a local, so it must have run by the time
+        // this returns. drain() is what says it has.
+        control_->drain();
+        return showing;
+    }
+
     void captureExternalPluginStateAt(const ChainNodePath& devicePath) {
         if (session_ == nullptr)
             return;
@@ -976,6 +1029,22 @@ void EngineHost::captureExternalPluginStates() {
 
 void EngineHost::captureExternalPluginStateAt(const ChainNodePath& devicePath) {
     impl_->captureExternalPluginStateAt(devicePath);
+}
+
+bool EngineHost::showDeviceEditor(const ChainNodePath& devicePath) {
+    return impl_->deviceEditor(devicePath, adapter::EditorAction::Show);
+}
+
+bool EngineHost::hideDeviceEditor(const ChainNodePath& devicePath) {
+    return impl_->deviceEditor(devicePath, adapter::EditorAction::Hide);
+}
+
+bool EngineHost::toggleDeviceEditor(const ChainNodePath& devicePath) {
+    return impl_->deviceEditor(devicePath, adapter::EditorAction::Toggle);
+}
+
+bool EngineHost::isDeviceEditorOpen(const ChainNodePath& devicePath) {
+    return impl_->deviceEditor(devicePath, adapter::EditorAction::Query);
 }
 
 void EngineHost::play() {

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -221,6 +221,11 @@ class SessionDevices final : public adapter::DeviceRegistry {
  * callback renders is what the model last published, and both are bounded by
  * the device's own start and stop.
  */
+/// Whether an edit could have changed what the plan is, as opposed to what it
+/// is worth. Only a compile can answer it; this is which edits are worth
+/// asking about (#2592).
+enum class Shape { Unchanged, MayHaveMoved };
+
 struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                                 private juce::AsyncUpdater,
                                 private juce::Timer,
@@ -380,7 +385,15 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     /// The four things a plan publish is: the topology, the values resolved
     /// against it, the IDs the model still holds, and the context they render
     /// under.
-    void publishPlan() {
+    /// The model as an engine plan. One call, so the compile options cannot
+    /// differ between the publish and the comparison below.
+    static std::shared_ptr<const engine::RenderPlan> compilePlan(
+        const std::vector<TrackInfo>& tracks, const TrackInfo& master) {
+        return std::make_shared<const engine::RenderPlan>(
+            engine::compileRenderPlan(tracks, master, {.auditionMidi = true}));
+    }
+
+    void publishPlan(std::shared_ptr<const engine::RenderPlan> plan = nullptr) {
         const auto& tracks = TrackManager::getInstance().getTracks();
         const auto* master = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
         if (session_ == nullptr || master == nullptr)
@@ -392,8 +405,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         sources_.registerAvailableDevices();
         factory_.setModel(tracks, *master);
 
-        auto plan = std::make_shared<const engine::RenderPlan>(
-            engine::compileRenderPlan(tracks, *master, {.auditionMidi = true}));
+        if (plan == nullptr)
+            plan = compilePlan(tracks, *master);
         report("plan", plan->diagnostics);
 
         engine::PlanValues values;
@@ -407,7 +420,6 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
             return;
 
         livePlan_ = std::move(plan);
-        routing_ = inputRoutingOf(tracks);
         traceEdit(EngineTrace::Kind::Swap);
         tracePlan(*livePlan_);
         reportUnbuiltDevices();
@@ -422,13 +434,17 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         if (session_ == nullptr || livePlan_ == nullptr || master == nullptr)
             return;
 
-        // An input route or a monitor switch arrives here, being a track
-        // property, and the route tables below cannot carry either: a
-        // "track:N" edge is compiled into the plan, and what a monitored
-        // audio input is at all is an op (#2579).
-        if (inputRoutingOf(tracks) != routing_) {
-            publishPlan();
-            return;
+        // A property edit can be one values cannot carry: a bypass takes the
+        // device out of the plan, a route moves an edge, a monitor switch
+        // decides whether an input op exists at all. Compiling and comparing
+        // is the exact question; a list of properties would be one more thing
+        // to keep in step with the compiler (#2592).
+        if (shape_.exchange(false, std::memory_order_relaxed)) {
+            auto compiled = compilePlan(tracks, *master);
+            if (engine::planFingerprint(*compiled) != engine::planFingerprint(*livePlan_)) {
+                publishPlan(std::move(compiled));
+                return;
+            }
         }
 
         engine::PlanValues values;
@@ -501,20 +517,24 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     void deviceAdded(const ChainNodePath&, const DeviceInfo&) override {
         wantPlan();
     }
+    // A property is the kind of edit that can move the plan's shape -- a
+    // bypass takes the device out of it, a route moves an edge -- so these say
+    // so, and publishValues() checks. A parameter cannot: that is what values
+    // are for.
     void trackPropertyChanged(int) override {
-        wantValues();
+        wantValues(Shape::MayHaveMoved);
     }
     void masterChannelChanged() override {
-        wantValues();
+        wantValues(Shape::MayHaveMoved);
     }
     void devicePropertyChanged(const ChainNodePath&) override {
-        wantValues();
+        wantValues(Shape::MayHaveMoved);
     }
     void deviceParameterChanged(const ChainNodePath&, int, float) override {
-        wantValues();
+        wantValues(Shape::Unchanged);
     }
     void deviceModifiersChanged(TrackId) override {
-        wantValues();
+        wantValues(Shape::MayHaveMoved);
     }
     void clipsChanged() override {
         wantClips();
@@ -527,7 +547,10 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         plan_.store(true, std::memory_order_relaxed);
         triggerAsyncUpdate();
     }
-    void wantValues() {
+    void wantValues(Shape shape) {
+        if (shape == Shape::MayHaveMoved)
+            shape_.store(true, std::memory_order_relaxed);
+
         values_.store(true, std::memory_order_relaxed);
         triggerAsyncUpdate();
     }
@@ -608,6 +631,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
 
         plan_.store(false, std::memory_order_relaxed);
         values_.store(false, std::memory_order_relaxed);
+        shape_.store(false, std::memory_order_relaxed);
         clips_.store(false, std::memory_order_relaxed);
 
         publishTransport();
@@ -981,10 +1005,6 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     /// values against it without compiling another.
     std::shared_ptr<const engine::RenderPlan> livePlan_;
 
-    /// The input routing that plan was compiled from. What a values publish
-    /// compares against to know it has to be a plan publish instead.
-    std::vector<InputRouting> routing_;
-
     double bpm_ = 120.0;
     int numerator_ = 4;
     int denominator_ = 4;
@@ -1004,6 +1024,9 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     std::atomic<int> inputChannels_{0};
     std::atomic<bool> plan_{false};
     std::atomic<bool> values_{false};
+
+    /// An edit arrived that a values publish may not be able to carry.
+    std::atomic<bool> shape_{false};
     std::atomic<bool> clips_{false};
 
     /// Callbacks this host has rendered. Only ever read by the trace, and the

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -116,6 +116,18 @@ class EngineHost {
     /// rendering.
     void captureExternalPluginStateAt(const ChainNodePath& devicePath);
 
+    // ===== The plugins' own windows (#2580) =====
+    //
+    // Message thread, and each answers what the window is after it: the slot
+    // that asked draws its light from the return value rather than asking
+    // again. False for a device this is not rendering, which is every device
+    // the fork holds instead.
+
+    bool showDeviceEditor(const ChainNodePath& devicePath);
+    bool hideDeviceEditor(const ChainNodePath& devicePath);
+    bool toggleDeviceEditor(const ChainNodePath& devicePath);
+    bool isDeviceEditorOpen(const ChainNodePath& devicePath);
+
     // ===== Transport =====
     //
     // Play, stop and locate are a request the clock applies once, so each of

--- a/magda/daw/engine/host/EngineProject.cpp
+++ b/magda/daw/engine/host/EngineProject.cpp
@@ -59,17 +59,4 @@ double projectEndBeat() {
     return end;
 }
 
-std::vector<InputRouting> inputRoutingOf(const std::vector<TrackInfo>& tracks) {
-    std::vector<InputRouting> routing;
-    routing.reserve(tracks.size());
-
-    for (const auto& track : tracks)
-        routing.push_back({.trackId = track.id,
-                           .midiInputDevice = track.midiInputDevice,
-                           .audioInputDevice = track.audioInputDevice,
-                           .monitors = track.monitorsInput()});
-
-    return routing;
-}
-
 }  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/EngineProject.hpp
+++ b/magda/daw/engine/host/EngineProject.hpp
@@ -39,24 +39,4 @@ engine::TempoMap tempoMapAt(double bpm, int numerator, int denominator);
 /// What the length of a project is with no Edit to ask (#2579).
 double projectEndBeat();
 
-/**
- * @brief What the compiler read to decide where a track's input comes from.
- *
- * A route and a monitor switch are track properties, so they arrive as a
- * values publish -- but a "track:N" edge is compiled into the plan and a
- * monitored audio input is an op, so neither can be carried by one. Compared
- * against what the live plan was built from, this is how the host notices
- * that a property change has to be a plan.
- */
-struct InputRouting {
-    TrackId trackId = INVALID_TRACK_ID;
-    juce::String midiInputDevice;
-    juce::String audioInputDevice;
-    bool monitors = false;
-
-    bool operator==(const InputRouting&) const = default;
-};
-
-std::vector<InputRouting> inputRoutingOf(const std::vector<TrackInfo>& tracks);
-
 }  // namespace magda::daw::engine_host

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -344,20 +344,20 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
             toggleAnalyzerWindow();
             return;
         }
-        // Get the audio bridge and toggle plugin window
+        // Asked of whichever engine is rendering: the window opens onto the
+        // instance that makes the sound (#2580).
         auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-        if (audioEngine) {
-            if (auto* bridge = audioEngine->getAudioBridge()) {
-                bool isOpen = bridge->togglePluginWindow(nodePath_);
-                uiButton_->setToggleState(isOpen, juce::dontSendNotification);
-                uiButton_->setActive(isOpen);
-                learnButton_->setEnabled(isOpen);
-                if (!isOpen && learnButton_->getToggleState()) {
-                    learnButton_->setToggleState(false, juce::dontSendNotification);
-                    learnButton_->setActive(false);
-                    paramGrid_->setLearnMode(false);
-                }
-            }
+        if (audioEngine == nullptr)
+            return;
+
+        const bool isOpen = audioEngine->toggleDeviceEditor(nodePath_);
+        uiButton_->setToggleState(isOpen, juce::dontSendNotification);
+        uiButton_->setActive(isOpen);
+        learnButton_->setEnabled(isOpen);
+        if (!isOpen && learnButton_->getToggleState()) {
+            learnButton_->setToggleState(false, juce::dontSendNotification);
+            learnButton_->setActive(false);
+            paramGrid_->setLearnMode(false);
         }
     };
     addAndMakeVisible(*uiButton_);
@@ -636,13 +636,13 @@ void DeviceSlotComponent::aiSoundDesignerPreferenceChanged(const juce::String& p
 }
 
 void DeviceSlotComponent::timerCallback() {
-    auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-    if (!audioEngine)
+    auto* engine = magda::TrackManager::getInstance().getAudioEngine();
+    if (!engine)
         return;
 
-    auto* bridge = audioEngine->getAudioBridge();
-    if (!bridge)
-        return;
+    // Null under the native engine, and only the slot meter below needs it
+    // (#2570): the editor's light is the engine's answer either way.
+    auto* bridge = engine->getAudioBridge();
 
     if (compiledPanel_ != nullptr || traits_.isAnalysis)
         refreshInlinePluginBindings();
@@ -652,7 +652,7 @@ void DeviceSlotComponent::timerCallback() {
         // Analysis devices use the popout AnalyzerWindow, not a native plugin window.
         const bool isOpen = audio::isInternalAnalysisPlugin(device_.pluginId)
                                 ? (analyzerWindow_ != nullptr && analyzerWindow_->isVisible())
-                                : bridge->isPluginWindowOpen(nodePath_);
+                                : engine->isDeviceEditorOpen(nodePath_);
         bool currentState = uiButton_->getToggleState();
 
         // Only update if state changed to avoid unnecessary repaints
@@ -688,7 +688,7 @@ void DeviceSlotComponent::timerCallback() {
     } else {
         // Poll device peak levels for right-side meter strip
         magda::DeviceMeteringManager::DeviceMeterData data;
-        if (bridge->getDeviceMetering().getLatestLevels(nodePath_, data)) {
+        if (bridge != nullptr && bridge->getDeviceMetering().getLatestLevels(nodePath_, data)) {
             levelMeter_.setLevels(data.peakL, data.peakR);
         }
     }
@@ -1627,11 +1627,9 @@ void DeviceSlotComponent::mouseDown(const juce::MouseEvent& e) {
         if (audio::isInternalAnalysisPlugin(device_.pluginId)) {
             toggleAnalyzerWindow();
         } else if (auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine()) {
-            if (auto* bridge = audioEngine->getAudioBridge()) {
-                bool isOpen = bridge->togglePluginWindow(nodePath_);
-                uiButton_->setToggleState(isOpen, juce::dontSendNotification);
-                uiButton_->setActive(isOpen);
-            }
+            const bool isOpen = audioEngine->toggleDeviceEditor(nodePath_);
+            uiButton_->setToggleState(isOpen, juce::dontSendNotification);
+            uiButton_->setActive(isOpen);
         }
     } else {
         // Pass to base class for normal click handling

--- a/magda/daw/ui/components/mixer/MiniChainRow.cpp
+++ b/magda/daw/ui/components/mixer/MiniChainRow.cpp
@@ -59,11 +59,9 @@ void MiniChainRow::setDevice(const ChainNodePath& devicePath, AudioEngine* engin
         uiButton_->onClick = [this]() {
             if (engine_ == nullptr)
                 return;
-            if (auto* bridge = engine_->getAudioBridge()) {
-                const bool isOpen = bridge->togglePluginWindow(devicePath_);
-                uiButton_->setToggleState(isOpen, juce::dontSendNotification);
-                uiButton_->setActive(isOpen);
-            }
+            const bool isOpen = engine_->toggleDeviceEditor(devicePath_);
+            uiButton_->setToggleState(isOpen, juce::dontSendNotification);
+            uiButton_->setActive(isOpen);
         };
         addAndMakeVisible(*uiButton_);
     }

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -535,6 +535,19 @@ adapter::CaptureOutcome capture(adapter::DeviceControlPlane& plane, magda::engin
     return answered.get();
 }
 
+/// The same, for an editor request (#2580).
+adapter::EditorOutcome editor(adapter::DeviceControlPlane& plane, magda::engine::DeviceKey key,
+                              adapter::EditorAction action) {
+    std::promise<adapter::EditorOutcome> answer;
+    auto answered = answer.get_future();
+
+    plane.editorWindow(key, action, [&answer](adapter::EditorOutcome outcome) {
+        answer.set_value(std::move(outcome));
+    });
+
+    return answered.get();
+}
+
 /// A registry over one device, which is what a runtime hands a plane (#2270).
 ///
 /// It owns the device, the way a runtime owns the ones it runs, and hands out a
@@ -2810,6 +2823,50 @@ TEST_CASE("A key with no device bound is a failure rather than an empty state",
     // And it says which slot, because a host with a project's worth of devices
     // is holding a failure that has to name one of them.
     CHECK(answered.failure().contains("12"));
+}
+
+TEST_CASE("A plugin with no editor of its own opens no window", "[engine][external][2580]") {
+    // What a generic editor would paper over: an analysis device, or a plugin
+    // whose UI this build cannot make. The answer is "not showing" rather than
+    // a failure -- nothing went wrong, there is nothing to open.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    auto model = externalDevice();
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    const auto external = ownedExternalDevice(result);
+    REQUIRE(external != nullptr);
+
+    const magda::engine::DeviceKey key{magda::ChainSegment::Fx, model.id};
+    const auto registry = std::make_shared<const OneDeviceRegistry>(key, external);
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
+
+    const auto shown = editor(plane, key, adapter::EditorAction::Show);
+    CHECK(shown.ok());
+    CHECK_FALSE(shown.isShowing());
+    CHECK_FALSE(external->isEditorOpen());
+
+    // And a hide on a window that was never open is not a failure either.
+    const auto hidden = editor(plane, key, adapter::EditorAction::Hide);
+    CHECK(hidden.ok());
+    CHECK_FALSE(hidden.isShowing());
+}
+
+TEST_CASE("An editor asked of a key with no device bound says which", "[engine][external][2580]") {
+    const auto registry = std::make_shared<const EmptyRegistry>();
+    adapter::LocalDeviceControlPlane plane(std::make_shared<adapter::SerialControlThread>(),
+                                           registry);
+
+    const auto answered =
+        editor(plane, {magda::ChainSegment::PostFx, 12}, adapter::EditorAction::Toggle);
+    CHECK_FALSE(answered.ok());
+    CHECK(answered.failure().contains("no plugin is bound"));
+    CHECK(answered.failure().contains("12"));
+
+    // A failure is never mistaken for an answer, which is what ok() reads.
+    CHECK_FALSE(answered.isShowing());
 }
 
 TEST_CASE("A plugin that will not describe itself is a failure with a reason",

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -173,7 +173,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::test::runWithCleanJuceState([this] { testDeviceMidiReachesOnlyItsOwnTrack(); });
         magda::test::runWithCleanJuceState([this] { testRouteRemovalPanicsTheInput(); });
         magda::test::runWithCleanJuceState([this] { testDeviceConnectedAfterAPublishResolves(); });
-        magda::test::runWithCleanJuceState([this] { testRouteChangesAreAPlanChange(); });
+        magda::test::runWithCleanJuceState([this] { testShapeChangesAreAPlanChange(); });
         magda::test::runWithCleanJuceState([this] { testOnlyTrackMetersAreTapped(); });
     }
 
@@ -888,37 +888,45 @@ class EngineHostPublishTest final : public juce::UnitTest {
                "Unplugged, it leaves the all route and the keyboard stays");
     }
 
-    void testRouteChangesAreAPlanChange() {
-        beginTest("What the compiler reads for a track's input is what a values publish watches");
+    void testShapeChangesAreAPlanChange() {
+        beginTest("An edit a values publish cannot carry is one the plan's fingerprint moves for");
 
         auto& trackManager = magda::TrackManager::getInstance();
+        const auto sourceId = synthTrack("Source", 2, magda::InputMonitorMode::Off, {});
         const auto trackId = synthTrack("Instrument", 1, magda::InputMonitorMode::Off, {});
         auto* track = trackManager.getTrack(trackId);
-        expect(track != nullptr, "The track exists");
-        if (track == nullptr)
+        const auto* master = trackManager.getTrack(magda::MASTER_TRACK_ID);
+        expect(track != nullptr && master != nullptr, "The track and the master exist");
+        if (track == nullptr || master == nullptr)
             return;
 
-        const auto compiledFrom = host::inputRoutingOf(trackManager.getTracks());
+        const auto shapeNow = [&] {
+            return magda::engine::planFingerprint(magda::engine::compileRenderPlan(
+                trackManager.getTracks(), *master, {.auditionMidi = true}));
+        };
+
+        const auto compiledFrom = shapeNow();
 
         // A mixer move is what a values publish is for.
         track->volume = 0.5f;
-        expect(host::inputRoutingOf(trackManager.getTracks()) == compiledFrom,
-               "A fader move is not a routing change");
+        expect(shapeNow() == compiledFrom, "A fader move is not a shape change");
 
-        // Each of these is an edge or an op the plan holds, so none of them can
-        // be carried by a values publish.
-        track->midiInputDevice = "track:2";
-        expect(host::inputRoutingOf(trackManager.getTracks()) != compiledFrom, "A MIDI route is");
+        // Each of these is an op or an edge the plan holds, so a values
+        // publish has nowhere to put it and the host recompiles.
+        auto& device = magda::getDevice(track->chain.fxChainElements[0]);
+        device.bypassed = true;
+        expect(shapeNow() != compiledFrom, "Bypassing a device is");
+        device.bypassed = false;
 
-        track->midiInputDevice = "";
-        track->audioInputDevice = "Input 1";
-        expect(host::inputRoutingOf(trackManager.getTracks()) != compiledFrom,
-               "So is an audio input");
-
-        track->audioInputDevice = "";
+        // Monitoring is what the compiler gates an input route on, so the
+        // switch and the route are one edit here.
         track->inputMonitor = magda::InputMonitorMode::In;
-        expect(host::inputRoutingOf(trackManager.getTracks()) != compiledFrom,
-               "So is the monitor switch that decides whether either is read");
+        track->midiInputDevice = "track:" + juce::String(sourceId);
+        expect(shapeNow() != compiledFrom, "So is taking MIDI from another track");
+        track->midiInputDevice = "";
+
+        track->audioInputDevice = "Input 1";
+        expect(shapeNow() != compiledFrom, "So is a monitored audio input");
     }
 
     void testOnlyTrackMetersAreTapped() {

--- a/tests/project/test_project_serialization.cpp
+++ b/tests/project/test_project_serialization.cpp
@@ -247,6 +247,22 @@ class ProjectBoundaryResetEngine : public AudioEngine {
 
     void capturePluginStateAt(const ChainNodePath&) override {}
 
+    bool showDeviceEditor(const ChainNodePath&) override {
+        return false;
+    }
+
+    bool hideDeviceEditor(const ChainNodePath&) override {
+        return false;
+    }
+
+    bool toggleDeviceEditor(const ChainNodePath&) override {
+        return false;
+    }
+
+    bool isDeviceEditorOpen(const ChainNodePath&) const override {
+        return false;
+    }
+
     MidiBridge* getMidiBridge() override {
         return nullptr;
     }


### PR DESCRIPTION
Fixes #2580.

Under magda no plugin window opened at all. `PluginWindowManager` drives
`te::ExternalPlugin::windowState`, and the window that used to open was onto the fork's parallel
copy of the plugin — not the one you hear. #2579 removed that copy, so the click went nowhere.

## The endpoint

`DeviceControlPlane` grows `editorWindow(key, action, completed)` beside `captureState`, with
`EditorAction` of Show, Hide, Toggle or Query. Keyed by `DeviceKey`, answered on the control
executor, fallible: a device that has gone answers with a reason rather than dangling.

The executor is the message thread's, which is where a window may be opened at all, and it is
what serialises an editor being built against a state being read — the second half of why the
plane exists (#2268).

## The window

`EngineExternalDevice` owns it, being the only object allowed to reach the instance: the header
has no accessor by design and this does not add one. A `DocumentWindow` whose close button tells
the device rather than deleting itself, so the device's `unique_ptr` is both the owner and the
answer to "is it open".

Lifetime falls out of that ownership rather than needing a second mechanism:

- a slot whose plugin changed retires the old instance, which `releaseDeleted` destroys at the end
  of that same publish (#2575);
- a project torn down forgets every device it held (#2576);
- the session going away destroys the store, and the store owns the instances.

Each of those runs on the message thread, which the destructor asserts when a window is open.

## The callers

`AudioEngine` grows show, hide, toggle and is-open. The fork answers from `AudioBridge` exactly as
before; `MagdaAudioEngine` asks the host, which maps the `ChainNodePath` to one key — the device
the path names, without the pads a capture also takes, since a pad's editor is its own.

The five sites that reached for `AudioBridge` by name now ask the engine that is rendering:
`DeviceSlotComponent` (the UI button, the double-click, the light its timer draws),
`MiniChainRow`, and `DeviceApiLive::openDeviceEditor`. The slot's timer no longer returns early
when there is no bridge, which is why its light was dead under magda; the bridge is still what the
per-slot meter reads, and that stays #2570.

## And the power button, found in the same pass

A device's power button wrote `device.bypassed` and published values. Bypass is structural — the
compiler takes a bypassed device out of the plan — so the plan kept rendering it and the button did
nothing under magda.

`publishValues` now compiles and compares `planFingerprint` against the live plan whenever the edit
was a property rather than a parameter, and publishes the plan it just compiled when the shape
moved. The fingerprint is the exact question; a list of which properties are structural would be
one more thing to keep in step with the compiler (#2592). It replaces the routing signature from
#2584, which was that list in miniature.

Confirmed by hand: the power button works.

## Tests

- A plugin with no editor of its own opens no window, and answers "not showing" rather than
  failing — nothing went wrong, there is nothing to open. A hide on a window that was never open
  is not a failure either.
- An editor asked of a key with no device bound says which key, the way a capture does.
- A fader move leaves the plan's fingerprint alone; bypassing a device, taking MIDI from another
  track while monitoring, and naming a monitored audio input each move it.

`magda_tests` 3931 passed, 13 skipped. `magda_juce_tests` all passed.

## Not driven by hand

The issue's own check: under magda, open an external plugin's editor, move a control, hear it;
close the project with the window open and nothing dangles. Under Tracktion, unchanged. Worth a
pass with a VST3 before merging — the corpus has no windows in it, and CI has no display.

Out-of-process editors stay #1899, which is why the endpoint is asynchronous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN

