### PR TITLE
Put an external plugin's parameters into the model on the native engine

### DIFF
--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -1,6 +1,7 @@
 #include "ExternalPluginState.hpp"
 
 #include <algorithm>
+#include <map>
 
 #include "../Vst3Preset.hpp"
 #include "core/ParameterUtils.hpp"
@@ -89,6 +90,59 @@ void applyVst3Records(DeviceInfo& device, const Vst3PresetRead& read) {
     device.vst3Preset = juce::Base64::toBase64(read.preset.getData(), read.preset.getSize());
 }
 
+/// The length the fork asks a plugin for its parameter names at.
+constexpr int kParameterNameLength = 1024;
+
+/// A record over [0, 1], which is the only shape an external plugin's
+/// parameters take: the fork wraps every one of them in that range whatever the
+/// plugin's own units are.
+ParameterInfo normalisedParameter(int index, const juce::String& name) {
+    ParameterInfo info;
+    info.paramIndex = index;
+    info.name = name;
+    info.minValue = 0.0f;
+    info.maxValue = 1.0f;
+    info.teMinValue = 0.0f;
+    info.teMaxValue = 1.0f;
+    return info;
+}
+
+/// The fork's name for @p parameter, de-duplication included: a repeated name
+/// gains a " (2)", and an unnamed one is numbered by its position in the
+/// plugin's own array. @p used counts the names seen before this one.
+juce::String hostParameterName(const juce::AudioProcessorParameter& parameter,
+                               std::map<juce::String, int>& used) {
+    const auto declared = parameter.getName(kParameterNameLength);
+    const auto seen = ++used[declared.isEmpty() ? juce::String("Unnamed") : declared];
+
+    if (declared.isEmpty())
+        return "Unnamed " + juce::String(parameter.getParameterIndex() + 1);
+
+    return seen > 1 ? declared + " (" + juce::String(seen) + ")" : declared;
+}
+
+/// The fork's id for @p parameter: the plugin's own where it declares one, and
+/// its index otherwise.
+juce::String hostParameterId(const juce::AudioProcessorParameter& parameter) {
+    if (const auto* withId = dynamic_cast<const juce::AudioProcessorParameterWithID*>(&parameter))
+        return withId->paramID;
+
+    return juce::String(parameter.getParameterIndex());
+}
+
+/// One of the wrapper pair, at the value @p device holds for it.
+ParameterInfo wrapperParameter(const DeviceInfo& device, int index, const juce::String& id,
+                               const juce::String& name, WrapperRole role, float defaultValue) {
+    auto info = normalisedParameter(index, name);
+    info.stableId = id;
+    info.wrapperRole = role;
+    info.defaultValue = defaultValue;
+
+    const auto* saved = modelParameterAt(device, index);
+    info.currentValue = saved != nullptr ? saved->currentValue : defaultValue;
+    return info;
+}
+
 }  // namespace
 
 std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
@@ -103,6 +157,32 @@ std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
             order.push_back(parameter);
 
     return order;
+}
+
+HostParameters describeHostParameters(const juce::AudioPluginInstance& instance,
+                                      const DeviceInfo& device) {
+    HostParameters described;
+
+    described.wrapperParameters = {
+        wrapperParameter(device, 0, "dry level", "Dry Level", WrapperRole::DryGain, 0.0f),
+        wrapperParameter(device, 1, "wet level", "Wet Level", WrapperRole::WetGain, 1.0f)};
+
+    const auto order = hostParameterOrder(instance);
+    std::map<juce::String, int> used;
+
+    for (int index = kWrapperParameterCount; index < static_cast<int>(order.size()); ++index) {
+        const auto* parameter = order[static_cast<std::size_t>(index)];
+        if (parameter == nullptr)
+            continue;
+
+        auto info = normalisedParameter(index, hostParameterName(*parameter, used));
+        info.stableId = hostParameterId(*parameter);
+        info.defaultValue = parameter->getDefaultValue();
+        info.currentValue = parameter->getValue();
+        described.parameters.push_back(std::move(info));
+    }
+
+    return described;
 }
 
 /** @brief Suspends a plugin's processing for the lifetime of this object. */

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
@@ -80,6 +80,32 @@ namespace magda {
 std::vector<juce::AudioProcessorParameter*> hostParameterOrder(
     const juce::AudioPluginInstance& instance);
 
+/** @brief A plugin's parameters, split the way DeviceInfo keeps them. */
+struct HostParameters {
+    std::vector<ParameterInfo> parameters;
+    std::vector<ParameterInfo> wrapperParameters;
+};
+
+/**
+ * @brief The model's record of every parameter @p instance exposes.
+ *
+ * The other half of hostParameterOrder(): that says which slot a saved value
+ * lands on, this says what the slot is. Only the instance can enumerate a
+ * hosted plugin's parameters, and everything that addresses one reads the model
+ * (#2595).
+ *
+ * Names, ids, ranges and defaults are the fork's
+ * (ExternalPlugin::buildParameterList), de-duplicating suffix included, so a
+ * project moved between engines finds the same parameter under the same name.
+ * The range is normalised because that is the space the fork wraps an external
+ * parameter in, and the plan converts through it (ParameterUtils::domainOf).
+ *
+ * The wrapper pair keeps the value @p device holds: it is the host's own
+ * number, no chunk carries it, and the model is the only place it lives.
+ */
+HostParameters describeHostParameters(const juce::AudioPluginInstance& instance,
+                                      const DeviceInfo& device);
+
 /** One parameter's live value, addressed the way a project addresses it. */
 struct RestoredParameter {
     int paramIndex = 0;

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -202,6 +202,13 @@ ExternalDeviceResult adaptExternalPluginInstance(
         resolvedDevice.canReceiveMidi = true;
     resolvedDevice.producesMidi = instance->producesMidi() || instance->isMidiEffect();
 
+    // After the chunk, which is free to rename a parameter or move its default.
+    // Nothing but the instance can enumerate a hosted plugin's parameters, and
+    // the model is what every reader downstream has (#2595).
+    auto described = magda::describeHostParameters(*instance, device);
+    resolvedDevice.parameters = std::move(described.parameters);
+    resolvedDevice.wrapperParameters = std::move(described.wrapperParameters);
+
     auto restored = magda::snapshotHostParameters(*instance);
 
     return {.device = std::make_unique<EngineExternalDevice>(std::move(instance), resolvedDevice,

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "core/ParameterInfo.hpp"
+#include "core/ParameterUtils.hpp"
 #include "exec/EngineDevice.hpp"
 #include "magda/daw/audio/Vst3Preset.hpp"
 #include "magda/daw/audio/plugin_manager/ExternalPluginLookup.hpp"
@@ -760,6 +761,25 @@ struct Block {
     juce::AudioBuffer<float> buffer;
     magda::engine::BlockInfo info;
 };
+
+/// The stub with the names real plugins turn out to have: two parameters called
+/// the same thing and one with no name at all.
+std::unique_ptr<StubPlugin> awkwardlyNamedStub() {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    plugin->addHostedParameter(std::make_unique<StubParameter>("cut1", "Cutoff", 0.0f, true));
+    plugin->addHostedParameter(std::make_unique<StubParameter>("cut2", "Cutoff", 0.0f, true));
+    plugin->addHostedParameter(std::make_unique<StubParameter>("blank", "", 0.0f, true));
+    return plugin;
+}
+
+/// The resolved record at plan slot @p index, from whichever bucket holds it.
+const magda::ParameterInfo* resolvedParameterAt(const adapter::ExternalDeviceResult& result,
+                                                int index) {
+    if (!result.resolvedDevice.has_value())
+        return nullptr;
+
+    return result.resolvedDevice->findParameterByIndex(index);
+}
 
 }  // namespace
 
@@ -1761,6 +1781,149 @@ TEST_CASE("A device with no saved state keeps the plugin's defaults", "[engine][
 
     REQUIRE(result.device != nullptr);
     CHECK(raw->stateRestores == 0);
+}
+
+TEST_CASE("An external plugin's parameters reach the model", "[engine][external]") {
+    // Nothing but the instance can enumerate them, and everything that
+    // addresses one reads the model: the plan's parameter table, a macro link,
+    // the slot's grid. A device published with an empty array is a plugin the
+    // host cannot see the inside of at all (#2595).
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    magda::DeviceInfo model;
+    model.name = "Stub";
+    model.format = magda::PluginFormat::VST3;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.resolvedDevice.has_value());
+
+    // The plugin's own, at the slots the fork's list puts them at, with the
+    // non-automatable one between them absent the way the fork drops it.
+    const auto& parameters = result.resolvedDevice->parameters;
+    REQUIRE(parameters.size() == 2);
+    CHECK(parameters[0].paramIndex == 2);
+    CHECK(parameters[0].name == "Gain");
+    CHECK(parameters[0].stableId == "gain");
+    CHECK(parameters[1].paramIndex == 3);
+    CHECK(parameters[1].name == "Tone");
+    CHECK(parameters[1].stableId == "tone");
+
+    // And the pair the plugin never declared, in the bucket the fork's split
+    // puts it in rather than among the plugin's own.
+    const auto& wrapper = result.resolvedDevice->wrapperParameters;
+    REQUIRE(wrapper.size() == 2);
+    CHECK(wrapper[0].paramIndex == 0);
+    CHECK(wrapper[0].wrapperRole == magda::WrapperRole::DryGain);
+    CHECK(wrapper[1].paramIndex == 1);
+    CHECK(wrapper[1].wrapperRole == magda::WrapperRole::WetGain);
+}
+
+TEST_CASE("Resolved parameters carry the range the plan converts through", "[engine][external]") {
+    // The plan resolves a slot in the parameter's own units and the adapter
+    // converts it back through this description. An external plugin's units are
+    // normalised, so a made-up range here would move every value the plan
+    // writes.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    magda::DeviceInfo model;
+    model.format = magda::PluginFormat::VST3;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    const auto* tone = resolvedParameterAt(result, 3);
+    REQUIRE(tone != nullptr);
+    CHECK(tone->minValue == Catch::Approx(0.0f));
+    CHECK(tone->maxValue == Catch::Approx(1.0f));
+    CHECK(tone->teMinValue == Catch::Approx(0.0f));
+    CHECK(tone->teMaxValue == Catch::Approx(1.0f));
+    CHECK(tone->scale == magda::ParameterScale::Linear);
+    CHECK(magda::ParameterUtils::realToNormalized(0.3f, *tone) == Catch::Approx(0.3f));
+
+    // The plugin's own default, not the struct's 0.5.
+    CHECK(tone->defaultValue == Catch::Approx(0.0f));
+}
+
+TEST_CASE("Resolved parameters describe the plugin after its chunk", "[engine][external]") {
+    // A patch is allowed to move a parameter, so a list read before the chunk
+    // describes a plugin that no longer exists. Everything downstream reads
+    // these values, and the plan writes them back every block.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    const StubPlugin::State chunkVoice{.tone = 0.9f, .fixed = 0.8f};
+    juce::MemoryBlock chunk(&chunkVoice, sizeof(chunkVoice));
+
+    auto model = externalDeviceSaving(1.0f, 0.25f);  // stale: the chunk says 0.9
+    model.pluginState = chunk.toBase64Encoding();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    const auto* tone = resolvedParameterAt(result, 3);
+    REQUIRE(tone != nullptr);
+    CHECK(tone->currentValue == Catch::Approx(0.9f));
+}
+
+TEST_CASE("The wrapper pair keeps the mix the model held", "[engine][external]") {
+    // Nothing on the plugin holds these: they are the host's own numbers and no
+    // chunk carries them, so rebuilding the list from the instance must not
+    // take a slot's mix back to fully wet.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    auto model = externalDevice();
+    model.wrapperParameters[0].currentValue = 0.3f;
+    model.wrapperParameters[1].currentValue = 0.7f;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    const auto* dry = resolvedParameterAt(result, 0);
+    const auto* wet = resolvedParameterAt(result, 1);
+    REQUIRE(dry != nullptr);
+    REQUIRE(wet != nullptr);
+    CHECK(dry->currentValue == Catch::Approx(0.3f));
+    CHECK(wet->currentValue == Catch::Approx(0.7f));
+
+    // The rest of the record is still the rebuilt one, ids included.
+    CHECK(dry->stableId == "dry level");
+    CHECK(wet->stableId == "wet level");
+}
+
+TEST_CASE("A device that never had a wrapper pair gets one fully wet", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+
+    magda::DeviceInfo model;
+    model.format = magda::PluginFormat::VST3;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+
+    const auto* dry = resolvedParameterAt(result, 0);
+    const auto* wet = resolvedParameterAt(result, 1);
+    REQUIRE(dry != nullptr);
+    REQUIRE(wet != nullptr);
+    CHECK(dry->currentValue == Catch::Approx(0.0f));
+    CHECK(wet->currentValue == Catch::Approx(1.0f));
+}
+
+TEST_CASE("Repeated and missing parameter names are the fork's", "[engine][external]") {
+    // A project moved between the engines has to find the same parameter under
+    // the same name, and plenty of plugins declare two called the same thing or
+    // none at all. The suffix and the numbering are
+    // ExternalPlugin::buildParameterList's.
+    const auto result =
+        adapter::adaptExternalPluginInstance(awkwardlyNamedStub(), externalDevice());
+    REQUIRE(result.resolvedDevice.has_value());
+
+    const auto* first = resolvedParameterAt(result, 4);
+    const auto* second = resolvedParameterAt(result, 5);
+    const auto* unnamed = resolvedParameterAt(result, 6);
+    REQUIRE(first != nullptr);
+    REQUIRE(second != nullptr);
+    REQUIRE(unnamed != nullptr);
+
+    CHECK(first->name == "Cutoff");
+    CHECK(second->name == "Cutoff (2)");
+
+    // Numbered by its place in the plugin's own array, which counts the
+    // non-automatable parameter the host's list skips.
+    CHECK(unnamed->name == "Unnamed 6");
 }
 
 TEST_CASE("Successful adaptation reports live buses and MIDI capabilities", "[engine][external]") {


### PR DESCRIPTION
Closes #2595.

Under `MAGDA_AUDIO_ENGINE=magda` a hosted plugin's slot drew a grid of `--`.
`adaptExternalPluginInstance` resolved the instance's bus widths, MIDI
capabilities and spent `vst3Preset` into `resolvedDevice` but never its
parameters, and `applyRestoredParameters` only writes values onto entries that
already exist. An empty array is a plugin with no slot in the plan's parameter
table, nothing for a macro, mod or automation lane to address, and nothing the
parameter config dialog or MIDI learn can pick.

## What it does

`describeHostParameters()` reads the list off the instance. It lives beside
`hostParameterOrder()`, which already owns the slot numbering, so one file
defines both which slot a saved value lands on and what that slot is.

- **Identity is the fork's.** Names, ids, ranges and defaults come out the way
  `ExternalPlugin::buildParameterList` produces them, de-duplicating suffix
  (`Cutoff`, `Cutoff (2)`) and `Unnamed <n>` fallback included, so a project
  moved between the engines finds the same parameter under the same name.
  `stableId` is the plugin's own `paramID` where it declares one.
- **The range is normalised**, because that is the space the fork wraps an
  external parameter in and the plan converts through it
  (`ParameterUtils::domainOf`); a made-up range would move every value the plan
  writes.
- **Published after the chunk**, which is free to rename a parameter or move its
  default — the same reason the bus widths are read there.
- **The wrapper pair stays in `wrapperParameters`** at slots 0 and 1 with the
  `DryGain`/`WetGain` roles, keeping whatever value the model held: it is the
  host's own number and no chunk carries it. #2327 is what replaces the pair
  with one Mix.

## Tests

Six cases in `tests/engine/test_engine_external_device.cpp`, all of which fail
with the three-line publish removed: the parameters and the wrapper pair reach
`resolvedDevice`, the non-automatable parameter is dropped the way the fork
drops it, the range and defaults are the instance's, values describe the plugin
after its chunk rather than before, a slot with no saved mix comes back fully
wet, and repeated/missing names get the fork's treatment.

`make test` (3942 passed, 13 skipped) and `make test-juce` green, corpus
included. `make lint-changed` reports nothing new.

## Known gap, not in this change

The fork gives each external parameter a live `displayText` provider that goes
through `AudioBridge` -> `DeviceProcessor`, which is the TE path; the native
engine has no equivalent, so a parameter's cell formats from its range
("0.50") rather than asking the plugin ("500 Hz"). The grid and every addressing
path work; only the value text is poorer. Filed as #2600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
