### PR TITLE
Name the pluginState emptiness test

### DIFF
--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -577,7 +577,7 @@ void PluginManager::restorePluginState(const ChainNodePath& devicePath,
                                        const te::Plugin::Ptr& plugin) {
     auto& tm = TrackManager::getInstance();
     auto* devInfo = tm.getDeviceInChainByPath(devicePath);
-    if (!devInfo || devInfo->pluginState.isEmpty()) {
+    if (!devInfo || !devInfo->hasPluginState()) {
         return;
     }
 

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2161,7 +2161,7 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
                 edit_.getPluginCache().createNewPlugin(te::ExternalPlugin::xmlTypeName, descCopy);
 
             // Restore plugin native state for rack plugins
-            if (plugin && device.pluginState.isNotEmpty()) {
+            if (plugin && device.hasPluginState()) {
                 if (auto* ext = dynamic_cast<te::ExternalPlugin*>(plugin.get())) {
                     ext->state.setProperty(te::IDs::state, device.pluginState, nullptr);
                     if (!ext->isInitialisingAsync()) {
@@ -2344,7 +2344,7 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
                     // authoritative restore + param-cache refresh happens after
                     // syncFromDeviceInfo below, where it can't be clobbered by the
                     // saved per-parameter array.)
-                    if (device.pluginState.isNotEmpty()) {
+                    if (device.hasPluginState()) {
                         ext->restorePluginStateFromValueTree(ext->state);
                     }
                     // Imported DAWproject .vstpreset state (instance is live here).
@@ -2581,7 +2581,7 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
                 if ((device.pluginId.containsIgnoreCase(daw::audio::DrumGridPlugin::xmlTypeName) ||
                      device.pluginId.containsIgnoreCase(
                          daw::audio::MagdaSamplerPlugin::xmlTypeName)) &&
-                    device.pluginState.isNotEmpty()) {
+                    device.hasPluginState()) {
                     auto savedState = daw::audio::tracktion_adapter::devicePluginTreeFromState(
                         device.pluginState);
                     if (savedState.isValid())

--- a/magda/daw/audio/plugins/DeviceStateHydration.cpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.cpp
@@ -141,7 +141,7 @@ Provenance provenanceFromMagdaVersion(const juce::String& version) {
 }
 
 bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& provenance) {
-    if (device.format != PluginFormat::Internal || device.pluginState.isEmpty())
+    if (device.format != PluginFormat::Internal || !device.hasPluginState())
         return false;
 
     const auto doc = ds::decode(device.pluginState);

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -429,7 +429,8 @@ struct DeviceInfo {
     // Multi-output configuration (for instruments with >2 output channels)
     MultiOutConfig multiOut;
 
-    // Plugin native state (base64-encoded binary blob from TE ExternalPlugin)
+    // Saved device state. An external plugin's own chunk, base64-encoded; for
+    // an internal device, a device_state document (DeviceStateHydration.cpp).
     juce::String pluginState;
 
     // VST3 class id (32-char hex FUID) for hosted VST3 plugins, captured once
@@ -506,9 +507,8 @@ struct DeviceInfo {
         return format != PluginFormat::Internal;
     }
 
-    /// Whether the plugin saved a state chunk. A preset without one carries
-    /// only its parameter values.
-    bool hasPluginChunk() const {
+    /// Whether pluginState holds anything.
+    bool hasPluginState() const {
         return pluginState.isNotEmpty();
     }
 

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -848,7 +848,7 @@ void TracktionEngineWrapper::applyPluginStateAt(const ChainNodePath& devicePath)
 
     // A preset with no chunk must not repopulate: that would discard the
     // parameter values it carried.
-    if (!live->hasPluginChunk())
+    if (!live->hasPluginState())
         return;
 
     applyExternalPluginChunk(plugin.get(), live->pluginState);

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -363,7 +363,7 @@ std::optional<DeviceStateFile> deviceStateFile(const DeviceInfo& device) {
             return DeviceStateFile{base + ".vstpreset", decoded.getMemoryBlock()};
     }
 
-    if (device.pluginState.isNotEmpty()) {
+    if (device.hasPluginState()) {
         const auto* utf8 = device.pluginState.toRawUTF8();
         return DeviceStateFile{base + ".bin", juce::MemoryBlock(utf8, std::strlen(utf8))};
     }

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -522,7 +522,7 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
     }
 
     // Plugin native state (base64 blob, only if captured)
-    if (device.pluginState.isNotEmpty()) {
+    if (device.hasPluginState()) {
         obj->setProperty("pluginState", device.pluginState);
     }
 


### PR DESCRIPTION
Closes #2593.

`hasPluginChunk()` landed in #2591 so one call site could say what it meant without a comment
over it. The seven other sites that spelled the same test out now use it.

## The rename

`hasPluginChunk()` -> `hasPluginState()`. Two of the seven are not about chunks:

- `DeviceStateHydration.cpp:144` (`hydrateParametersFromDeviceState`) guards
  `format == PluginFormat::Internal`
- `PluginManagerSync.cpp:2584` restores DrumGrid and Sampler pads

Both store a `device_state` document in `pluginState`, not an external plugin's opaque blob, so
"chunk" would have been wrong there. The field's own comment claimed it was always a
"base64-encoded binary blob from TE ExternalPlugin"; that has not been true since internal
devices started saving through it, and it is corrected here.

The one call site that is about a chunk keeps the word in its comment, where it is accurate.

## Converted

`TrackSerializer.cpp:525`, `DawProjectXmlAdapter.cpp:366`, `DeviceStateHydration.cpp:144`,
`PluginManager.cpp:580`, `PluginManagerSync.cpp:2164`, `:2347`, `:2584`.

Each is a rename: `hasPluginState()` is `pluginState.isNotEmpty()` and nothing else. The two
that read `isEmpty()` are negated, and I checked the surrounding condition at both rather than
inverting blind.

## Left alone

`stripDuplicateRuntimePluginState`, `scanEmbeddedDeviceIds`, `stripPresetRuntimePluginState` and
`readLegacyPads` take a bare `const juce::String& pluginState`. They are string helpers with no
device in scope, and handing them one to use the predicate would be the wrong direction.

No local build: this is a rename, and dev's post-merge CI had the macOS runner.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF
