### PR TITLE
Put a block through before the edit that ends a take

### DIFF
--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -349,18 +349,6 @@ class Rig {
         std::this_thread::sleep_for(how_long);
     }
 
-    /// Wait until @p recorder has taken something, for a case about what a
-    /// take gained across an edit: the callbacks are a thread, and a loaded
-    /// machine can let the edit land before any of them finished a block.
-    static bool waitUntilCapturing(const TakeRecorder& recorder) {
-        for (auto waited = 0; waited < 2000; ++waited) {
-            if (recorder.capturedSamples() > 0)
-                return true;
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-        return false;
-    }
-
     void stopCallbacks() {
         // Parking first, always: a callback stopped inside the device is a
         // callback that never returns to see the flag, and a case that failed
@@ -802,12 +790,13 @@ TEST_CASE("A callback inside the window between the plan and the takes it ended"
     auto& continuing = rig.startTakeOn(kOther);
     auto& parking = rig.parking();
 
+    // One callback on this thread, before the callbacks thread exists: both
+    // takes then have something in them by construction. A loaded machine can
+    // otherwise let the edit land before the first background block, and "the
+    // ended take gained nothing" is measured from a take that never had
+    // anything.
+    rig.run(kBlockSize);
     rig.runInBackground(true);
-
-    // Both takes are rolling before the edit, or "the ended one gained
-    // nothing" is measured from a take that never had anything.
-    REQUIRE(Rig::waitUntilCapturing(ended));
-    REQUIRE(Rig::waitUntilCapturing(continuing));
 
     // Read from inside the publish, with a callback parked: the plan is live
     // and the recording set is still the one from before the edit, which is

--- a/tests/engine/test_take_across_swap.cpp
+++ b/tests/engine/test_take_across_swap.cpp
@@ -349,6 +349,18 @@ class Rig {
         std::this_thread::sleep_for(how_long);
     }
 
+    /// Wait until @p recorder has taken something, for a case about what a
+    /// take gained across an edit: the callbacks are a thread, and a loaded
+    /// machine can let the edit land before any of them finished a block.
+    static bool waitUntilCapturing(const TakeRecorder& recorder) {
+        for (auto waited = 0; waited < 2000; ++waited) {
+            if (recorder.capturedSamples() > 0)
+                return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return false;
+    }
+
     void stopCallbacks() {
         // Parking first, always: a callback stopped inside the device is a
         // callback that never returns to see the flag, and a case that failed
@@ -791,6 +803,11 @@ TEST_CASE("A callback inside the window between the plan and the takes it ended"
     auto& parking = rig.parking();
 
     rig.runInBackground(true);
+
+    // Both takes are rolling before the edit, or "the ended one gained
+    // nothing" is measured from a take that never had anything.
+    REQUIRE(Rig::waitUntilCapturing(ended));
+    REQUIRE(Rig::waitUntilCapturing(continuing));
 
     // Read from inside the publish, with a callback parked: the plan is live
     // and the recording set is still the one from before the edit, which is


### PR DESCRIPTION
`A callback inside the window between the plan and the takes it ended` failed on the Windows runner
with `REQUIRE( endedBefore > 0 )` → `0 > 0`, on a shard that took 336s against ~100s for the next
slowest. Nothing in the product: the case asserts that the take the edit ended had been capturing
beforehand, and never made that true.

`runInBackground(true)` starts a thread delivering blocks and the publish follows immediately, so a
loaded machine can land the edit before any callback has finished one. "The ended take gained
nothing across the window" is then measured from a take that never had anything.

The rig already drives blocks synchronously (`run`), so one callback on the test's own thread
before the callbacks thread exists makes the precondition true by construction — no wait, no
timeout, nothing that can be slow in the wrong order. What the case is actually about, where the
publish lands between two background callbacks, is untouched.

Reproduced by delaying the callback thread's first block by 50ms: the case fails exactly as CI did
without the line, and passes with it.

`magda_tests` 3934 passed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN