### PR TITLE
Translate 4OSC patches to Poly Synth and offer the project migration

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -465,6 +465,7 @@ target_sources(magda_daw PRIVATE
     DeviceParameterDisplayTextProvider.cpp
     DeviceParameterDisplayTextProvider.hpp
     ClipCommands.cpp
+    FourOscMigration.cpp
     FourOscTranslation.cpp
     TrackMeasurementManager.cpp
     AudioBridgeMixer.cpp

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -465,6 +465,7 @@ target_sources(magda_daw PRIVATE
     DeviceParameterDisplayTextProvider.cpp
     DeviceParameterDisplayTextProvider.hpp
     ClipCommands.cpp
+    FourOscTranslation.cpp
     TrackMeasurementManager.cpp
     AudioBridgeMixer.cpp
     AudioBridgeMixer.hpp

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -114,10 +114,15 @@ juce::File convertedProjectFileFor(const juce::File& project) {
     if (!projects.isDirectory())
         return {};
 
-    const auto name = project.getFileNameWithoutExtension() + " (Poly Synth)";
-    const auto folder = projects.getChildFile(name).getNonexistentSibling();
+    // Unwrapped, and deliberately: saveProjectAs() builds the folder itself,
+    // and only when the file is not already sitting in one of its own name.
+    // Handing it the wrapped path meant it created nothing and wrote into a
+    // directory that was not there.
+    const auto folder =
+        projects.getChildFile(project.getFileNameWithoutExtension() + " (Poly Synth)")
+            .getNonexistentSibling();
 
-    return folder.getChildFile(folder.getFileName() + project.getFileExtension());
+    return projects.getChildFile(folder.getFileName() + project.getFileExtension());
 }
 
 juce::String describeConversion(const std::vector<FourOscCandidate>& candidates) {

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -2,7 +2,9 @@
 
 #include <set>
 
+#include "../core/AutomationManager.hpp"
 #include "../core/ChainWalk.hpp"
+#include "../core/DeviceParamMigrations.hpp"
 #include "../core/TrackInfo.hpp"
 #include "../core/TrackManager.hpp"
 
@@ -42,16 +44,23 @@ std::vector<juce::String> distinctGaps(const std::vector<FourOscCandidate>& cand
  *
  * The rack of effects goes in directly after the synth it came from, so it
  * reaches the same signal 4OSC's own effects did.
+ *
+ * @p replaced collects the path of every device converted, which is what the
+ * links and lanes still addressing 4OSC's parameters are found by.
  */
-int convertIn(std::vector<ChainElement>& elements, TrackManager& tracks) {
+int convertIn(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
+              TrackManager& tracks, std::set<ChainNodePath>& replaced) {
     auto converted = 0;
 
     for (auto index = 0; index < static_cast<int>(elements.size()); ++index) {
         auto& element = elements[static_cast<std::size_t>(index)];
 
         if (isRack(element)) {
-            for (auto& chain : getRack(element).chains)
-                converted += convertIn(chain.elements, tracks);
+            auto& rack = getRack(element);
+            const auto rackPath = chain_walk::rackIn(parentPath, rack.id);
+            for (auto& chain : rack.chains)
+                converted +=
+                    convertIn(chain.elements, rackPath.withChain(chain.id), tracks, replaced);
 
             continue;
         }
@@ -60,10 +69,13 @@ int convertIn(std::vector<ChainElement>& elements, TrackManager& tracks) {
             continue;
 
         auto& device = getDevice(element);
+        const auto devicePath = chain_walk::deviceIn(parentPath, device.id);
 
         if (device.pads)
             for (auto& pad : device.pads->chains)
-                converted += convertIn(pad.elements, tracks);
+                converted += convertIn(
+                    pad.elements, ChainNodePath::padChain(parentPath.trackId, device.id, pad.id),
+                    tracks, replaced);
 
         if (!isFourOscDevice(device))
             continue;
@@ -71,6 +83,7 @@ int convertIn(std::vector<ChainElement>& elements, TrackManager& tracks) {
         auto translated = translateFourOsc(device, [&tracks] { return tracks.allocateDeviceId(); });
         device = std::move(translated.device);
         ++converted;
+        replaced.insert(devicePath);
 
         if (translated.effects == nullptr)
             continue;
@@ -154,15 +167,32 @@ juce::String describeMigration(const std::vector<FourOscCandidate>& candidates) 
 
 int convertFourOscDevices(TrackManager& tracks) {
     auto converted = 0;
+    std::set<ChainNodePath> replaced;
 
-    tracks.forEachTrackIncludingMaster([&tracks, &converted](TrackInfo& track) {
-        const auto onThisTrack = convertIn(track.chain.fxChainElements, tracks);
+    tracks.forEachTrackIncludingMaster([&tracks, &converted, &replaced](TrackInfo& track) {
+        const auto onThisTrack = convertIn(track.chain.fxChainElements,
+                                           ChainNodePath::trackLevel(track.id), tracks, replaced);
         if (onThisTrack == 0)
             return;
 
         converted += onThisTrack;
         tracks.notifyTrackDevicesChanged(track.id);
     });
+
+    if (replaced.empty())
+        return converted;
+
+    // Poly Synth's parameters are different controls in different units at the
+    // same indices, and the path a link names still resolves. A macro left
+    // pointing at 4OSC's Tune 1 would drive Poly Synth's Osc 1 Wave.
+    tracks.forEachTrackIncludingMaster([&replaced](TrackInfo& track) {
+        device_param_migrations::dropParamLinksInTrack(track, replaced);
+    });
+
+    auto& automation = AutomationManager::getInstance();
+    for (const auto lane :
+         device_param_migrations::lanesAddressing(automation.getLanes(), replaced))
+        automation.deleteLane(lane);
 
     return converted;
 }

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -7,6 +7,8 @@
 #include "../core/DeviceParamMigrations.hpp"
 #include "../core/TrackInfo.hpp"
 #include "../core/TrackManager.hpp"
+#include "../core/aliases/AliasRegistry.hpp"
+#include "../core/controllers/BindingRegistry.hpp"
 
 namespace magda::daw::audio {
 
@@ -96,6 +98,30 @@ int convertIn(std::vector<ChainElement>& elements, const ChainNodePath& parentPa
     }
 
     return converted;
+}
+
+/**
+ * @brief Forget every controller binding and alias naming a 4OSC parameter on
+ * @p paths.
+ *
+ * Both store a concrete path and index, and the path still resolves after the
+ * replacement, so what they addressed on 4OSC they would address on Poly
+ * Synth. Bindings go first: one of them can reach its target through an alias.
+ */
+void forgetExplicitReferences(const std::set<ChainNodePath>& paths) {
+    auto& bindings = BindingRegistry::getInstance();
+    auto& aliases = AliasRegistry::getInstance();
+
+    for (const auto& path : paths)
+        for (auto index = 0; index < fourOscParameterCount(); ++index) {
+            bindings.removeFor(ControlTarget::pluginParam(path, index));
+
+            for (const auto& match : aliases.findByPath(path, index, /*autoGenOnly=*/false))
+                // Curated is shipped and read-only, and carries no concrete
+                // path to have matched on.
+                if (match.layer != AliasLayer::Curated)
+                    aliases.clear(match.layer, match.canonicalName);
+        }
 }
 
 }  // namespace
@@ -193,6 +219,8 @@ int convertFourOscDevices(TrackManager& tracks) {
     for (const auto lane :
          device_param_migrations::lanesAddressing(automation.getLanes(), replaced))
         automation.deleteLane(lane);
+
+    forgetExplicitReferences(replaced);
 
     return converted;
 }

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -53,6 +53,7 @@ std::vector<juce::String> distinctGaps(const std::vector<FourOscCandidate>& cand
 int convertIn(std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
               TrackManager& tracks, std::set<ChainNodePath>& replaced) {
     auto converted = 0;
+    const auto nextEffectId = [&tracks] { return tracks.allocateDeviceId(); };
 
     for (auto index = 0; index < static_cast<int>(elements.size()); ++index) {
         auto& element = elements[static_cast<std::size_t>(index)];
@@ -82,7 +83,7 @@ int convertIn(std::vector<ChainElement>& elements, const ChainNodePath& parentPa
         if (!isFourOscDevice(device))
             continue;
 
-        auto translated = translateFourOsc(device, [&tracks] { return tracks.allocateDeviceId(); });
+        auto translated = translateFourOsc(device, nextEffectId);
         device = std::move(translated.device);
         ++converted;
         replaced.insert(devicePath);
@@ -195,7 +196,7 @@ int convertFourOscDevices(TrackManager& tracks) {
     auto converted = 0;
     std::set<ChainNodePath> replaced;
 
-    tracks.forEachTrackIncludingMaster([&tracks, &converted, &replaced](TrackInfo& track) {
+    const auto convertTrack = [&tracks, &converted, &replaced](TrackInfo& track) {
         const auto onThisTrack = convertIn(track.chain.fxChainElements,
                                            ChainNodePath::trackLevel(track.id), tracks, replaced);
         if (onThisTrack == 0)
@@ -203,7 +204,9 @@ int convertFourOscDevices(TrackManager& tracks) {
 
         converted += onThisTrack;
         tracks.notifyTrackDevicesChanged(track.id);
-    });
+    };
+
+    tracks.forEachTrackIncludingMaster(convertTrack);
 
     if (replaced.empty())
         return converted;
@@ -211,9 +214,11 @@ int convertFourOscDevices(TrackManager& tracks) {
     // Poly Synth's parameters are different controls in different units at the
     // same indices, and the path a link names still resolves. A macro left
     // pointing at 4OSC's Tune 1 would drive Poly Synth's Osc 1 Wave.
-    tracks.forEachTrackIncludingMaster([&replaced](TrackInfo& track) {
+    const auto dropStaleLinks = [&replaced](TrackInfo& track) {
         device_param_migrations::dropParamLinksInTrack(track, replaced);
-    });
+    };
+
+    tracks.forEachTrackIncludingMaster(dropStaleLinks);
 
     auto& automation = AutomationManager::getInstance();
     for (const auto lane :

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -187,7 +187,7 @@ juce::File convertedProjectFileFor(const juce::File& project) {
     // Handing it the wrapped path meant it created nothing and wrote into a
     // directory that was not there.
     const auto folder =
-        projects.getChildFile(project.getFileNameWithoutExtension() + " (magda engine)")
+        projects.getChildFile(project.getFileNameWithoutExtension() + " (MAGDA Engine)")
             .getNonexistentSibling();
 
     return projects.getChildFile(folder.getFileName() + project.getFileExtension());
@@ -195,15 +195,12 @@ juce::File convertedProjectFileFor(const juce::File& project) {
 
 juce::String describeMigration(const std::vector<FourOscCandidate>& candidates) {
     juce::String text =
-        "This project was made with the Tracktion engine. MAGDA's engine does not render every "
-        "device the same way, so it opens as a copy and the original is left alone.";
+        "This project was made with Tracktion Engine. MAGDA Engine does not render every device "
+        "the same way, so it opens as a copy and the original is left alone.";
 
     if (!candidates.empty()) {
-        const auto count = static_cast<int>(candidates.size());
-        text += count == 1 ? " Its 4OSC becomes a Poly Synth"
-                           : " Its " + juce::String(count) + " 4OSC devices become Poly Synths";
-        text += ", carrying the oscillators, the filter, both envelopes, the voice settings and "
-                "the built-in effects.";
+        text += " Any 4OSC in it becomes a Poly Synth, carrying the oscillators, the filter, "
+                "both envelopes, the voice settings and the built-in effects.";
 
         const auto gaps = distinctGaps(candidates);
         if (!gaps.empty()) {

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -131,9 +131,25 @@ void forgetExplicitReferences(const std::set<ChainNodePath>& paths) {
             for (const auto& binding : bindings.findFor(target))
                 bindings.remove(BindingScope::Project, binding.id);
 
-            for (const auto& match : aliases.findByPath(path, index, /*autoGenOnly=*/false))
-                if (isProjectLocal(match.layer))
+            for (const auto& match : aliases.findByPath(path, index, /*autoGenOnly=*/false)) {
+                if (isProjectLocal(match.layer)) {
                     aliases.clear(match.layer, match.canonicalName);
+                    continue;
+                }
+
+                if (match.layer != AliasLayer::UserGlobal)
+                    continue;
+
+                // The user's own alias, shared with every project: the name and
+                // the plugin it names survive and only the path into this one
+                // goes. A stored alias with no path is materialised at
+                // resolution time against a device of its own plugin type
+                // (AliasRegistry.hpp), so it stops answering for this device
+                // without being taken from anybody.
+                auto detached = match.alias;
+                detached.path.reset();
+                aliases.set(match.layer, match.canonicalName, detached);
+            }
         }
 }
 

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -104,18 +104,20 @@ std::vector<FourOscCandidate> findFourOscDevices(const std::vector<TrackInfo>& t
     return found;
 }
 
-juce::File backupFileFor(const juce::File& project) {
+juce::File convertedProjectFileFor(const juce::File& project) {
     if (project == juce::File{})
         return {};
 
-    // A sibling rather than a hidden file: this is the copy the user goes back
-    // to if the conversion was not what they wanted, so it belongs where they
-    // keep their projects. Nonexistent, so converting twice does not overwrite
-    // the first copy.
-    return project
-        .getSiblingFile(project.getFileNameWithoutExtension() + " (4OSC)" +
-                        project.getFileExtension())
-        .getNonexistentSibling();
+    // Up out of the project's own folder, so the new one is its neighbour
+    // rather than a stray .mgd inside it.
+    const auto projects = project.getParentDirectory().getParentDirectory();
+    if (!projects.isDirectory())
+        return {};
+
+    const auto name = project.getFileNameWithoutExtension() + " (Poly Synth)";
+    const auto folder = projects.getChildFile(name).getNonexistentSibling();
+
+    return folder.getChildFile(folder.getFileName() + project.getFileExtension());
 }
 
 juce::String describeConversion(const std::vector<FourOscCandidate>& candidates) {
@@ -143,8 +145,8 @@ juce::String describeConversion(const std::vector<FourOscCandidate>& candidates)
         text += ".";
     }
 
-    text += " Your project is saved as a new file first. The converted one cannot be turned "
-            "back into a 4OSC project.";
+    text += " The converted project is saved alongside this one as a new project. This one "
+            "is left as it is.";
 
     return text;
 }

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -101,13 +101,24 @@ int convertIn(std::vector<ChainElement>& elements, const ChainNodePath& parentPa
     return converted;
 }
 
+/// The alias layers a project owns. UserGlobal is the user's own config and
+/// Curated is shipped: a conversion makes a copy of one project and has no
+/// business editing either.
+bool isProjectLocal(AliasLayer layer) {
+    return layer == AliasLayer::UserProject || layer == AliasLayer::AutoGen;
+}
+
 /**
- * @brief Forget every controller binding and alias naming a 4OSC parameter on
- * @p paths.
+ * @brief Forget every project-local controller binding and alias naming a 4OSC
+ * parameter on @p paths.
  *
  * Both store a concrete path and index, and the path still resolves after the
  * replacement, so what they addressed on 4OSC they would address on Poly
  * Synth. Bindings go first: one of them can reach its target through an alias.
+ *
+ * Project scope only. A global binding or a UserGlobal alias belongs to the
+ * user across every project, including the one this copy was made from, and
+ * removing it here would take it from all of them.
  */
 void forgetExplicitReferences(const std::set<ChainNodePath>& paths) {
     auto& bindings = BindingRegistry::getInstance();
@@ -115,12 +126,13 @@ void forgetExplicitReferences(const std::set<ChainNodePath>& paths) {
 
     for (const auto& path : paths)
         for (auto index = 0; index < fourOscParameterCount(); ++index) {
-            bindings.removeFor(ControlTarget::pluginParam(path, index));
+            const auto target = ControlTarget::pluginParam(path, index);
+
+            for (const auto& binding : bindings.findFor(target))
+                bindings.remove(BindingScope::Project, binding.id);
 
             for (const auto& match : aliases.findByPath(path, index, /*autoGenOnly=*/false))
-                // Curated is shipped and read-only, and carries no concrete
-                // path to have matched on.
-                if (match.layer != AliasLayer::Curated)
+                if (isProjectLocal(match.layer))
                     aliases.clear(match.layer, match.canonicalName);
         }
 }

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -16,15 +16,15 @@ namespace {
 
 void collectFrom(const std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
                  std::vector<FourOscCandidate>& found) {
-    chain_walk::forEachDevice(elements, parentPath, chain_walk::Pads::Enter,
-                              [&found](const DeviceInfo& device, const ChainNodePath& path) {
-                                  if (!isFourOscDevice(device))
-                                      return;
+    const auto collectFourOsc = [&found](const DeviceInfo& device, const ChainNodePath& path) {
+        if (!isFourOscDevice(device))
+            return;
 
-                                  found.push_back({.path = path,
-                                                   .deviceName = device.name,
-                                                   .gaps = translateFourOsc(device).gaps});
-                              });
+        found.push_back(
+            {.path = path, .deviceName = device.name, .gaps = translateFourOsc(device).gaps});
+    };
+
+    chain_walk::forEachDevice(elements, parentPath, chain_walk::Pads::Enter, collectFourOsc);
 }
 
 /// The gap reasons across every device, said once each. Four oscillators on

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -1,0 +1,102 @@
+#include "FourOscMigration.hpp"
+
+#include <set>
+
+#include "../core/ChainWalk.hpp"
+#include "../core/TrackInfo.hpp"
+
+namespace magda::daw::audio {
+
+namespace {
+
+void collectFrom(const std::vector<ChainElement>& elements, const ChainNodePath& parentPath,
+                 std::vector<FourOscCandidate>& found) {
+    chain_walk::forEachDevice(elements, parentPath, chain_walk::Pads::Enter,
+                              [&found](const DeviceInfo& device, const ChainNodePath& path) {
+                                  if (!isFourOscDevice(device))
+                                      return;
+
+                                  found.push_back({.path = path,
+                                                   .deviceName = device.name,
+                                                   .gaps = translateFourOsc(device).gaps});
+                              });
+}
+
+/// The gap reasons across every device, said once each. Four oscillators on
+/// three devices all losing unison is one thing to tell someone, not twelve.
+std::vector<juce::String> distinctGaps(const std::vector<FourOscCandidate>& candidates) {
+    std::vector<juce::String> ordered;
+    std::set<juce::String> seen;
+
+    for (const auto& candidate : candidates)
+        for (const auto& gap : candidate.gaps)
+            if (seen.insert(gap.control).second)
+                ordered.push_back(gap.control);
+
+    return ordered;
+}
+
+}  // namespace
+
+std::vector<FourOscCandidate> findFourOscDevices(const std::vector<TrackInfo>& tracks,
+                                                 const TrackInfo& master) {
+    std::vector<FourOscCandidate> found;
+
+    const auto collectTrack = [&found](const TrackInfo& track) {
+        const auto path = ChainNodePath::trackLevel(track.id);
+        collectFrom(track.chain.fxChainElements, path, found);
+    };
+
+    for (const auto& track : tracks)
+        collectTrack(track);
+
+    collectTrack(master);
+
+    return found;
+}
+
+juce::File backupFileFor(const juce::File& project) {
+    if (project == juce::File{})
+        return {};
+
+    // A sibling rather than a hidden file: this is the copy the user goes back
+    // to if the conversion was not what they wanted, so it belongs where they
+    // keep their projects. Nonexistent, so converting twice does not overwrite
+    // the first copy.
+    return project
+        .getSiblingFile(project.getFileNameWithoutExtension() + " (4OSC)" +
+                        project.getFileExtension())
+        .getNonexistentSibling();
+}
+
+juce::String describeConversion(const std::vector<FourOscCandidate>& candidates) {
+    if (candidates.empty())
+        return {};
+
+    const auto count = static_cast<int>(candidates.size());
+    juce::String text = count == 1 ? "This project uses 4OSC, which the MAGDA engine does not have."
+                                   : "This project uses 4OSC on " + juce::String(count) +
+                                         " devices, and the MAGDA engine does not have it.";
+
+    text += " It can be converted to Poly Synth, which carries the oscillators, the filter, both "
+            "envelopes and the voice settings.";
+
+    const auto gaps = distinctGaps(candidates);
+    if (gaps.empty()) {
+        text += " Everything this patch uses has somewhere to go.";
+    } else {
+        // Named rather than summarised. "Some settings will be lost" tells
+        // somebody to expect a difference without telling them what to listen
+        // for.
+        text += " These have no equivalent and will be lost: ";
+        for (auto index = 0; index < static_cast<int>(gaps.size()); ++index)
+            text += (index > 0 ? ", " : "") + gaps[static_cast<std::size_t>(index)];
+        text += ".";
+    }
+
+    text += " The project as it is now is saved alongside first, so nothing is overwritten.";
+
+    return text;
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -4,6 +4,7 @@
 
 #include "../core/ChainWalk.hpp"
 #include "../core/TrackInfo.hpp"
+#include "../core/TrackManager.hpp"
 
 namespace magda::daw::audio {
 
@@ -34,6 +35,54 @@ std::vector<juce::String> distinctGaps(const std::vector<FourOscCandidate>& cand
                 ordered.push_back(gap.control);
 
     return ordered;
+}
+
+/**
+ * @brief Replace every 4OSC in @p elements, and in any rack or pad under it.
+ *
+ * The rack of effects goes in directly after the synth it came from, so it
+ * reaches the same signal 4OSC's own effects did.
+ */
+int convertIn(std::vector<ChainElement>& elements, TrackManager& tracks) {
+    auto converted = 0;
+
+    for (auto index = 0; index < static_cast<int>(elements.size()); ++index) {
+        auto& element = elements[static_cast<std::size_t>(index)];
+
+        if (isRack(element)) {
+            for (auto& chain : getRack(element).chains)
+                converted += convertIn(chain.elements, tracks);
+
+            continue;
+        }
+
+        if (!isDevice(element))
+            continue;
+
+        auto& device = getDevice(element);
+
+        if (device.pads)
+            for (auto& pad : device.pads->chains)
+                converted += convertIn(pad.elements, tracks);
+
+        if (!isFourOscDevice(device))
+            continue;
+
+        auto translated = translateFourOsc(device, [&tracks] { return tracks.allocateDeviceId(); });
+        device = std::move(translated.device);
+        ++converted;
+
+        if (translated.effects == nullptr)
+            continue;
+
+        translated.effects->id = tracks.allocateRackId();
+        translated.effects->chains.front().id = tracks.allocateChainId();
+
+        elements.insert(elements.begin() + index + 1, ChainElement{std::move(translated.effects)});
+        ++index;
+    }
+
+    return converted;
 }
 
 }  // namespace
@@ -94,9 +143,25 @@ juce::String describeConversion(const std::vector<FourOscCandidate>& candidates)
         text += ".";
     }
 
-    text += " The project as it is now is saved alongside first, so nothing is overwritten.";
+    text += " Your project is saved as a new file first. The converted one cannot be turned "
+            "back into a 4OSC project.";
 
     return text;
+}
+
+int convertFourOscDevices(TrackManager& tracks) {
+    auto converted = 0;
+
+    tracks.forEachTrackIncludingMaster([&tracks, &converted](TrackInfo& track) {
+        const auto onThisTrack = convertIn(track.chain.fxChainElements, tracks);
+        if (onThisTrack == 0)
+            return;
+
+        converted += onThisTrack;
+        tracks.notifyTrackDevicesChanged(track.id);
+    });
+
+    return converted;
 }
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/FourOscMigration.cpp
+++ b/magda/daw/audio/FourOscMigration.cpp
@@ -119,39 +119,35 @@ juce::File convertedProjectFileFor(const juce::File& project) {
     // Handing it the wrapped path meant it created nothing and wrote into a
     // directory that was not there.
     const auto folder =
-        projects.getChildFile(project.getFileNameWithoutExtension() + " (Poly Synth)")
+        projects.getChildFile(project.getFileNameWithoutExtension() + " (magda engine)")
             .getNonexistentSibling();
 
     return projects.getChildFile(folder.getFileName() + project.getFileExtension());
 }
 
-juce::String describeConversion(const std::vector<FourOscCandidate>& candidates) {
-    if (candidates.empty())
-        return {};
+juce::String describeMigration(const std::vector<FourOscCandidate>& candidates) {
+    juce::String text =
+        "This project was made with the Tracktion engine. MAGDA's engine does not render every "
+        "device the same way, so it opens as a copy and the original is left alone.";
 
-    const auto count = static_cast<int>(candidates.size());
-    juce::String text = count == 1 ? "This project uses 4OSC, which the MAGDA engine does not have."
-                                   : "This project uses 4OSC on " + juce::String(count) +
-                                         " devices, and the MAGDA engine does not have it.";
+    if (!candidates.empty()) {
+        const auto count = static_cast<int>(candidates.size());
+        text += count == 1 ? " Its 4OSC becomes a Poly Synth"
+                           : " Its " + juce::String(count) + " 4OSC devices become Poly Synths";
+        text += ", carrying the oscillators, the filter, both envelopes, the voice settings and "
+                "the built-in effects.";
 
-    text += " It can be converted to Poly Synth, which carries the oscillators, the filter, both "
-            "envelopes and the voice settings.";
-
-    const auto gaps = distinctGaps(candidates);
-    if (gaps.empty()) {
-        text += " Everything this patch uses has somewhere to go.";
-    } else {
-        // Named rather than summarised. "Some settings will be lost" tells
-        // somebody to expect a difference without telling them what to listen
-        // for.
-        text += " These have no equivalent and will be lost: ";
-        for (auto index = 0; index < static_cast<int>(gaps.size()); ++index)
-            text += (index > 0 ? ", " : "") + gaps[static_cast<std::size_t>(index)];
-        text += ".";
+        const auto gaps = distinctGaps(candidates);
+        if (!gaps.empty()) {
+            // Named rather than summarised. "Some settings may change" tells
+            // somebody to expect a difference without telling them what to
+            // listen for.
+            text += " These have no equivalent and will be lost: ";
+            for (auto index = 0; index < static_cast<int>(gaps.size()); ++index)
+                text += (index > 0 ? ", " : "") + gaps[static_cast<std::size_t>(index)];
+            text += ".";
+        }
     }
-
-    text += " The converted project is saved alongside this one as a new project. This one "
-            "is left as it is.";
 
     return text;
 }

--- a/magda/daw/audio/FourOscMigration.hpp
+++ b/magda/daw/audio/FourOscMigration.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vector>
+
+#include "FourOscTranslation.hpp"
+
+namespace magda {
+class TrackInfo;
+}
+
+/**
+ * @file FourOscMigration.hpp
+ * @brief Converting a whole project's 4OSC devices at once (#2437).
+ *
+ * The translation itself is FourOscTranslation.hpp. This is the project-level
+ * half: what to ask about, and what the answer changes.
+ */
+
+namespace magda::daw::audio {
+
+/** @brief One device the project would convert. */
+struct FourOscCandidate {
+    ChainNodePath path;
+    juce::String deviceName;
+    std::vector<FourOscGap> gaps;
+};
+
+/// Every 4OSC in @p tracks, with what each one would lose. Empty means there
+/// is nothing to ask about.
+std::vector<FourOscCandidate> findFourOscDevices(const std::vector<TrackInfo>& tracks,
+                                                 const TrackInfo& master);
+
+/// Where the pre-conversion project is written, beside @p project. A project
+/// that has never been saved has no file and gets no copy.
+juce::File backupFileFor(const juce::File& project);
+
+/// What the dialog says, built from @p candidates. Names the gaps when there
+/// are any and promises nothing when there are not.
+juce::String describeConversion(const std::vector<FourOscCandidate>& candidates);
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/FourOscMigration.hpp
+++ b/magda/daw/audio/FourOscMigration.hpp
@@ -41,9 +41,10 @@ std::vector<FourOscCandidate> findFourOscDevices(const std::vector<TrackInfo>& t
  */
 juce::File convertedProjectFileFor(const juce::File& project);
 
-/// What the dialog says, built from @p candidates. Names the gaps when there
-/// are any and promises nothing when there are not.
-juce::String describeConversion(const std::vector<FourOscCandidate>& candidates);
+/// What the dialog says. @p candidates may be empty: a project with no 4OSC
+/// in it is still worth copying, because the engines do not render every
+/// device identically.
+juce::String describeMigration(const std::vector<FourOscCandidate>& candidates);
 
 /**
  * @brief Convert every 4OSC in the project, in place.

--- a/magda/daw/audio/FourOscMigration.hpp
+++ b/magda/daw/audio/FourOscMigration.hpp
@@ -5,8 +5,9 @@
 #include "FourOscTranslation.hpp"
 
 namespace magda {
-class TrackInfo;
-}
+struct TrackInfo;
+class TrackManager;
+}  // namespace magda
 
 /**
  * @file FourOscMigration.hpp
@@ -37,5 +38,14 @@ juce::File backupFileFor(const juce::File& project);
 /// What the dialog says, built from @p candidates. Names the gaps when there
 /// are any and promises nothing when there are not.
 juce::String describeConversion(const std::vector<FourOscCandidate>& candidates);
+
+/**
+ * @brief Convert every 4OSC in the project, in place.
+ *
+ * Write @ref backupFileFor first: this does not keep the old devices.
+ *
+ * @return how many devices changed. Message thread.
+ */
+int convertFourOscDevices(TrackManager& tracks);
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/FourOscMigration.hpp
+++ b/magda/daw/audio/FourOscMigration.hpp
@@ -31,9 +31,15 @@ struct FourOscCandidate {
 std::vector<FourOscCandidate> findFourOscDevices(const std::vector<TrackInfo>& tracks,
                                                  const TrackInfo& master);
 
-/// Where the pre-conversion project is written, beside @p project. A project
-/// that has never been saved has no file and gets no copy.
-juce::File backupFileFor(const juce::File& project);
+/**
+ * @brief Where the converted project is saved, as a new project beside the old.
+ *
+ * A MAGDA project is a folder holding its .mgd and its media, so this names a
+ * sibling of that folder rather than a file inside it. Pass the result to
+ * ProjectManager::saveProjectAs(), which builds the folder. Nothing for a
+ * project that has never been saved and so has nowhere to sit beside.
+ */
+juce::File convertedProjectFileFor(const juce::File& project);
 
 /// What the dialog says, built from @p candidates. Names the gaps when there
 /// are any and promises nothing when there are not.

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -24,6 +24,11 @@ using PolySynth = compiled::MagdaPolySynthCompiledPlugin;
 /// 4OSC's own wave numbering (FourOscPlugin.h).
 enum class FourOscWave { none, sine, triangle, sawUp, sawDown, square, random };
 
+/// The rack fader's own range (RackComponent.cpp), which is what the gains
+/// moved onto it have to fit in.
+constexpr float kRackFaderMinDb = -60.0f;
+constexpr float kRackFaderMaxDb = 6.0f;
+
 /// Poly Synth's, which is a different order and a shorter list.
 constexpr int kPolySine = 0;
 constexpr int kPolySaw = 1;
@@ -596,10 +601,27 @@ FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
     if (nextEffectId)
         translated.effects = buildEffects(fourOsc, props, nextEffectId);
 
-    // 4OSC's master level is the synth's own output, not an effect.
     const auto master = parameterValue(fourOsc, props, "masterLevel");
-    setSlot(translated.device, PolySynth::kOutputGainSlot,
-            clampToSlot(translated.device, PolySynth::kOutputGainSlot, master));
+
+    if (translated.effects == nullptr) {
+        // Nothing between the synth and the slot's output, so the master level
+        // is the synth's own output gain.
+        setSlot(translated.device, PolySynth::kOutputGainSlot,
+                clampToSlot(translated.device, PolySynth::kOutputGainSlot, master));
+
+        return translated;
+    }
+
+    // 4OSC runs its effects BEFORE its master level, and the slot's own trim
+    // follows the whole plugin (FourOscPlugin::applyEffects). Split across two
+    // slots, both of those now sit in front of the rack, where a gain is a
+    // different distortion drive and a different delay and reverb balance.
+    // The rack's fader is where they land: it is the one control in the
+    // translation that is downstream of all four effects.
+    translated.effects->volume =
+        std::clamp(master + translated.device.gainDb, kRackFaderMinDb, kRackFaderMaxDb);
+    translated.device.gainDb = 0.0f;
+    translated.device.gainValue = 1.0f;
 
     return translated;
 }

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -24,11 +24,6 @@ using PolySynth = compiled::MagdaPolySynthCompiledPlugin;
 /// 4OSC's own wave numbering (FourOscPlugin.h).
 enum class FourOscWave { none, sine, triangle, sawUp, sawDown, square, random };
 
-/// The rack fader's own range (RackComponent.cpp), which is what the gains
-/// moved onto it have to fit in.
-constexpr float kRackFaderMinDb = -60.0f;
-constexpr float kRackFaderMaxDb = 6.0f;
-
 /// Poly Synth's, which is a different order and a shorter list.
 constexpr int kPolySine = 0;
 constexpr int kPolySaw = 1;
@@ -613,15 +608,27 @@ FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
     }
 
     // 4OSC runs its effects BEFORE its master level, and the slot's own trim
-    // follows the whole plugin (FourOscPlugin::applyEffects). Split across two
-    // slots, both of those now sit in front of the rack, where a gain is a
-    // different distortion drive and a different delay and reverb balance.
-    // The rack's fader is where they land: it is the one control in the
-    // translation that is downstream of all four effects.
-    translated.effects->volume =
-        std::clamp(master + translated.device.gainDb, kRackFaderMinDb, kRackFaderMaxDb);
-    translated.device.gainDb = 0.0f;
-    translated.device.gainValue = 1.0f;
+    // follows the whole plugin (FourOscPlugin::applyEffects). Split across a
+    // synth slot and a rack, both of those would sit in front of the rack,
+    // where a gain is a different distortion drive and a different delay and
+    // reverb balance.
+    //
+    // They stay two controls rather than one sum, because one sum fits in
+    // neither range. The chain fader takes the master level: -100 dB is the
+    // engine's silence (PlanValues.cpp), which no parameter slot reaches. The
+    // trim takes the last effect's own slot, the only thing downstream of it
+    // that carries a trim's full -60..+12 dB.
+    auto& chain = translated.effects->chains.front();
+    chain.volume = master;
+
+    if (isDevice(chain.elements.back())) {
+        auto& last = getDevice(chain.elements.back());
+        last.gainValue = translated.device.gainValue;
+        last.gainDb = translated.device.gainDb;
+
+        translated.device.gainValue = 1.0f;
+        translated.device.gainDb = 0.0f;
+    }
 
     return translated;
 }

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -255,20 +255,38 @@ int polyVoiceModeFor(int fourOscMode) {
 
 /// A Poly Synth at its defaults, which is what everything 4OSC does not
 /// describe is left at.
+///
+/// Built from the 4OSC rather than from nothing: the slot's gain, its macros
+/// and modulators, its panel state and its name belong to the device in the
+/// chain, not to the plugin being swapped underneath it. Only what describes
+/// 4OSC itself is replaced.
 DeviceInfo polySynthDevice(const DeviceInfo& fourOsc) {
     const PolySynth metadata;
 
-    DeviceInfo device;
-    device.id = fourOsc.id;
-    device.name = fourOsc.name;
+    DeviceInfo device = fourOsc;
     device.pluginId = PolySynth::xmlTypeName;
     device.deviceType = DeviceType::Instrument;
     device.isInstrument = true;
     device.canReceiveMidi = true;
+    device.producesMidi = false;
     device.format = PluginFormat::Internal;
     device.audioInputChannels = 0;
     device.audioOutputChannels = 2;
-    device.bypassed = fourOsc.bypassed;
+
+    // 4OSC's, all of it: the saved patch, the scan identity, the parameters
+    // and every selection made by index into them.
+    device.pluginState = {};
+    device.uniqueId = {};
+    device.fileOrIdentifier = {};
+    device.vst3ClassId = {};
+    device.vst3Preset = {};
+    device.parameters.clear();
+    device.wrapperParameters.clear();
+    device.meters.clear();
+    device.visibleParameters.clear();
+    device.miniMixerParameters.clear();
+    device.aiSoundDesignerParameters.clear();
+    device.currentParameterPage = 0;
 
     for (auto index = 0; index < metadata.parameterCount(); ++index) {
         auto info = metadata.parameterInfo(index);
@@ -439,19 +457,21 @@ float gainFromDecibels(float decibels) {
     return decibels <= -100.0f ? 0.0f : std::pow(10.0f, decibels / 20.0f);
 }
 
-/// The Division entry nearest @p beats (magda_delay.dsp). Both scales count
-/// quarter notes, so the number carries straight across and only has to land
-/// on a menu entry.
-float nearestDelayDivision(float beats) {
-    constexpr float kDivisions[] = {0.125f,   0.16667f, 0.25f, 0.375f,   0.33333f, 0.5f, 0.75f,
-                                    0.66667f, 1.0f,     1.5f,  1.33333f, 2.0f,     3.0f, 4.0f};
+/// The Division choice nearest @p beats, as the index the slot stores. Both
+/// scales count quarter notes, so the number carries across and only has to
+/// land on an entry; the slot holds that entry's position, not its value, and
+/// the entries come from the dsp's own menu rather than a copy of it.
+float nearestDelayDivision(const compiled::MagdaDelayCompiledPlugin& delay, float beats) {
+    const auto values = delay.menuValuesForIdx(compiled::MagdaDelayCompiledPlugin::kDivisionSlot);
+    if (values.empty())
+        return 0.0f;
 
-    auto nearest = kDivisions[0];
-    for (const auto division : kDivisions)
-        if (std::abs(division - beats) < std::abs(nearest - beats))
-            nearest = division;
+    std::size_t nearest = 0;
+    for (std::size_t index = 0; index < values.size(); ++index)
+        if (std::abs(values[index] - beats) < std::abs(values[nearest] - beats))
+            nearest = index;
 
-    return nearest;
+    return static_cast<float>(nearest);
 }
 
 /**
@@ -507,7 +527,7 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
         setSlot(device, Delay::kSyncSlot, 1.0f);
         setSlot(device, Delay::kDivisionSlot,
                 clampToSlot(device, Delay::kDivisionSlot,
-                            nearestDelayDivision(floatPropertyOr(props, "delay", 1.0f))));
+                            nearestDelayDivision(Delay{}, floatPropertyOr(props, "delay", 1.0f))));
         setSlot(
             device, Delay::kFeedbackSlot,
             clampToSlot(device, Delay::kFeedbackSlot, gainFromDecibels(value("delayFeedback"))));
@@ -548,6 +568,10 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
 
 bool isFourOscDevice(const DeviceInfo& device) {
     return device.pluginId.equalsIgnoreCase("4osc");
+}
+
+int fourOscParameterCount() {
+    return static_cast<int>(std::size(kFourOscParameters));
 }
 
 FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <optional>
 #include <tuple>
 
@@ -29,12 +30,62 @@ constexpr int kPolySaw = 1;
 constexpr int kPolySquare = 2;
 constexpr int kPolyTriangle = 3;
 
-/// The value @p name holds, or nothing. 4OSC's parameters are addressed by the
-/// id TE gave them ("tune1", "filterFreq"), which is what a project saves.
-std::optional<float> parameterValue(const DeviceInfo& device, const juce::String& name) {
-    for (const auto& parameter : device.parameters)
-        if (parameter.name.equalsIgnoreCase(name))
-            return parameter.currentValue;
+/// 4OSC's parameters in the order it declares them, which is the order a
+/// project's paramIndex counts in (tests/device_param_schema.txt). The names
+/// a project saves are display names ("Tune 1"), so the id cannot be matched
+/// against them and the index is what addresses a parameter.
+constexpr const char* kFourOscParameterIds[] = {
+    "tune1",          "fineTune1",   "level1",
+    "pulseWidth1",    "detune1",     "spread1",
+    "pan1",           "tune2",       "fineTune2",
+    "level2",         "pulseWidth2", "detune2",
+    "spread2",        "pan2",        "tune3",
+    "fineTune3",      "level3",      "pulseWidth3",
+    "detune3",        "spread3",     "pan3",
+    "tune4",          "fineTune4",   "level4",
+    "pulseWidth4",    "detune4",     "spread4",
+    "pan4",           "lfoRate1",    "lfoDepth1",
+    "lfoRate2",       "lfoDepth2",   "modAttack1",
+    "modDecay1",      "modSustain1", "modRelease1",
+    "modAttack2",     "modDecay2",   "modSustain2",
+    "modRelease2",    "ampAttack",   "ampDecay",
+    "ampSustain",     "ampRelease",  "ampVelocity",
+    "filterAttack",   "filterDecay", "filterSustain",
+    "filterRelease",  "filterFreq",  "filterResonance",
+    "filterAmount",   "filterKey",   "filterVelocity",
+    "distortion",     "reverbSize",  "reverbDamping",
+    "reverbWidth",    "reverbMix",   "delayFeedback",
+    "delayCrossfeed", "delayMix",    "chorusSpeed",
+    "chorusDepth",    "chorusWidth", "chorusMix",
+    "legato",         "masterLevel",
+};
+
+/// Where @p id sits in the list above, or -1.
+int fourOscParameterIndex(const juce::String& id) {
+    for (auto index = 0; index < static_cast<int>(std::size(kFourOscParameterIds)); ++index)
+        if (id == kFourOscParameterIds[index])
+            return index;
+
+    return -1;
+}
+
+/**
+ * @brief The value 4OSC's @p id holds, or nothing.
+ *
+ * The model first, addressed by index. A legacy project also writes the
+ * non-default values into its plugin XML, and that is the fallback: a project
+ * saved before the model became the authority for parameters (#2317) can have
+ * the value in only one of the two.
+ */
+std::optional<float> parameterValue(const DeviceInfo& device, const juce::ValueTree& props,
+                                    const juce::String& id) {
+    if (const auto index = fourOscParameterIndex(id); index >= 0)
+        for (const auto& parameter : device.parameters)
+            if (parameter.paramIndex == index)
+                return parameter.currentValue;
+
+    if (const auto saved = props.getProperty(juce::Identifier(id)); !saved.isVoid())
+        return static_cast<float>(saved);
 
     return std::nullopt;
 }
@@ -161,8 +212,14 @@ void translateOscillators(const DeviceInfo& fourOsc, const juce::ValueTree& prop
     for (auto osc = 1; osc <= PolySynth::kNumOscillators; ++osc) {
         const auto number = juce::String(osc);
         const auto base = PolySynth::kOscBaseSlot + (osc - 1) * PolySynth::kOscSlotCount;
-        const auto shape = static_cast<FourOscWave>(
-            propertyOr(props, "waveShape" + number, static_cast<int>(FourOscWave::none)));
+        // TE writes only what differs from a property's default, so a patch
+        // left on 4OSC's own defaults has no waveShape at all. Osc 1 defaults
+        // to sine and the rest to none (FourOscPlugin.cpp): defaulting all
+        // four to none silenced every such patch.
+        const auto fallback =
+            osc == 1 ? static_cast<int>(FourOscWave::sine) : static_cast<int>(FourOscWave::none);
+        const auto shape =
+            static_cast<FourOscWave>(propertyOr(props, "waveShape" + number, fallback));
 
         const auto wave = polyWaveFor(shape);
         setSlot(poly, PolySynth::kOscEnableBaseSlot + (osc - 1), wave.has_value() ? 1.0f : 0.0f);
@@ -179,15 +236,15 @@ void translateOscillators(const DeviceInfo& fourOsc, const juce::ValueTree& prop
         if (shape == FourOscWave::sawDown)
             gaps.push_back({"Osc " + number + " saw down", "translated as saw up"});
 
-        if (const auto tune = parameterValue(fourOsc, "tune" + number))
+        if (const auto tune = parameterValue(fourOsc, props, "tune" + number))
             setSlot(poly, base + 2, clampToSlot(poly, base + 2, *tune));
 
-        if (const auto fine = parameterValue(fourOsc, "fineTune" + number))
+        if (const auto fine = parameterValue(fourOsc, props, "fineTune" + number))
             setSlot(poly, base + 3, clampToSlot(poly, base + 3, *fine));
 
         // Both are already dB. 4OSC reaches -100 where Poly Synth stops at
         // -60, and both are silence.
-        if (const auto level = parameterValue(fourOsc, "level" + number))
+        if (const auto level = parameterValue(fourOsc, props, "level" + number))
             setSlot(poly, base + 1, clampToSlot(poly, base + 1, *level));
 
         // Addressed by 4OSC's own parameter ids, which are what a project
@@ -197,21 +254,21 @@ void translateOscillators(const DeviceInfo& fourOsc, const juce::ValueTree& prop
               std::tuple{"detune", "Detune", "no unison"},
               std::tuple{"spread", "Spread", "no unison"},
               std::tuple{"pan", "Pan", "no per-oscillator pan"}})
-            if (const auto value = parameterValue(fourOsc, juce::String(id) + number);
+            if (const auto value = parameterValue(fourOsc, props, juce::String(id) + number);
                 value.has_value() && *value != 0.0f)
                 gaps.push_back({"Osc " + number + " " + label, juce::String("dropped: ") + reason});
     }
 }
 
-void translateEnvelopes(const DeviceInfo& fourOsc, DeviceInfo& poly) {
+void translateEnvelopes(const DeviceInfo& fourOsc, const juce::ValueTree& props, DeviceInfo& poly) {
     // 4OSC holds envelope times in seconds and sustain as a percentage; Poly
     // Synth uses milliseconds and a 0..1 fraction.
     const auto seconds = [&](const juce::String& name, int slot) {
-        if (const auto value = parameterValue(fourOsc, name))
+        if (const auto value = parameterValue(fourOsc, props, name))
             setSlot(poly, slot, clampToSlot(poly, slot, *value * 1000.0f));
     };
     const auto percent = [&](const juce::String& name, int slot) {
-        if (const auto value = parameterValue(fourOsc, name))
+        if (const auto value = parameterValue(fourOsc, props, name))
             setSlot(poly, slot, clampToSlot(poly, slot, *value / 100.0f));
     };
 
@@ -240,17 +297,17 @@ void translateFilter(const DeviceInfo& fourOsc, const juce::ValueTree& props, De
         setSlot(poly, PolySynth::kCutoffSlot, slotMaximum(poly, PolySynth::kCutoffSlot));
 
     if (type.has_value())
-        if (const auto note = parameterValue(fourOsc, "filterFreq"))
+        if (const auto note = parameterValue(fourOsc, props, "filterFreq"))
             setSlot(poly, PolySynth::kCutoffSlot,
                     clampToSlot(poly, PolySynth::kCutoffSlot, cutoffHzFromMidiNote(*note)));
 
-    if (const auto resonance = parameterValue(fourOsc, "filterResonance"))
+    if (const auto resonance = parameterValue(fourOsc, props, "filterResonance"))
         setSlot(poly, PolySynth::kResonanceSlot,
                 clampToSlot(poly, PolySynth::kResonanceSlot,
                             *resonance / 100.0f * slotMaximum(poly, PolySynth::kResonanceSlot)));
 
     // 4OSC's amount is -1..1 of its own sweep; Poly Synth's is octaves.
-    if (const auto amount = parameterValue(fourOsc, "filterAmount"))
+    if (const auto amount = parameterValue(fourOsc, props, "filterAmount"))
         setSlot(poly, PolySynth::kFilterEnvAmtSlot,
                 clampToSlot(poly, PolySynth::kFilterEnvAmtSlot,
                             *amount * slotMaximum(poly, PolySynth::kFilterEnvAmtSlot)));
@@ -258,7 +315,8 @@ void translateFilter(const DeviceInfo& fourOsc, const juce::ValueTree& props, De
     setSlot(poly, PolySynth::kFilterSlopeSlot,
             propertyOr(props, "filterSlope", 12) >= 24 ? 1.0f : 0.0f);
 
-    if (const auto key = parameterValue(fourOsc, "filterKey"); key.has_value() && *key != 0.0f)
+    if (const auto key = parameterValue(fourOsc, props, "filterKey");
+        key.has_value() && *key != 0.0f)
         gaps.push_back({"Filter Key", "dropped: no keyboard tracking"});
 }
 
@@ -271,14 +329,14 @@ void reportUnisonAndEffects(const DeviceInfo& fourOsc, const juce::ValueTree& pr
         }
 
     for (auto lfo = 1; lfo <= 2; ++lfo)
-        if (const auto depth = parameterValue(fourOsc, "lfoDepth" + juce::String(lfo));
+        if (const auto depth = parameterValue(fourOsc, props, "lfoDepth" + juce::String(lfo));
             depth.has_value() && *depth != 0.0f) {
             gaps.push_back({"LFO", "dropped: use a modifier on the parameter"});
             break;
         }
 
     for (auto env = 1; env <= 2; ++env)
-        if (const auto sustain = parameterValue(fourOsc, "modSustain" + juce::String(env));
+        if (const auto sustain = parameterValue(fourOsc, props, "modSustain" + juce::String(env));
             sustain.has_value() && *sustain != 0.0f) {
             gaps.push_back({"Mod envelope", "dropped: use a modifier on the parameter"});
             break;
@@ -327,8 +385,8 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
     ChainInfo chain;
 
     const auto on = [&props](const juce::String& name) { return propertyOr(props, name, 0) != 0; };
-    const auto value = [&fourOsc](const juce::String& name, float fallback) {
-        return parameterValue(fourOsc, name).value_or(fallback);
+    const auto value = [&fourOsc, &props](const juce::String& name, float fallback) {
+        return parameterValue(fourOsc, props, name).value_or(fallback);
     };
 
     if (on("distortionOn")) {
@@ -411,10 +469,10 @@ FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
     FourOscTranslation translated{.device = polySynthDevice(fourOsc)};
 
     translateOscillators(fourOsc, props, translated.device, translated.gaps);
-    translateEnvelopes(fourOsc, translated.device);
+    translateEnvelopes(fourOsc, props, translated.device);
     translateFilter(fourOsc, props, translated.device, translated.gaps);
 
-    if (const auto legato = parameterValue(fourOsc, "legato"))
+    if (const auto legato = parameterValue(fourOsc, props, "legato"))
         setSlot(translated.device, PolySynth::kGlideSlot,
                 clampToSlot(translated.device, PolySynth::kGlideSlot, *legato));
 
@@ -427,7 +485,7 @@ FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
         translated.effects = buildEffects(fourOsc, props, nextEffectId);
 
     // 4OSC's master level is the synth's own output, not an effect.
-    if (const auto master = parameterValue(fourOsc, "masterLevel"))
+    if (const auto master = parameterValue(fourOsc, props, "masterLevel"))
         setSlot(translated.device, PolySynth::kOutputGainSlot,
                 clampToSlot(translated.device, PolySynth::kOutputGainSlot, *master));
 

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -12,6 +12,7 @@
 #include "plugins/compiled/MagdaDelayCompiledPlugin.hpp"
 #include "plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
 #include "plugins/compiled/MagdaReverbCompiledPlugin.hpp"
+#include "plugins/tracktion/TracktionDeviceStateBridge.hpp"
 
 namespace magda::daw::audio {
 
@@ -40,16 +41,18 @@ std::optional<float> parameterValue(const DeviceInfo& device, const juce::String
 
 /// 4OSC keeps wave shape, filter type and voice mode outside its parameters,
 /// as properties on its own ValueTree.
-juce::NamedValueSet savedProperties(const DeviceInfo& device) {
-    if (const auto doc = device_state::decode(device.pluginState))
-        return doc->root.props;
-
-    return {};
+///
+/// Through devicePluginTreeFromState() rather than device_state::decode():
+/// a project old enough to hold a 4OSC often stores it as legacy engine XML,
+/// which decode() refuses. Reading nothing there left every oscillator
+/// looking like "none" and the translated synth silent.
+juce::ValueTree savedProperties(const DeviceInfo& device) {
+    return tracktion_adapter::devicePluginTreeFromState(device.pluginState);
 }
 
-int propertyOr(const juce::NamedValueSet& props, const juce::String& name, int fallback) {
-    const auto* value = props.getVarPointer(name);
-    return value != nullptr ? static_cast<int>(*value) : fallback;
+int propertyOr(const juce::ValueTree& props, const juce::String& name, int fallback) {
+    const auto value = props.getProperty(juce::Identifier(name));
+    return value.isVoid() ? fallback : static_cast<int>(value);
 }
 
 void setSlot(DeviceInfo& device, int slot, float value) {
@@ -153,8 +156,8 @@ DeviceInfo polySynthDevice(const DeviceInfo& fourOsc) {
     return device;
 }
 
-void translateOscillators(const DeviceInfo& fourOsc, const juce::NamedValueSet& props,
-                          DeviceInfo& poly, std::vector<FourOscGap>& gaps) {
+void translateOscillators(const DeviceInfo& fourOsc, const juce::ValueTree& props, DeviceInfo& poly,
+                          std::vector<FourOscGap>& gaps) {
     for (auto osc = 1; osc <= PolySynth::kNumOscillators; ++osc) {
         const auto number = juce::String(osc);
         const auto base = PolySynth::kOscBaseSlot + (osc - 1) * PolySynth::kOscSlotCount;
@@ -225,7 +228,7 @@ void translateEnvelopes(const DeviceInfo& fourOsc, DeviceInfo& poly) {
     percent("filterVelocity", PolySynth::kVelFilterSlot);
 }
 
-void translateFilter(const DeviceInfo& fourOsc, const juce::NamedValueSet& props, DeviceInfo& poly,
+void translateFilter(const DeviceInfo& fourOsc, const juce::ValueTree& props, DeviceInfo& poly,
                      std::vector<FourOscGap>& gaps) {
     const auto type = polyFilterTypeFor(propertyOr(props, "filterType", 0));
 
@@ -259,7 +262,7 @@ void translateFilter(const DeviceInfo& fourOsc, const juce::NamedValueSet& props
         gaps.push_back({"Filter Key", "dropped: no keyboard tracking"});
 }
 
-void reportUnisonAndEffects(const DeviceInfo& fourOsc, const juce::NamedValueSet& props,
+void reportUnisonAndEffects(const DeviceInfo& fourOsc, const juce::ValueTree& props,
                             std::vector<FourOscGap>& gaps) {
     for (auto osc = 1; osc <= PolySynth::kNumOscillators; ++osc)
         if (propertyOr(props, "voices" + juce::String(osc), 1) > 1) {
@@ -319,7 +322,7 @@ float gainFromDecibels(float decibels) {
  * @p nextId hands out ids for the devices, which the caller owns: these are
  * new devices in the project and cannot reuse the synth's.
  */
-std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::NamedValueSet& props,
+std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::ValueTree& props,
                                        const std::function<DeviceId()>& nextId) {
     ChainInfo chain;
 

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -1,0 +1,315 @@
+#include "FourOscTranslation.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+#include <tuple>
+
+#include "../core/DeviceState.hpp"
+#include "plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
+
+namespace magda::daw::audio {
+
+namespace {
+
+using PolySynth = compiled::MagdaPolySynthCompiledPlugin;
+
+/// 4OSC's own wave numbering (FourOscPlugin.h).
+enum class FourOscWave { none, sine, triangle, sawUp, sawDown, square, random };
+
+/// Poly Synth's, which is a different order and a shorter list.
+constexpr int kPolySine = 0;
+constexpr int kPolySaw = 1;
+constexpr int kPolySquare = 2;
+constexpr int kPolyTriangle = 3;
+
+/// The value @p name holds, or nothing. 4OSC's parameters are addressed by the
+/// id TE gave them ("tune1", "filterFreq"), which is what a project saves.
+std::optional<float> parameterValue(const DeviceInfo& device, const juce::String& name) {
+    for (const auto& parameter : device.parameters)
+        if (parameter.name.equalsIgnoreCase(name))
+            return parameter.currentValue;
+
+    return std::nullopt;
+}
+
+/// 4OSC keeps wave shape, filter type and voice mode outside its parameters,
+/// as properties on its own ValueTree.
+juce::NamedValueSet savedProperties(const DeviceInfo& device) {
+    if (const auto doc = device_state::decode(device.pluginState))
+        return doc->root.props;
+
+    return {};
+}
+
+int propertyOr(const juce::NamedValueSet& props, const juce::String& name, int fallback) {
+    const auto* value = props.getVarPointer(name);
+    return value != nullptr ? static_cast<int>(*value) : fallback;
+}
+
+void setSlot(DeviceInfo& device, int slot, float value) {
+    for (auto& parameter : device.parameters)
+        if (parameter.paramIndex == slot) {
+            parameter.currentValue = value;
+            return;
+        }
+}
+
+/// Clamped to the slot's own range, which the device carries. 4OSC's ranges
+/// are wider than Poly Synth's in several places.
+float clampToSlot(const DeviceInfo& poly, int slot, float value) {
+    for (const auto& parameter : poly.parameters)
+        if (parameter.paramIndex == slot)
+            return std::clamp(value, parameter.minValue, parameter.maxValue);
+
+    return value;
+}
+
+/// The top of a slot's range, for a control that has to be put out of the way.
+float slotMaximum(const DeviceInfo& poly, int slot) {
+    for (const auto& parameter : poly.parameters)
+        if (parameter.paramIndex == slot)
+            return parameter.maxValue;
+
+    return 0.0f;
+}
+
+/// 4OSC's filter cutoff is a MIDI note number, 0 to 135.076232, which is its
+/// way of spacing the control logarithmically. Poly Synth's is Hz.
+float cutoffHzFromMidiNote(float note) {
+    return 440.0f * std::pow(2.0f, (note - 69.0f) / 12.0f);
+}
+
+/// Poly Synth has no inverted saw and no noise oscillator. Nullopt means the
+/// oscillator cannot be translated and is silenced instead.
+std::optional<int> polyWaveFor(FourOscWave wave) {
+    switch (wave) {
+        case FourOscWave::sine:
+            return kPolySine;
+        case FourOscWave::triangle:
+            return kPolyTriangle;
+        case FourOscWave::sawUp:
+        case FourOscWave::sawDown:
+            return kPolySaw;
+        case FourOscWave::square:
+            return kPolySquare;
+        case FourOscWave::none:
+        case FourOscWave::random:
+            break;
+    }
+
+    return std::nullopt;
+}
+
+/// 4OSC filterType: 0 off, then lowpass, highpass, bandpass, notch. Poly
+/// Synth's list starts at lowpass and has no off, so off is carried as a
+/// cutoff wide open rather than as a type.
+std::optional<int> polyFilterTypeFor(int fourOscType) {
+    return fourOscType >= 1 && fourOscType <= 4 ? std::optional<int>{fourOscType - 1}
+                                                : std::nullopt;
+}
+
+/// 4OSC voiceMode: 0 mono, 1 legato, 2 poly. Poly Synth: 0 poly, 1 mono,
+/// 2 legato.
+int polyVoiceModeFor(int fourOscMode) {
+    switch (fourOscMode) {
+        case 0:
+            return 1;
+        case 1:
+            return 2;
+        default:
+            return 0;
+    }
+}
+
+/// A Poly Synth at its defaults, which is what everything 4OSC does not
+/// describe is left at.
+DeviceInfo polySynthDevice(const DeviceInfo& fourOsc) {
+    const PolySynth metadata;
+
+    DeviceInfo device;
+    device.id = fourOsc.id;
+    device.name = fourOsc.name;
+    device.pluginId = PolySynth::xmlTypeName;
+    device.deviceType = DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    device.format = PluginFormat::Internal;
+    device.audioInputChannels = 0;
+    device.audioOutputChannels = 2;
+    device.bypassed = fourOsc.bypassed;
+
+    for (auto index = 0; index < metadata.parameterCount(); ++index) {
+        auto info = metadata.parameterInfo(index);
+        info.currentValue = info.defaultValue;
+        device.parameters.push_back(std::move(info));
+    }
+
+    return device;
+}
+
+void translateOscillators(const DeviceInfo& fourOsc, const juce::NamedValueSet& props,
+                          DeviceInfo& poly, std::vector<FourOscGap>& gaps) {
+    for (auto osc = 1; osc <= PolySynth::kNumOscillators; ++osc) {
+        const auto number = juce::String(osc);
+        const auto base = PolySynth::kOscBaseSlot + (osc - 1) * PolySynth::kOscSlotCount;
+        const auto shape = static_cast<FourOscWave>(
+            propertyOr(props, "waveShape" + number, static_cast<int>(FourOscWave::none)));
+
+        const auto wave = polyWaveFor(shape);
+        setSlot(poly, PolySynth::kOscEnableBaseSlot + (osc - 1), wave.has_value() ? 1.0f : 0.0f);
+
+        if (shape == FourOscWave::random)
+            gaps.push_back(
+                {"Osc " + number + " noise", "silenced: Poly Synth has no noise source"});
+
+        if (!wave.has_value())
+            continue;
+
+        setSlot(poly, base + 0, static_cast<float>(*wave));
+
+        if (shape == FourOscWave::sawDown)
+            gaps.push_back({"Osc " + number + " saw down", "translated as saw up"});
+
+        if (const auto tune = parameterValue(fourOsc, "tune" + number))
+            setSlot(poly, base + 2, clampToSlot(poly, base + 2, *tune));
+
+        if (const auto fine = parameterValue(fourOsc, "fineTune" + number))
+            setSlot(poly, base + 3, clampToSlot(poly, base + 3, *fine));
+
+        // Both are already dB. 4OSC reaches -100 where Poly Synth stops at
+        // -60, and both are silence.
+        if (const auto level = parameterValue(fourOsc, "level" + number))
+            setSlot(poly, base + 1, clampToSlot(poly, base + 1, *level));
+
+        // Addressed by 4OSC's own parameter ids, which are what a project
+        // saves.
+        for (const auto& [id, label, reason] :
+             {std::tuple{"pulseWidth", "Pulse Width", "no pulse width control"},
+              std::tuple{"detune", "Detune", "no unison"},
+              std::tuple{"spread", "Spread", "no unison"},
+              std::tuple{"pan", "Pan", "no per-oscillator pan"}})
+            if (const auto value = parameterValue(fourOsc, juce::String(id) + number);
+                value.has_value() && *value != 0.0f)
+                gaps.push_back({"Osc " + number + " " + label, juce::String("dropped: ") + reason});
+    }
+}
+
+void translateEnvelopes(const DeviceInfo& fourOsc, DeviceInfo& poly) {
+    // 4OSC holds envelope times in seconds and sustain as a percentage; Poly
+    // Synth uses milliseconds and a 0..1 fraction.
+    const auto seconds = [&](const juce::String& name, int slot) {
+        if (const auto value = parameterValue(fourOsc, name))
+            setSlot(poly, slot, clampToSlot(poly, slot, *value * 1000.0f));
+    };
+    const auto percent = [&](const juce::String& name, int slot) {
+        if (const auto value = parameterValue(fourOsc, name))
+            setSlot(poly, slot, clampToSlot(poly, slot, *value / 100.0f));
+    };
+
+    seconds("ampAttack", PolySynth::kAmpAttackSlot);
+    seconds("ampDecay", PolySynth::kAmpDecaySlot);
+    percent("ampSustain", PolySynth::kAmpSustainSlot);
+    seconds("ampRelease", PolySynth::kAmpReleaseSlot);
+    percent("ampVelocity", PolySynth::kVelAmpSlot);
+
+    seconds("filterAttack", PolySynth::kFilterAttackSlot);
+    seconds("filterDecay", PolySynth::kFilterDecaySlot);
+    percent("filterSustain", PolySynth::kFilterSustainSlot);
+    seconds("filterRelease", PolySynth::kFilterReleaseSlot);
+    percent("filterVelocity", PolySynth::kVelFilterSlot);
+}
+
+void translateFilter(const DeviceInfo& fourOsc, const juce::NamedValueSet& props, DeviceInfo& poly,
+                     std::vector<FourOscGap>& gaps) {
+    const auto type = polyFilterTypeFor(propertyOr(props, "filterType", 0));
+
+    if (type.has_value())
+        setSlot(poly, PolySynth::kFilterTypeSlot, static_cast<float>(*type));
+    else
+        // 4OSC bypasses the filter entirely at type 0. Poly Synth's is always
+        // in the path, so the nearest thing is a lowpass out of the way.
+        setSlot(poly, PolySynth::kCutoffSlot, slotMaximum(poly, PolySynth::kCutoffSlot));
+
+    if (type.has_value())
+        if (const auto note = parameterValue(fourOsc, "filterFreq"))
+            setSlot(poly, PolySynth::kCutoffSlot,
+                    clampToSlot(poly, PolySynth::kCutoffSlot, cutoffHzFromMidiNote(*note)));
+
+    if (const auto resonance = parameterValue(fourOsc, "filterResonance"))
+        setSlot(poly, PolySynth::kResonanceSlot,
+                clampToSlot(poly, PolySynth::kResonanceSlot,
+                            *resonance / 100.0f * slotMaximum(poly, PolySynth::kResonanceSlot)));
+
+    // 4OSC's amount is -1..1 of its own sweep; Poly Synth's is octaves.
+    if (const auto amount = parameterValue(fourOsc, "filterAmount"))
+        setSlot(poly, PolySynth::kFilterEnvAmtSlot,
+                clampToSlot(poly, PolySynth::kFilterEnvAmtSlot,
+                            *amount * slotMaximum(poly, PolySynth::kFilterEnvAmtSlot)));
+
+    setSlot(poly, PolySynth::kFilterSlopeSlot,
+            propertyOr(props, "filterSlope", 12) >= 24 ? 1.0f : 0.0f);
+
+    if (const auto key = parameterValue(fourOsc, "filterKey"); key.has_value() && *key != 0.0f)
+        gaps.push_back({"Filter Key", "dropped: no keyboard tracking"});
+}
+
+void reportUnisonAndEffects(const DeviceInfo& fourOsc, const juce::NamedValueSet& props,
+                            std::vector<FourOscGap>& gaps) {
+    for (auto osc = 1; osc <= PolySynth::kNumOscillators; ++osc)
+        if (propertyOr(props, "voices" + juce::String(osc), 1) > 1) {
+            gaps.push_back({"Unison", "dropped: Poly Synth has one voice per oscillator"});
+            break;
+        }
+
+    for (const auto& [property, name] :
+         {std::pair{juce::String("distortionOn"), juce::String("Distortion")},
+          std::pair{juce::String("reverbOn"), juce::String("Reverb")},
+          std::pair{juce::String("delayOn"), juce::String("Delay")},
+          std::pair{juce::String("chorusOn"), juce::String("Chorus")}})
+        if (propertyOr(props, property, 0) != 0)
+            gaps.push_back({name, "dropped: add the device to the chain instead"});
+
+    for (auto lfo = 1; lfo <= 2; ++lfo)
+        if (const auto depth = parameterValue(fourOsc, "lfoDepth" + juce::String(lfo));
+            depth.has_value() && *depth != 0.0f) {
+            gaps.push_back({"LFO", "dropped: use a modifier on the parameter"});
+            break;
+        }
+
+    for (auto env = 1; env <= 2; ++env)
+        if (const auto sustain = parameterValue(fourOsc, "modSustain" + juce::String(env));
+            sustain.has_value() && *sustain != 0.0f) {
+            gaps.push_back({"Mod envelope", "dropped: use a modifier on the parameter"});
+            break;
+        }
+}
+
+}  // namespace
+
+bool isFourOscDevice(const DeviceInfo& device) {
+    return device.pluginId.equalsIgnoreCase("4osc");
+}
+
+FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc) {
+    const auto props = savedProperties(fourOsc);
+
+    FourOscTranslation translated{.device = polySynthDevice(fourOsc), .gaps = {}};
+
+    translateOscillators(fourOsc, props, translated.device, translated.gaps);
+    translateEnvelopes(fourOsc, translated.device);
+    translateFilter(fourOsc, props, translated.device, translated.gaps);
+
+    if (const auto legato = parameterValue(fourOsc, "legato"))
+        setSlot(translated.device, PolySynth::kGlideSlot,
+                clampToSlot(translated.device, PolySynth::kGlideSlot, *legato));
+
+    setSlot(translated.device, PolySynth::kVoiceModeSlot,
+            static_cast<float>(polyVoiceModeFor(propertyOr(props, "voiceMode", 2))));
+
+    reportUnisonAndEffects(fourOsc, props, translated.gaps);
+
+    return translated;
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -6,7 +6,12 @@
 #include <tuple>
 
 #include "../core/DeviceState.hpp"
+#include "../core/RackInfo.hpp"
+#include "plugins/compiled/MagdaChorusCompiledPlugin.hpp"
+#include "plugins/compiled/MagdaClipperCompiledPlugin.hpp"
+#include "plugins/compiled/MagdaDelayCompiledPlugin.hpp"
 #include "plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
+#include "plugins/compiled/MagdaReverbCompiledPlugin.hpp"
 
 namespace magda::daw::audio {
 
@@ -262,14 +267,6 @@ void reportUnisonAndEffects(const DeviceInfo& fourOsc, const juce::NamedValueSet
             break;
         }
 
-    for (const auto& [property, name] :
-         {std::pair{juce::String("distortionOn"), juce::String("Distortion")},
-          std::pair{juce::String("reverbOn"), juce::String("Reverb")},
-          std::pair{juce::String("delayOn"), juce::String("Delay")},
-          std::pair{juce::String("chorusOn"), juce::String("Chorus")}})
-        if (propertyOr(props, property, 0) != 0)
-            gaps.push_back({name, "dropped: add the device to the chain instead"});
-
     for (auto lfo = 1; lfo <= 2; ++lfo)
         if (const auto depth = parameterValue(fourOsc, "lfoDepth" + juce::String(lfo));
             depth.has_value() && *depth != 0.0f) {
@@ -285,16 +282,130 @@ void reportUnisonAndEffects(const DeviceInfo& fourOsc, const juce::NamedValueSet
         }
 }
 
+/// A compiled device at its defaults, ready for the slots below to move.
+template <typename Device> DeviceInfo compiledDevice(DeviceId id) {
+    const Device metadata;
+
+    DeviceInfo device;
+    device.id = id;
+    device.name = metadata.deviceName();
+    device.pluginId = Device::xmlTypeName;
+    device.deviceType = DeviceType::Effect;
+    device.format = PluginFormat::Internal;
+    device.audioInputChannels = 2;
+    device.audioOutputChannels = 2;
+
+    for (auto index = 0; index < metadata.parameterCount(); ++index) {
+        auto info = metadata.parameterInfo(index);
+        info.currentValue = info.defaultValue;
+        device.parameters.push_back(std::move(info));
+    }
+
+    return device;
+}
+
+/// dB to a 0..1 gain, for the two 4OSC controls held in dB that reach a
+/// normalised slot.
+float gainFromDecibels(float decibels) {
+    return decibels <= -100.0f ? 0.0f : std::pow(10.0f, decibels / 20.0f);
+}
+
+/**
+ * @brief 4OSC's built-in effects as MAGDA devices, in one rack.
+ *
+ * Ordered as 4OSC processes them (FourOscPlugin.cpp): distortion, chorus,
+ * delay, reverb. Only the ones its `<fx>On` properties switched on.
+ *
+ * @p nextId hands out ids for the devices, which the caller owns: these are
+ * new devices in the project and cannot reuse the synth's.
+ */
+std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::NamedValueSet& props,
+                                       const std::function<DeviceId()>& nextId) {
+    ChainInfo chain;
+
+    const auto on = [&props](const juce::String& name) { return propertyOr(props, name, 0) != 0; };
+    const auto value = [&fourOsc](const juce::String& name, float fallback) {
+        return parameterValue(fourOsc, name).value_or(fallback);
+    };
+
+    if (on("distortionOn")) {
+        using Clipper = compiled::MagdaClipperCompiledPlugin;
+        auto device = compiledDevice<Clipper>(nextId());
+        // 4OSC multiplies by drive and clamps at 1/(2*drive), so its 0..1 is
+        // the whole range of the effect.
+        setSlot(device, Clipper::kDriveSlot,
+                clampToSlot(device, Clipper::kDriveSlot, value("distortion", 0.0f) * 24.0f));
+        chain.elements.push_back(ChainElement{std::move(device)});
+    }
+
+    if (on("chorusOn")) {
+        using Chorus = compiled::MagdaChorusCompiledPlugin;
+        auto device = compiledDevice<Chorus>(nextId());
+        setSlot(device, Chorus::kRateSlot,
+                clampToSlot(device, Chorus::kRateSlot, value("chorusSpeed", 1.0f)));
+        // 4OSC's depth is milliseconds of delay, up to 20; MAGDA's is a
+        // fraction of its own range.
+        setSlot(device, Chorus::kDepthSlot,
+                clampToSlot(device, Chorus::kDepthSlot, value("chorusDepth", 0.0f) / 20.0f));
+        setSlot(device, Chorus::kWidthSlot,
+                clampToSlot(device, Chorus::kWidthSlot, value("chorusWidth", 0.0f)));
+        setSlot(device, Chorus::kMixSlot,
+                clampToSlot(device, Chorus::kMixSlot, value("chorusMix", 0.5f)));
+        chain.elements.push_back(ChainElement{std::move(device)});
+    }
+
+    if (on("delayOn")) {
+        using Delay = compiled::MagdaDelayCompiledPlugin;
+        auto device = compiledDevice<Delay>(nextId());
+        setSlot(device, Delay::kFeedbackSlot,
+                clampToSlot(device, Delay::kFeedbackSlot,
+                            gainFromDecibels(value("delayFeedback", -100.0f))));
+        setSlot(device, Delay::kCrossSlot,
+                clampToSlot(device, Delay::kCrossSlot,
+                            gainFromDecibels(value("delayCrossfeed", -100.0f))));
+        setSlot(device, Delay::kMixSlot,
+                clampToSlot(device, Delay::kMixSlot, value("delayMix", 0.5f)));
+        chain.elements.push_back(ChainElement{std::move(device)});
+    }
+
+    if (on("reverbOn")) {
+        using Reverb = compiled::MagdaReverbCompiledPlugin;
+        auto device = compiledDevice<Reverb>(nextId());
+        // 4OSC holds all four as 0..1; MAGDA's decay, damping and width are
+        // percentages.
+        setSlot(device, Reverb::kDecaySlot,
+                clampToSlot(device, Reverb::kDecaySlot, value("reverbSize", 0.5f) * 100.0f));
+        setSlot(device, Reverb::kDampingSlot,
+                clampToSlot(device, Reverb::kDampingSlot, value("reverbDamping", 0.5f) * 100.0f));
+        setSlot(device, Reverb::kWidthSlot,
+                clampToSlot(device, Reverb::kWidthSlot, value("reverbWidth", 1.0f) * 100.0f));
+        setSlot(device, Reverb::kMixSlot,
+                clampToSlot(device, Reverb::kMixSlot, value("reverbMix", 0.3f)));
+        chain.elements.push_back(ChainElement{std::move(device)});
+    }
+
+    if (chain.elements.empty())
+        return nullptr;
+
+    auto rack = std::make_unique<RackInfo>();
+    rack->name = "4OSC FX";
+    chain.id = ChainId{1};
+    rack->chains.push_back(std::move(chain));
+
+    return rack;
+}
+
 }  // namespace
 
 bool isFourOscDevice(const DeviceInfo& device) {
     return device.pluginId.equalsIgnoreCase("4osc");
 }
 
-FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc) {
+FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
+                                    const std::function<DeviceId()>& nextEffectId) {
     const auto props = savedProperties(fourOsc);
 
-    FourOscTranslation translated{.device = polySynthDevice(fourOsc), .gaps = {}};
+    FourOscTranslation translated{.device = polySynthDevice(fourOsc)};
 
     translateOscillators(fourOsc, props, translated.device, translated.gaps);
     translateEnvelopes(fourOsc, translated.device);
@@ -308,6 +419,14 @@ FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc) {
             static_cast<float>(polyVoiceModeFor(propertyOr(props, "voiceMode", 2))));
 
     reportUnisonAndEffects(fourOsc, props, translated.gaps);
+
+    if (nextEffectId)
+        translated.effects = buildEffects(fourOsc, props, nextEffectId);
+
+    // 4OSC's master level is the synth's own output, not an effect.
+    if (const auto master = parameterValue(fourOsc, "masterLevel"))
+        setSlot(translated.device, PolySynth::kOutputGainSlot,
+                clampToSlot(translated.device, PolySynth::kOutputGainSlot, *master));
 
     return translated;
 }

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -173,6 +173,11 @@ int propertyOr(const juce::ValueTree& props, const juce::String& name, int fallb
     return value.isVoid() ? fallback : static_cast<int>(value);
 }
 
+float floatPropertyOr(const juce::ValueTree& props, const juce::String& name, float fallback) {
+    const auto value = props.getProperty(juce::Identifier(name));
+    return value.isVoid() ? fallback : static_cast<float>(value);
+}
+
 void setSlot(DeviceInfo& device, int slot, float value) {
     for (auto& parameter : device.parameters)
         if (parameter.paramIndex == slot) {
@@ -434,6 +439,21 @@ float gainFromDecibels(float decibels) {
     return decibels <= -100.0f ? 0.0f : std::pow(10.0f, decibels / 20.0f);
 }
 
+/// The Division entry nearest @p beats (magda_delay.dsp). Both scales count
+/// quarter notes, so the number carries straight across and only has to land
+/// on a menu entry.
+float nearestDelayDivision(float beats) {
+    constexpr float kDivisions[] = {0.125f,   0.16667f, 0.25f, 0.375f,   0.33333f, 0.5f, 0.75f,
+                                    0.66667f, 1.0f,     1.5f,  1.33333f, 2.0f,     3.0f, 4.0f};
+
+    auto nearest = kDivisions[0];
+    for (const auto division : kDivisions)
+        if (std::abs(division - beats) < std::abs(nearest - beats))
+            nearest = division;
+
+    return nearest;
+}
+
 /**
  * @brief 4OSC's built-in effects as MAGDA devices, in one rack.
  *
@@ -481,6 +501,13 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
     if (on("delayOn")) {
         using Delay = compiled::MagdaDelayCompiledPlugin;
         auto device = compiledDevice<Delay>(nextId());
+        // 4OSC holds its delay in beats and divides by the tempo at render
+        // time (FourOscPlugin.cpp), so the synced division is the same number
+        // and the free-time slot would be the wrong home for it.
+        setSlot(device, Delay::kSyncSlot, 1.0f);
+        setSlot(device, Delay::kDivisionSlot,
+                clampToSlot(device, Delay::kDivisionSlot,
+                            nearestDelayDivision(floatPropertyOr(props, "delay", 1.0f))));
         setSlot(
             device, Delay::kFeedbackSlot,
             clampToSlot(device, Delay::kFeedbackSlot, gainFromDecibels(value("delayFeedback"))));

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -34,52 +34,111 @@ constexpr int kPolyTriangle = 3;
 /// project's paramIndex counts in (tests/device_param_schema.txt). The names
 /// a project saves are display names ("Tune 1"), so the id cannot be matched
 /// against them and the index is what addresses a parameter.
-constexpr const char* kFourOscParameterIds[] = {
-    "tune1",          "fineTune1",   "level1",
-    "pulseWidth1",    "detune1",     "spread1",
-    "pan1",           "tune2",       "fineTune2",
-    "level2",         "pulseWidth2", "detune2",
-    "spread2",        "pan2",        "tune3",
-    "fineTune3",      "level3",      "pulseWidth3",
-    "detune3",        "spread3",     "pan3",
-    "tune4",          "fineTune4",   "level4",
-    "pulseWidth4",    "detune4",     "spread4",
-    "pan4",           "lfoRate1",    "lfoDepth1",
-    "lfoRate2",       "lfoDepth2",   "modAttack1",
-    "modDecay1",      "modSustain1", "modRelease1",
-    "modAttack2",     "modDecay2",   "modSustain2",
-    "modRelease2",    "ampAttack",   "ampDecay",
-    "ampSustain",     "ampRelease",  "ampVelocity",
-    "filterAttack",   "filterDecay", "filterSustain",
-    "filterRelease",  "filterFreq",  "filterResonance",
-    "filterAmount",   "filterKey",   "filterVelocity",
-    "distortion",     "reverbSize",  "reverbDamping",
-    "reverbWidth",    "reverbMix",   "delayFeedback",
-    "delayCrossfeed", "delayMix",    "chorusSpeed",
-    "chorusDepth",    "chorusWidth", "chorusMix",
-    "legato",         "masterLevel",
+///
+/// Each carries the value 4OSC holds when nothing writes the property
+/// (FourOscPlugin.cpp), which is not the value Poly Synth holds.
+struct FourOscParameter {
+    const char* id;
+    float defaultValue;
+};
+
+constexpr FourOscParameter kFourOscParameters[] = {
+    {"tune1", 0.0f},
+    {"fineTune1", 0.0f},
+    {"level1", 0.0f},
+    {"pulseWidth1", 0.5f},
+    {"detune1", 0.0f},
+    {"spread1", 0.0f},
+    {"pan1", 0.0f},
+    {"tune2", 0.0f},
+    {"fineTune2", 0.0f},
+    {"level2", 0.0f},
+    {"pulseWidth2", 0.5f},
+    {"detune2", 0.0f},
+    {"spread2", 0.0f},
+    {"pan2", 0.0f},
+    {"tune3", 0.0f},
+    {"fineTune3", 0.0f},
+    {"level3", 0.0f},
+    {"pulseWidth3", 0.5f},
+    {"detune3", 0.0f},
+    {"spread3", 0.0f},
+    {"pan3", 0.0f},
+    {"tune4", 0.0f},
+    {"fineTune4", 0.0f},
+    {"level4", 0.0f},
+    {"pulseWidth4", 0.5f},
+    {"detune4", 0.0f},
+    {"spread4", 0.0f},
+    {"pan4", 0.0f},
+    {"lfoRate1", 1.0f},
+    {"lfoDepth1", 1.0f},
+    {"lfoRate2", 1.0f},
+    {"lfoDepth2", 1.0f},
+    {"modAttack1", 0.1f},
+    {"modDecay1", 0.1f},
+    {"modSustain1", 80.0f},
+    {"modRelease1", 0.1f},
+    {"modAttack2", 0.1f},
+    {"modDecay2", 0.1f},
+    {"modSustain2", 80.0f},
+    {"modRelease2", 0.1f},
+    {"ampAttack", 0.1f},
+    {"ampDecay", 0.1f},
+    {"ampSustain", 80.0f},
+    {"ampRelease", 0.1f},
+    {"ampVelocity", 100.0f},
+    {"filterAttack", 0.1f},
+    {"filterDecay", 0.1f},
+    {"filterSustain", 80.0f},
+    {"filterRelease", 0.1f},
+    {"filterFreq", 69.0f},
+    {"filterResonance", 0.5f},
+    {"filterAmount", 0.0f},
+    {"filterKey", 0.0f},
+    {"filterVelocity", 0.0f},
+    {"distortion", 0.0f},
+    {"reverbSize", 0.0f},
+    {"reverbDamping", 0.0f},
+    {"reverbWidth", 0.0f},
+    {"reverbMix", 0.0f},
+    {"delayFeedback", -10.0f},
+    {"delayCrossfeed", -100.0f},
+    {"delayMix", 0.0f},
+    {"chorusSpeed", 1.0f},
+    {"chorusDepth", 3.0f},
+    {"chorusWidth", 0.5f},
+    {"chorusMix", 0.0f},
+    {"legato", 0.0f},
+    {"masterLevel", 0.0f},
 };
 
 /// Where @p id sits in the list above, or -1.
 int fourOscParameterIndex(const juce::String& id) {
-    for (auto index = 0; index < static_cast<int>(std::size(kFourOscParameterIds)); ++index)
-        if (id == kFourOscParameterIds[index])
+    for (auto index = 0; index < static_cast<int>(std::size(kFourOscParameters)); ++index)
+        if (id == kFourOscParameters[index].id)
             return index;
 
     return -1;
 }
 
 /**
- * @brief The value 4OSC's @p id holds, or nothing.
+ * @brief The value 4OSC's @p id holds.
  *
  * The model first, addressed by index. A legacy project also writes the
  * non-default values into its plugin XML, and that is the fallback: a project
  * saved before the model became the authority for parameters (#2317) can have
  * the value in only one of the two.
+ *
+ * Written by neither means 4OSC was sitting on its own default, and 4OSC's
+ * defaults are not Poly Synth's: leaving the slot alone put an untouched
+ * patch at -12 dB and a 5 ms attack where 4OSC had 0 dB and 100 ms.
  */
-std::optional<float> parameterValue(const DeviceInfo& device, const juce::ValueTree& props,
-                                    const juce::String& id) {
-    if (const auto index = fourOscParameterIndex(id); index >= 0)
+float parameterValue(const DeviceInfo& device, const juce::ValueTree& props,
+                     const juce::String& id) {
+    const auto index = fourOscParameterIndex(id);
+
+    if (index >= 0)
         for (const auto& parameter : device.parameters)
             if (parameter.paramIndex == index)
                 return parameter.currentValue;
@@ -87,7 +146,15 @@ std::optional<float> parameterValue(const DeviceInfo& device, const juce::ValueT
     if (const auto saved = props.getProperty(juce::Identifier(id)); !saved.isVoid())
         return static_cast<float>(saved);
 
-    return std::nullopt;
+    return index >= 0 ? kFourOscParameters[index].defaultValue : 0.0f;
+}
+
+/// Whether the patch moved @p id off 4OSC's default. What makes a control
+/// Poly Synth has no place for worth reporting is that somebody set it.
+bool isSetByPatch(const DeviceInfo& device, const juce::ValueTree& props, const juce::String& id) {
+    const auto index = fourOscParameterIndex(id);
+    return index >= 0 &&
+           parameterValue(device, props, id) != kFourOscParameters[index].defaultValue;
 }
 
 /// 4OSC keeps wave shape, filter type and voice mode outside its parameters,
@@ -236,16 +303,16 @@ void translateOscillators(const DeviceInfo& fourOsc, const juce::ValueTree& prop
         if (shape == FourOscWave::sawDown)
             gaps.push_back({"Osc " + number + " saw down", "translated as saw up"});
 
-        if (const auto tune = parameterValue(fourOsc, props, "tune" + number))
-            setSlot(poly, base + 2, clampToSlot(poly, base + 2, *tune));
+        const auto tune = parameterValue(fourOsc, props, "tune" + number);
+        setSlot(poly, base + 2, clampToSlot(poly, base + 2, tune));
 
-        if (const auto fine = parameterValue(fourOsc, props, "fineTune" + number))
-            setSlot(poly, base + 3, clampToSlot(poly, base + 3, *fine));
+        const auto fine = parameterValue(fourOsc, props, "fineTune" + number);
+        setSlot(poly, base + 3, clampToSlot(poly, base + 3, fine));
 
         // Both are already dB. 4OSC reaches -100 where Poly Synth stops at
         // -60, and both are silence.
-        if (const auto level = parameterValue(fourOsc, props, "level" + number))
-            setSlot(poly, base + 1, clampToSlot(poly, base + 1, *level));
+        const auto level = parameterValue(fourOsc, props, "level" + number);
+        setSlot(poly, base + 1, clampToSlot(poly, base + 1, level));
 
         // Addressed by 4OSC's own parameter ids, which are what a project
         // saves.
@@ -254,8 +321,7 @@ void translateOscillators(const DeviceInfo& fourOsc, const juce::ValueTree& prop
               std::tuple{"detune", "Detune", "no unison"},
               std::tuple{"spread", "Spread", "no unison"},
               std::tuple{"pan", "Pan", "no per-oscillator pan"}})
-            if (const auto value = parameterValue(fourOsc, props, juce::String(id) + number);
-                value.has_value() && *value != 0.0f)
+            if (isSetByPatch(fourOsc, props, juce::String(id) + number))
                 gaps.push_back({"Osc " + number + " " + label, juce::String("dropped: ") + reason});
     }
 }
@@ -264,12 +330,11 @@ void translateEnvelopes(const DeviceInfo& fourOsc, const juce::ValueTree& props,
     // 4OSC holds envelope times in seconds and sustain as a percentage; Poly
     // Synth uses milliseconds and a 0..1 fraction.
     const auto seconds = [&](const juce::String& name, int slot) {
-        if (const auto value = parameterValue(fourOsc, props, name))
-            setSlot(poly, slot, clampToSlot(poly, slot, *value * 1000.0f));
+        setSlot(poly, slot,
+                clampToSlot(poly, slot, parameterValue(fourOsc, props, name) * 1000.0f));
     };
     const auto percent = [&](const juce::String& name, int slot) {
-        if (const auto value = parameterValue(fourOsc, props, name))
-            setSlot(poly, slot, clampToSlot(poly, slot, *value / 100.0f));
+        setSlot(poly, slot, clampToSlot(poly, slot, parameterValue(fourOsc, props, name) / 100.0f));
     };
 
     seconds("ampAttack", PolySynth::kAmpAttackSlot);
@@ -296,27 +361,27 @@ void translateFilter(const DeviceInfo& fourOsc, const juce::ValueTree& props, De
         // in the path, so the nearest thing is a lowpass out of the way.
         setSlot(poly, PolySynth::kCutoffSlot, slotMaximum(poly, PolySynth::kCutoffSlot));
 
-    if (type.has_value())
-        if (const auto note = parameterValue(fourOsc, props, "filterFreq"))
-            setSlot(poly, PolySynth::kCutoffSlot,
-                    clampToSlot(poly, PolySynth::kCutoffSlot, cutoffHzFromMidiNote(*note)));
+    if (type.has_value()) {
+        const auto note = parameterValue(fourOsc, props, "filterFreq");
+        setSlot(poly, PolySynth::kCutoffSlot,
+                clampToSlot(poly, PolySynth::kCutoffSlot, cutoffHzFromMidiNote(note)));
+    }
 
-    if (const auto resonance = parameterValue(fourOsc, props, "filterResonance"))
-        setSlot(poly, PolySynth::kResonanceSlot,
-                clampToSlot(poly, PolySynth::kResonanceSlot,
-                            *resonance / 100.0f * slotMaximum(poly, PolySynth::kResonanceSlot)));
+    const auto resonance = parameterValue(fourOsc, props, "filterResonance");
+    setSlot(poly, PolySynth::kResonanceSlot,
+            clampToSlot(poly, PolySynth::kResonanceSlot,
+                        resonance / 100.0f * slotMaximum(poly, PolySynth::kResonanceSlot)));
 
     // 4OSC's amount is -1..1 of its own sweep; Poly Synth's is octaves.
-    if (const auto amount = parameterValue(fourOsc, props, "filterAmount"))
-        setSlot(poly, PolySynth::kFilterEnvAmtSlot,
-                clampToSlot(poly, PolySynth::kFilterEnvAmtSlot,
-                            *amount * slotMaximum(poly, PolySynth::kFilterEnvAmtSlot)));
+    const auto amount = parameterValue(fourOsc, props, "filterAmount");
+    setSlot(poly, PolySynth::kFilterEnvAmtSlot,
+            clampToSlot(poly, PolySynth::kFilterEnvAmtSlot,
+                        amount * slotMaximum(poly, PolySynth::kFilterEnvAmtSlot)));
 
     setSlot(poly, PolySynth::kFilterSlopeSlot,
             propertyOr(props, "filterSlope", 12) >= 24 ? 1.0f : 0.0f);
 
-    if (const auto key = parameterValue(fourOsc, props, "filterKey");
-        key.has_value() && *key != 0.0f)
+    if (isSetByPatch(fourOsc, props, "filterKey"))
         gaps.push_back({"Filter Key", "dropped: no keyboard tracking"});
 }
 
@@ -329,15 +394,13 @@ void reportUnisonAndEffects(const DeviceInfo& fourOsc, const juce::ValueTree& pr
         }
 
     for (auto lfo = 1; lfo <= 2; ++lfo)
-        if (const auto depth = parameterValue(fourOsc, props, "lfoDepth" + juce::String(lfo));
-            depth.has_value() && *depth != 0.0f) {
+        if (isSetByPatch(fourOsc, props, "lfoDepth" + juce::String(lfo))) {
             gaps.push_back({"LFO", "dropped: use a modifier on the parameter"});
             break;
         }
 
     for (auto env = 1; env <= 2; ++env)
-        if (const auto sustain = parameterValue(fourOsc, props, "modSustain" + juce::String(env));
-            sustain.has_value() && *sustain != 0.0f) {
+        if (isSetByPatch(fourOsc, props, "modSustain" + juce::String(env))) {
             gaps.push_back({"Mod envelope", "dropped: use a modifier on the parameter"});
             break;
         }
@@ -385,8 +448,8 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
     ChainInfo chain;
 
     const auto on = [&props](const juce::String& name) { return propertyOr(props, name, 0) != 0; };
-    const auto value = [&fourOsc, &props](const juce::String& name, float fallback) {
-        return parameterValue(fourOsc, props, name).value_or(fallback);
+    const auto value = [&fourOsc, &props](const juce::String& name) {
+        return parameterValue(fourOsc, props, name);
     };
 
     if (on("distortionOn")) {
@@ -395,7 +458,7 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
         // 4OSC multiplies by drive and clamps at 1/(2*drive), so its 0..1 is
         // the whole range of the effect.
         setSlot(device, Clipper::kDriveSlot,
-                clampToSlot(device, Clipper::kDriveSlot, value("distortion", 0.0f) * 24.0f));
+                clampToSlot(device, Clipper::kDriveSlot, value("distortion") * 24.0f));
         chain.elements.push_back(ChainElement{std::move(device)});
     }
 
@@ -403,29 +466,27 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
         using Chorus = compiled::MagdaChorusCompiledPlugin;
         auto device = compiledDevice<Chorus>(nextId());
         setSlot(device, Chorus::kRateSlot,
-                clampToSlot(device, Chorus::kRateSlot, value("chorusSpeed", 1.0f)));
+                clampToSlot(device, Chorus::kRateSlot, value("chorusSpeed")));
         // 4OSC's depth is milliseconds of delay, up to 20; MAGDA's is a
         // fraction of its own range.
         setSlot(device, Chorus::kDepthSlot,
-                clampToSlot(device, Chorus::kDepthSlot, value("chorusDepth", 0.0f) / 20.0f));
+                clampToSlot(device, Chorus::kDepthSlot, value("chorusDepth") / 20.0f));
         setSlot(device, Chorus::kWidthSlot,
-                clampToSlot(device, Chorus::kWidthSlot, value("chorusWidth", 0.0f)));
+                clampToSlot(device, Chorus::kWidthSlot, value("chorusWidth")));
         setSlot(device, Chorus::kMixSlot,
-                clampToSlot(device, Chorus::kMixSlot, value("chorusMix", 0.5f)));
+                clampToSlot(device, Chorus::kMixSlot, value("chorusMix")));
         chain.elements.push_back(ChainElement{std::move(device)});
     }
 
     if (on("delayOn")) {
         using Delay = compiled::MagdaDelayCompiledPlugin;
         auto device = compiledDevice<Delay>(nextId());
-        setSlot(device, Delay::kFeedbackSlot,
-                clampToSlot(device, Delay::kFeedbackSlot,
-                            gainFromDecibels(value("delayFeedback", -100.0f))));
+        setSlot(
+            device, Delay::kFeedbackSlot,
+            clampToSlot(device, Delay::kFeedbackSlot, gainFromDecibels(value("delayFeedback"))));
         setSlot(device, Delay::kCrossSlot,
-                clampToSlot(device, Delay::kCrossSlot,
-                            gainFromDecibels(value("delayCrossfeed", -100.0f))));
-        setSlot(device, Delay::kMixSlot,
-                clampToSlot(device, Delay::kMixSlot, value("delayMix", 0.5f)));
+                clampToSlot(device, Delay::kCrossSlot, gainFromDecibels(value("delayCrossfeed"))));
+        setSlot(device, Delay::kMixSlot, clampToSlot(device, Delay::kMixSlot, value("delayMix")));
         chain.elements.push_back(ChainElement{std::move(device)});
     }
 
@@ -435,13 +496,13 @@ std::unique_ptr<RackInfo> buildEffects(const DeviceInfo& fourOsc, const juce::Va
         // 4OSC holds all four as 0..1; MAGDA's decay, damping and width are
         // percentages.
         setSlot(device, Reverb::kDecaySlot,
-                clampToSlot(device, Reverb::kDecaySlot, value("reverbSize", 0.5f) * 100.0f));
+                clampToSlot(device, Reverb::kDecaySlot, value("reverbSize") * 100.0f));
         setSlot(device, Reverb::kDampingSlot,
-                clampToSlot(device, Reverb::kDampingSlot, value("reverbDamping", 0.5f) * 100.0f));
+                clampToSlot(device, Reverb::kDampingSlot, value("reverbDamping") * 100.0f));
         setSlot(device, Reverb::kWidthSlot,
-                clampToSlot(device, Reverb::kWidthSlot, value("reverbWidth", 1.0f) * 100.0f));
+                clampToSlot(device, Reverb::kWidthSlot, value("reverbWidth") * 100.0f));
         setSlot(device, Reverb::kMixSlot,
-                clampToSlot(device, Reverb::kMixSlot, value("reverbMix", 0.3f)));
+                clampToSlot(device, Reverb::kMixSlot, value("reverbMix")));
         chain.elements.push_back(ChainElement{std::move(device)});
     }
 
@@ -472,9 +533,9 @@ FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
     translateEnvelopes(fourOsc, props, translated.device);
     translateFilter(fourOsc, props, translated.device, translated.gaps);
 
-    if (const auto legato = parameterValue(fourOsc, props, "legato"))
-        setSlot(translated.device, PolySynth::kGlideSlot,
-                clampToSlot(translated.device, PolySynth::kGlideSlot, *legato));
+    const auto legato = parameterValue(fourOsc, props, "legato");
+    setSlot(translated.device, PolySynth::kGlideSlot,
+            clampToSlot(translated.device, PolySynth::kGlideSlot, legato));
 
     setSlot(translated.device, PolySynth::kVoiceModeSlot,
             static_cast<float>(polyVoiceModeFor(propertyOr(props, "voiceMode", 2))));
@@ -485,9 +546,9 @@ FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
         translated.effects = buildEffects(fourOsc, props, nextEffectId);
 
     // 4OSC's master level is the synth's own output, not an effect.
-    if (const auto master = parameterValue(fourOsc, props, "masterLevel"))
-        setSlot(translated.device, PolySynth::kOutputGainSlot,
-                clampToSlot(translated.device, PolySynth::kOutputGainSlot, *master));
+    const auto master = parameterValue(fourOsc, props, "masterLevel");
+    setSlot(translated.device, PolySynth::kOutputGainSlot,
+            clampToSlot(translated.device, PolySynth::kOutputGainSlot, master));
 
     return translated;
 }

--- a/magda/daw/audio/FourOscTranslation.cpp
+++ b/magda/daw/audio/FourOscTranslation.cpp
@@ -253,6 +253,12 @@ int polyVoiceModeFor(int fourOscMode) {
     }
 }
 
+/// The names a 4OSC carries when nobody has renamed it: the id a project
+/// saves, and the display name the registry gives it (BaseDevicePack.cpp).
+bool isStockFourOscName(const juce::String& name) {
+    return name.equalsIgnoreCase("4osc") || name.equalsIgnoreCase("4OSC Synth");
+}
+
 /// A Poly Synth at its defaults, which is what everything 4OSC does not
 /// describe is left at.
 ///
@@ -287,6 +293,14 @@ DeviceInfo polySynthDevice(const DeviceInfo& fourOsc) {
     device.miniMixerParameters.clear();
     device.aiSoundDesignerParameters.clear();
     device.currentParameterPage = 0;
+
+    // A Poly Synth called "4OSC" is wrong everywhere the name is read, the
+    // alias registry included: a pathless alias materialises against the
+    // device whose normalised NAME matches its key (TargetResolver.cpp), so a
+    // 4OSC alias would come straight back onto this one. A name somebody
+    // chose is theirs and stays.
+    if (isStockFourOscName(device.name))
+        device.name = metadata.deviceName();
 
     for (auto index = 0; index < metadata.parameterCount(); ++index) {
         auto info = metadata.parameterInfo(index);

--- a/magda/daw/audio/FourOscTranslation.hpp
+++ b/magda/daw/audio/FourOscTranslation.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+#include <memory>
 #include <vector>
 
 #include "../core/DeviceInfo.hpp"
@@ -27,6 +29,11 @@ struct FourOscGap {
 /** @brief A translated patch and everything Poly Synth has no place for. */
 struct FourOscTranslation {
     DeviceInfo device;
+
+    /// 4OSC's built-in effects, as MAGDA devices in one rack, in the order
+    /// 4OSC processes them. Null when the patch had none switched on.
+    std::unique_ptr<RackInfo> effects;
+
     std::vector<FourOscGap> gaps;
 };
 
@@ -41,10 +48,15 @@ bool isFourOscDevice(const DeviceInfo& device);
  * DeviceId, the same place in the chain, so links and automation still name
  * this device.
  *
+ * 4OSC's built-in effects become MAGDA devices in `effects`, so @p nextEffectId
+ * has to hand out ids the project is not already using. Passing nothing skips
+ * them, which is what a caller only asking what a patch would lose wants.
+ *
  * A control Poly Synth does not have is listed in `gaps` rather than
  * approximated. Unison is the loudest of those: a patch built on detuned
  * voices translates to a thinner sound and the caller has to say so.
  */
-FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc);
+FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc,
+                                    const std::function<DeviceId()>& nextEffectId = nullptr);
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/FourOscTranslation.hpp
+++ b/magda/daw/audio/FourOscTranslation.hpp
@@ -40,6 +40,10 @@ struct FourOscTranslation {
 /// Whether @p device is a 4OSC instance, by the pluginId a project saves.
 bool isFourOscDevice(const DeviceInfo& device);
 
+/// How many parameters 4OSC declares, which is the range of indices a saved
+/// link, binding or alias can be naming on one.
+int fourOscParameterCount();
+
 /**
  * @brief Translate @p fourOsc into a Poly Synth device.
  *

--- a/magda/daw/audio/FourOscTranslation.hpp
+++ b/magda/daw/audio/FourOscTranslation.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <vector>
+
+#include "../core/DeviceInfo.hpp"
+
+/**
+ * @file FourOscTranslation.hpp
+ * @brief A saved 4OSC patch as a Poly Synth patch (#2437).
+ *
+ * 4OSC is Tracktion Engine's own synth, so it goes when the fork goes (#2298)
+ * and is never ported. A project holding one still has to open on the native
+ * engine, and this is what it opens as.
+ */
+
+namespace magda::daw::audio {
+
+/** @brief What a translated patch could not carry, for the caller to report. */
+struct FourOscGap {
+    /// The 4OSC control, named as its UI names it.
+    juce::String control;
+
+    /// What happens instead.
+    juce::String effect;
+};
+
+/** @brief A translated patch and everything Poly Synth has no place for. */
+struct FourOscTranslation {
+    DeviceInfo device;
+    std::vector<FourOscGap> gaps;
+};
+
+/// Whether @p device is a 4OSC instance, by the pluginId a project saves.
+bool isFourOscDevice(const DeviceInfo& device);
+
+/**
+ * @brief Translate @p fourOsc into a Poly Synth device.
+ *
+ * Carries the four oscillators, the filter and both envelopes, voice mode,
+ * glide and the velocity amounts. Identity stays @p fourOsc's: the same
+ * DeviceId, the same place in the chain, so links and automation still name
+ * this device.
+ *
+ * A control Poly Synth does not have is listed in `gaps` rather than
+ * approximated. Unison is the loudest of those: a patch built on detuned
+ * voices translates to a thinner sound and the caller has to say so.
+ */
+FourOscTranslation translateFourOsc(const DeviceInfo& fourOsc);
+
+}  // namespace magda::daw::audio

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -76,6 +76,7 @@ void Config::save() {
 
     // Transport
     root->setProperty("openPluginWindowOnDrop", openPluginWindowOnDrop);
+    root->setProperty("skipFourOscConversionPrompt", skipFourOscConversionPrompt);
     root->setProperty("transportShowBothFormats", transportShowBothFormats);
     root->setProperty("transportDefaultBarsBeats", transportDefaultBarsBeats);
 
@@ -483,6 +484,8 @@ void Config::load() {
     zoomOutSensitivityShift = getDouble("zoomOutSensitivityShift", zoomOutSensitivityShift);
 
     openPluginWindowOnDrop = getBool("openPluginWindowOnDrop", openPluginWindowOnDrop);
+    skipFourOscConversionPrompt =
+        getBool("skipFourOscConversionPrompt", skipFourOscConversionPrompt);
     transportShowBothFormats = getBool("transportShowBothFormats", transportShowBothFormats);
     transportDefaultBarsBeats = getBool("transportDefaultBarsBeats", transportDefaultBarsBeats);
 

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -123,6 +123,15 @@ class Config {
         transportShowBothFormats = show;
     }
 
+    /// Whether the 4OSC conversion prompt has been turned off for good
+    /// (#2437). Set by the "don't ask again" tickbox on the prompt itself.
+    bool getSkipFourOscConversionPrompt() const {
+        return skipFourOscConversionPrompt;
+    }
+    void setSkipFourOscConversionPrompt(bool skip) {
+        skipFourOscConversionPrompt = skip;
+    }
+
     bool getOpenPluginWindowOnDrop() const {
         return openPluginWindowOnDrop;
     }
@@ -1401,6 +1410,7 @@ class Config {
 
     // Open a device's editor window automatically when it is dropped into a chain
     bool openPluginWindowOnDrop = false;
+    bool skipFourOscConversionPrompt = false;
     bool transportDefaultBarsBeats = true;  // Default to bars/beats (false = seconds)
 
     // Panel visibility settings

--- a/magda/daw/core/DeviceParamMigrations.cpp
+++ b/magda/daw/core/DeviceParamMigrations.cpp
@@ -379,14 +379,16 @@ void dropParamLinksInTrack(TrackInfo& track, const std::set<ChainNodePath>& path
                paths.count(target.devicePath) > 0;
     };
 
-    forEachLinkOwnerInTrack(track, [&addressed](MacroArray& macros, ModArray& mods) {
+    const auto dropFromOwner = [&addressed](MacroArray& macros, ModArray& mods) {
+        const auto isAddressed = [&addressed](const auto& link) { return addressed(link.target); };
+
         for (auto& macro : macros)
-            std::erase_if(macro.links,
-                          [&addressed](const MacroLink& link) { return addressed(link.target); });
+            std::erase_if(macro.links, isAddressed);
         for (auto& mod : mods)
-            std::erase_if(mod.links,
-                          [&addressed](const ModLink& link) { return addressed(link.target); });
-    });
+            std::erase_if(mod.links, isAddressed);
+    };
+
+    forEachLinkOwnerInTrack(track, dropFromOwner);
 }
 
 std::vector<AutomationLaneId> lanesAddressing(const std::vector<AutomationLaneInfo>& lanes,

--- a/magda/daw/core/DeviceParamMigrations.cpp
+++ b/magda/daw/core/DeviceParamMigrations.cpp
@@ -373,6 +373,34 @@ void applyParamIndexMigrations(std::vector<TrackInfo>& tracks, TrackInfo* master
     });
 }
 
+void dropParamLinksInTrack(TrackInfo& track, const std::set<ChainNodePath>& paths) {
+    const auto addressed = [&paths](const ControlTarget& target) {
+        return target.kind == ControlTarget::Kind::PluginParam &&
+               paths.count(target.devicePath) > 0;
+    };
+
+    forEachLinkOwnerInTrack(track, [&addressed](MacroArray& macros, ModArray& mods) {
+        for (auto& macro : macros)
+            std::erase_if(macro.links,
+                          [&addressed](const MacroLink& link) { return addressed(link.target); });
+        for (auto& mod : mods)
+            std::erase_if(mod.links,
+                          [&addressed](const ModLink& link) { return addressed(link.target); });
+    });
+}
+
+std::vector<AutomationLaneId> lanesAddressing(const std::vector<AutomationLaneInfo>& lanes,
+                                              const std::set<ChainNodePath>& paths) {
+    std::vector<AutomationLaneId> found;
+
+    for (const auto& lane : lanes)
+        if (lane.target.kind == ControlTarget::Kind::PluginParam &&
+            paths.count(lane.target.devicePath) > 0)
+            found.push_back(lane.id);
+
+    return found;
+}
+
 namespace {
 
 /// Migrate a preset fragment: its devices, then the links its own macros and

--- a/magda/daw/core/DeviceParamMigrations.hpp
+++ b/magda/daw/core/DeviceParamMigrations.hpp
@@ -3,11 +3,13 @@
 #include <juce_core/juce_core.h>
 
 #include <optional>
+#include <set>
 #include <span>
 #include <vector>
 
 #include "DeviceInfo.hpp"
 #include "RackInfo.hpp"
+#include "TypeIds.hpp"
 
 namespace magda {
 
@@ -136,6 +138,22 @@ inline void applyParamIndexMigrations(std::vector<TrackInfo>& tracks, TrackInfo*
                                       std::vector<AutomationClipInfo>& automationClips) {
     applyParamIndexMigrations(tracks, masterTrack, lanes, automationClips, shippedMigrations());
 }
+
+/**
+ * Drop every plugin-parameter link addressing a device at one of @p paths,
+ * whose parameter order was replaced wholesale rather than renumbered (#2437).
+ *
+ * There is no mapping to make: the two devices' parameters are different
+ * controls in different units, and a normalised curve or link amount written
+ * for one says nothing about the other. The path still resolves after the
+ * replacement, so a link left behind drives whatever now sits at that index.
+ */
+void dropParamLinksInTrack(TrackInfo& track, const std::set<ChainNodePath>& paths);
+
+/// The lanes among @p lanes driving a plugin parameter on one of @p paths, for
+/// the caller to delete through whatever owns them.
+std::vector<AutomationLaneId> lanesAddressing(const std::vector<AutomationLaneInfo>& lanes,
+                                              const std::set<ChainNodePath>& paths);
 
 // --- Fragments -------------------------------------------------------------
 //

--- a/magda/daw/core/aliases/TargetResolver.cpp
+++ b/magda/daw/core/aliases/TargetResolver.cpp
@@ -212,9 +212,13 @@ ResolveResult TargetResolver::resolveAt(const ParsedSigil& sigil) const {
     };
     if (const auto found = std::ranges::find_if(devices, matchesPluginType);
         found != devices.end()) {
-        int paramIdx = findParamByKey(*found->device, normalizeParamName(sigil.paramKey));
+        // By name only, as above: the device was matched on its name, which
+        // says nothing about its parameter order.
+        const int paramIdx = findParamByKey(*found->device, normalizeParamName(sigil.paramKey));
         if (paramIdx < 0)
-            paramIdx = stored->paramIndex;
+            return ResolveResult::failure("@" + sigil.pluginKey + "." + sigil.paramKey +
+                                          ": materialised on " + found->device->name +
+                                          ", which has no parameter of that name");
 
         ResolveResult r;
         r.target.devicePath = found->path;

--- a/magda/daw/core/aliases/TargetResolver.cpp
+++ b/magda/daw/core/aliases/TargetResolver.cpp
@@ -46,9 +46,16 @@ ResolveResult TargetResolver::resolve(const Target& target) const {
                 };
                 if (const auto found = std::ranges::find_if(devices, matchesPluginType);
                     found != devices.end()) {
-                    int paramIdx = findParamByKey(*found->device, normalizeParamName(t.name));
+                    // By name only. The device was matched on its name, and
+                    // the stored index counts positions in whatever plugin the
+                    // alias was made against: lending it to this one moves the
+                    // alias onto a neighbouring control, which is the silent
+                    // corruption DeviceParamMigrations.hpp exists to stop.
+                    const int paramIdx = findParamByKey(*found->device, normalizeParamName(t.name));
                     if (paramIdx < 0)
-                        paramIdx = stored->paramIndex;  // fallback to stored index
+                        return ResolveResult::failure("Alias materialised on " +
+                                                      found->device->name +
+                                                      " but it has no parameter named: " + t.name);
 
                     ResolveResult r;
                     r.target.devicePath = found->path;

--- a/magda/daw/project/ProjectInfo.hpp
+++ b/magda/daw/project/ProjectInfo.hpp
@@ -120,6 +120,11 @@ struct ProjectInfo {
     int timelineLengthBars = 256;
 
     // Render / bounce settings (per-project)
+    /// The engine that last wrote this project, by its setting word
+    /// (AudioEngineChoice.hpp). Empty in every project saved before the field
+    /// existed, which is a Tracktion project by definition (#2437).
+    juce::String savedWithEngine;
+
     int renderBitDepth = 24;  // 16, 24, 32
     int bounceBitDepth = 32;  // 16, 24, 32 (default 32-bit float for internal bounces)
 

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -16,6 +16,7 @@
 #include "../core/TrackManager.hpp"
 #include "../core/UndoManager.hpp"
 #include "../engine/AudioEngine.hpp"
+#include "engine/AudioEngineChoice.hpp"
 #include "serialization/ProjectSerializer.hpp"
 #include "version.hpp"
 
@@ -395,6 +396,10 @@ bool ProjectManager::saveProjectAs(const juce::File& file) {
     ProjectInfo newProject = currentProject_;
     newProject.filePath = actualFile.getFullPathName();
     newProject.name = projectName;
+
+    // Which engine wrote it, so opening it under the other one knows whether
+    // this project has been through that engine's migration (#2437).
+    newProject.savedWithEngine = settingWordFor(chosenAudioEngine());
     newProject.touch();
 
     // Save to file

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -131,10 +131,11 @@ enum class OnCollision {
     Skip,
 };
 
-// Move every file under srcDir into dstDir, nested structure intact, recording
-// where each one landed so the references to it can follow.
+// Move or copy every file under srcDir into dstDir, nested structure intact,
+// recording where each one landed so the references to it can follow.
 void moveMediaTree(const juce::File& srcDir, const juce::File& dstDir,
-                   std::map<juce::String, juce::String>& moves, OnCollision onCollision) {
+                   std::map<juce::String, juce::String>& moves, OnCollision onCollision,
+                   ProjectManager::MediaTransfer transfer) {
     if (!srcDir.isDirectory() || srcDir == dstDir)
         return;
 
@@ -150,9 +151,15 @@ void moveMediaTree(const juce::File& srcDir, const juce::File& dstDir,
                 continue;
             dstFile = dstFile.getNonexistentSibling();
         }
-        if (srcFile.moveFileTo(dstFile))
+        const auto landed = transfer == ProjectManager::MediaTransfer::Copy
+                                ? srcFile.copyFileTo(dstFile)
+                                : srcFile.moveFileTo(dstFile);
+        if (landed)
             moves[srcFile.getFullPathName()] = dstFile.getFullPathName();
     }
+
+    if (transfer == ProjectManager::MediaTransfer::Copy)
+        return;
 
     // Only the empty skeleton is left once every file has moved out. A skipped
     // collision keeps the directory alive, and the next load tries it again.
@@ -355,7 +362,7 @@ bool ProjectManager::saveProject() {
     return saveProjectAs(currentFile_);
 }
 
-bool ProjectManager::saveProjectAs(const juce::File& file) {
+bool ProjectManager::saveProjectAs(const juce::File& file, MediaTransfer transfer) {
     // Ensure the .mgd file lives inside a wrapper folder named after the project.
     // If the user picked /path/to/MyProject.mgd, wrap it as /path/to/MyProject/MyProject.mgd.
     // If it's already inside a matching folder, use it as-is.
@@ -381,7 +388,7 @@ bool ProjectManager::saveProjectAs(const juce::File& file) {
     ensureMediaSubdirectories(targetMediaDir);
 
     if (oldMediaDir != juce::File() && oldMediaDir != targetMediaDir && oldMediaDir.isDirectory()) {
-        migrateMediaFiles(oldMediaDir, targetMediaDir);
+        migrateMediaFiles(oldMediaDir, targetMediaDir, transfer);
     }
 
     // Capture live plugin state before serializing. Runs after the migration
@@ -942,7 +949,8 @@ void ProjectManager::ensureMediaSubdirectories(const juce::File& mediaRoot) {
     }
 }
 
-void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir) {
+void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir,
+                                       MediaTransfer transfer) {
     if (!oldDir.isDirectory() || oldDir == newDir)
         return;
 
@@ -953,23 +961,24 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     std::map<juce::String, juce::String> moves;
     for (const auto* subdir : kMediaSubdirs)
         moveMediaTree(oldDir.getChildFile(subdir), newDir.getChildFile(subdir), moves,
-                      OnCollision::Uniquify);
+                      OnCollision::Uniquify, transfer);
 
     // A Save-As from a project opened before #2170 can still be carrying the
     // retired roots, so fold them on the way across rather than stranding them.
     for (const auto& legacy : kLegacyMediaSubdirs)
         moveMediaTree(oldDir.getChildFile(legacy.from), newDir.getChildFile(legacy.to), moves,
-                      OnCollision::Uniquify);
+                      OnCollision::Uniquify, transfer);
 
     relinkMediaPaths([&moves](const juce::String& path) -> juce::String {
         const auto it = moves.find(path);
         return it == moves.end() ? juce::String() : it->second;
     });
 
-    // Remove old temp directory if it's empty or under the temp root
+    // Remove old temp directory if it's empty or under the temp root. A copy
+    // leaves everything it read where it was.
     auto tempRoot =
         juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile(kTempRootDir);
-    if (oldDir.isAChildOf(tempRoot)) {
+    if (transfer == MediaTransfer::Move && oldDir.isAChildOf(tempRoot)) {
         oldDir.deleteRecursively();
     }
 }
@@ -983,7 +992,7 @@ void ProjectManager::foldLegacyMediaDirectories(const juce::File& mediaRoot) {
     std::map<juce::String, juce::String> moves;
     for (const auto& legacy : kLegacyMediaSubdirs)
         moveMediaTree(mediaRoot.getChildFile(legacy.from), mediaRoot.getChildFile(legacy.to), moves,
-                      OnCollision::Skip);
+                      OnCollision::Skip, MediaTransfer::Move);
 
     // Record what moved before relinking. The new paths only reach the .mgd
     // when the user next saves, so without this the next load would have

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -92,12 +92,23 @@ class ProjectManager {
      */
     bool saveProject();
 
+    /// What a Save As does with the media the project is carrying.
+    enum class MediaTransfer {
+        /// The project is moving, so its recordings, renders and imports go
+        /// with it and the old media folder is left empty.
+        Move,
+        /// Both projects stay playable: the new one gets copies and the one
+        /// being saved from keeps the files its .mgd still names (#2437).
+        Copy,
+    };
+
     /**
      * @brief Save project to a new file
      * @param file Target file path
+     * @param transfer What happens to the media folder
      * @return true on success
      */
-    bool saveProjectAs(const juce::File& file);
+    bool saveProjectAs(const juce::File& file, MediaTransfer transfer = MediaTransfer::Move);
 
     /**
      * @brief Load project from file (synchronous)
@@ -396,7 +407,8 @@ class ProjectManager {
     /**
      * @brief Migrate media files from old directory to new, updating clip paths
      */
-    static void migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir);
+    static void migrateMediaFiles(const juce::File& oldDir, const juce::File& newDir,
+                                  MediaTransfer transfer);
 
     /**
      * @brief Fold the media roots retired by #2170 into the surviving three.

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -272,6 +272,8 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
             outData.info.sampleRate = projectObj->getProperty("sampleRate");
         if (projectObj->hasProperty("timelineLengthBars"))
             outData.info.timelineLengthBars = projectObj->getProperty("timelineLengthBars");
+        if (projectObj->hasProperty("savedWithEngine"))
+            outData.info.savedWithEngine = projectObj->getProperty("savedWithEngine").toString();
         if (projectObj->hasProperty("renderBitDepth"))
             outData.info.renderBitDepth = projectObj->getProperty("renderBitDepth");
         if (projectObj->hasProperty("bounceBitDepth"))
@@ -488,6 +490,7 @@ juce::var ProjectSerializer::serializeProject(const ProjectInfo& info) {
     projectObj->setProperty("projectLength", info.projectLength);
     projectObj->setProperty("sampleRate", info.sampleRate);
     projectObj->setProperty("timelineLengthBars", info.timelineLengthBars);
+    projectObj->setProperty("savedWithEngine", info.savedWithEngine);
     projectObj->setProperty("renderBitDepth", info.renderBitDepth);
     projectObj->setProperty("bounceBitDepth", info.bounceBitDepth);
     projectObj->setProperty("keyRoot", info.keyRoot);
@@ -626,6 +629,8 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
         outInfo.sampleRate = projectObj->getProperty("sampleRate");
     if (projectObj->hasProperty("timelineLengthBars"))
         outInfo.timelineLengthBars = projectObj->getProperty("timelineLengthBars");
+    if (projectObj->hasProperty("savedWithEngine"))
+        outInfo.savedWithEngine = projectObj->getProperty("savedWithEngine").toString();
     if (projectObj->hasProperty("renderBitDepth"))
         outInfo.renderBitDepth = projectObj->getProperty("renderBitDepth");
     if (projectObj->hasProperty("bounceBitDepth"))

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -64,6 +64,7 @@
 #include "custom_ui/ToneGeneratorUI.hpp"
 #include "drum_grid/DrumGridUI.hpp"
 #include "engine/AudioEngine.hpp"
+#include "engine/AudioEngineChoice.hpp"
 #include "media_db/ClapAudioEncoder.hpp"
 #include "media_db/ClapTextEncoder.hpp"
 #include "media_db/MediaDbContext.hpp"
@@ -1081,6 +1082,12 @@ bool DeviceCustomUIManager::createMidiUtilityUI(const magda::DeviceInfo& device,
 bool DeviceCustomUIManager::createFourOscUI(const magda::DeviceInfo& device,
                                             juce::Component& parent, const Callbacks& callbacks) {
     if (!device.pluginId.containsIgnoreCase("4osc"))
+        return false;
+
+    // Every control here writes through a te::FourOscPlugin, which the MAGDA
+    // engine never builds. The slot shows the device and nothing to turn
+    // (#2437).
+    if (chosenAudioEngine() == AudioEngineChoice::Magda)
         return false;
 
     fourOscUI_ = std::make_unique<FourOscUI>();

--- a/magda/daw/ui/dialogs/CMakeLists.txt
+++ b/magda/daw/ui/dialogs/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(magda_daw_app PRIVATE
     ControllersDialog.cpp
+    FourOscConversionPrompt.cpp
     ConnectionsDialog.cpp
     AISettingsDialog.cpp
     AudioSettingsDialog.cpp

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
@@ -20,10 +20,17 @@ namespace audio = magda::daw::audio;
 /// component, so the two are held together and read in the callback.
 struct Prompt {
     juce::AlertWindow alert;
-    juce::ToggleButton dontAskAgain{"Don't ask again"};
+
+    // Nameless on purpose. AlertWindow paints a custom component's name as a
+    // label above it (juce_AlertWindow.cpp), and a ToggleButton built from a
+    // string takes that string as its name as well as its text, so the words
+    // appeared twice.
+    juce::ToggleButton dontAskAgain;
 
     Prompt(const juce::String& title, const juce::String& message)
-        : alert(title, message, juce::MessageBoxIconType::QuestionIcon) {}
+        : alert(title, message, juce::MessageBoxIconType::QuestionIcon) {
+        dontAskAgain.setButtonText("Don't ask again");
+    }
 };
 
 /// Convert, then save as a project of its own. The one that was opened is

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
@@ -33,11 +33,10 @@ void convertAndSave() {
     auto& projects = ProjectManager::getInstance();
     const auto destination = audio::convertedProjectFileFor(projects.getCurrentProjectFile());
 
-    if (audio::convertFourOscDevices(TrackManager::getInstance()) == 0)
-        return;
+    audio::convertFourOscDevices(TrackManager::getInstance());
 
-    // An unsaved project has nowhere to sit beside, so it keeps the converted
-    // devices and the user names it at their next save.
+    // An unsaved project has nowhere to sit beside, so it keeps whatever the
+    // conversion did and the user names it at their next save.
     if (destination == juce::File{})
         return;
 
@@ -61,21 +60,32 @@ void offerFourOscConversion() {
     if (Config::getInstance().getSkipFourOscConversionPrompt())
         return;
 
+    auto& projects = ProjectManager::getInstance();
+
+    // Already through this engine's migration, so there is nothing to offer.
+    // An empty word is a project saved before the field existed, which is a
+    // Tracktion project.
+    if (projects.getCurrentProjectInfo().savedWithEngine ==
+        settingWordFor(AudioEngineChoice::Magda))
+        return;
+
+    if (projects.getCurrentProjectFile() == juce::File{})
+        return;
+
     auto& tracks = TrackManager::getInstance();
     const auto* master = tracks.getTrack(MASTER_TRACK_ID);
     if (master == nullptr)
         return;
 
     const auto candidates = audio::findFourOscDevices(tracks.getTracks(), *master);
-    if (candidates.empty())
-        return;
 
-    auto prompt = std::make_shared<Prompt>("Convert 4OSC?", audio::describeConversion(candidates));
+    auto prompt = std::make_shared<Prompt>("Open as a MAGDA engine project?",
+                                           audio::describeMigration(candidates));
 
     prompt->dontAskAgain.setSize(200, 24);
     prompt->alert.addCustomComponent(&prompt->dontAskAgain);
-    prompt->alert.addButton("Convert", 1, juce::KeyPress(juce::KeyPress::returnKey));
-    prompt->alert.addButton("Leave as it is", 0, juce::KeyPress(juce::KeyPress::escapeKey));
+    prompt->alert.addButton("Create it", 1, juce::KeyPress(juce::KeyPress::returnKey));
+    prompt->alert.addButton("Not now", 0, juce::KeyPress(juce::KeyPress::escapeKey));
 
     prompt->alert.enterModalState(true, juce::ModalCallbackFunction::create([prompt](int result) {
                                       // Remembered whichever button was pressed: somebody who ticks

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
@@ -93,7 +93,7 @@ void offerFourOscConversion() {
 
     const auto candidates = audio::findFourOscDevices(tracks.getTracks(), *master);
 
-    auto prompt = std::make_shared<Prompt>("Open as a MAGDA engine project?",
+    auto prompt = std::make_shared<Prompt>("Open as a MAGDA Engine project?",
                                            audio::describeMigration(candidates));
 
     prompt->dontAskAgain.setSize(200, 24);

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
@@ -94,22 +94,21 @@ void offerFourOscConversion() {
     prompt->alert.addButton("Create it", 1, juce::KeyPress(juce::KeyPress::returnKey));
     prompt->alert.addButton("Not now", 0, juce::KeyPress(juce::KeyPress::escapeKey));
 
-    prompt->alert.enterModalState(true, juce::ModalCallbackFunction::create([prompt](int result) {
-                                      // Remembered whichever button was pressed: somebody who ticks
-                                      // it and converts this project does not want asking about the
-                                      // next.
-                                      if (prompt->dontAskAgain.getToggleState())
-                                          Config::getInstance().setSkipFourOscConversionPrompt(
-                                              true);
+    const auto onDismissed = [prompt](int result) {
+        // Remembered whichever button was pressed: somebody who ticks it and
+        // converts this project does not want asking about the next.
+        if (prompt->dontAskAgain.getToggleState())
+            Config::getInstance().setSkipFourOscConversionPrompt(true);
 
-                                      if (result != 1)
-                                          return;
+        if (result != 1)
+            return;
 
-                                      // Off the modal callback, so the alert is gone before a save
-                                      // dialog or an error of its own can appear behind it.
-                                      juce::MessageManager::callAsync([] { convertAndSave(); });
-                                  }),
-                                  false);
+        // Off the modal callback, so the alert is gone before a save dialog or
+        // an error of its own can appear behind it.
+        juce::MessageManager::callAsync([] { convertAndSave(); });
+    };
+
+    prompt->alert.enterModalState(true, juce::ModalCallbackFunction::create(onDismissed), false);
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
@@ -26,20 +26,30 @@ struct Prompt {
         : alert(title, message, juce::MessageBoxIconType::QuestionIcon) {}
 };
 
-void writeBackup() {
-    const auto project = ProjectManager::getInstance().getCurrentProjectFile();
-    const auto backup = audio::backupFileFor(project);
-
-    if (project.existsAsFile() && backup != juce::File{})
-        project.copyFileTo(backup);
-}
-
+/// Convert, then save as a project of its own. The one that was opened is
+/// never written to, so a 4OSC project stays openable on the Tracktion
+/// engine.
 void convertAndSave() {
-    // Before the conversion, so the copy is the project as it was opened.
-    writeBackup();
+    auto& projects = ProjectManager::getInstance();
+    const auto destination = audio::convertedProjectFileFor(projects.getCurrentProjectFile());
 
-    if (audio::convertFourOscDevices(TrackManager::getInstance()) > 0)
-        ProjectManager::getInstance().saveProject();
+    if (audio::convertFourOscDevices(TrackManager::getInstance()) == 0)
+        return;
+
+    // An unsaved project has nowhere to sit beside, so it keeps the converted
+    // devices and the user names it at their next save.
+    if (destination == juce::File{})
+        return;
+
+    if (!projects.saveProjectAs(destination))
+        juce::AlertWindow::showAsync(juce::MessageBoxOptions()
+                                         .withIconType(juce::MessageBoxIconType::WarningIcon)
+                                         .withTitle("Could not save the converted project")
+                                         .withMessage(projects.getLastError() +
+                                                      "\n\nThe conversion is still in this "
+                                                      "session. Save it somewhere with Save As.")
+                                         .withButton("OK"),
+                                     nullptr);
 }
 
 }  // namespace

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
@@ -35,12 +35,19 @@ void convertAndSave() {
 
     audio::convertFourOscDevices(TrackManager::getInstance());
 
+    // The conversion writes the model directly. Without this a failed save
+    // below leaves it in the session with nothing to say it is unsaved, and
+    // the window closes without asking.
+    projects.markDirty();
+
     // An unsaved project has nowhere to sit beside, so it keeps whatever the
     // conversion did and the user names it at their next save.
     if (destination == juce::File{})
         return;
 
-    if (!projects.saveProjectAs(destination))
+    // Copies rather than moves the media: the project being converted stays
+    // where it is and its .mgd still names the files it always did.
+    if (!projects.saveProjectAs(destination, ProjectManager::MediaTransfer::Copy))
         juce::AlertWindow::showAsync(juce::MessageBoxOptions()
                                          .withIconType(juce::MessageBoxIconType::WarningIcon)
                                          .withTitle("Could not save the converted project")

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.cpp
@@ -1,0 +1,88 @@
+#include "FourOscConversionPrompt.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <memory>
+
+#include "audio/FourOscMigration.hpp"
+#include "core/Config.hpp"
+#include "core/TrackManager.hpp"
+#include "engine/AudioEngineChoice.hpp"
+#include "project/ProjectManager.hpp"
+
+namespace magda::daw::ui {
+
+namespace {
+
+namespace audio = magda::daw::audio;
+
+/// The alert and the tickbox it carries. AlertWindow does not own a custom
+/// component, so the two are held together and read in the callback.
+struct Prompt {
+    juce::AlertWindow alert;
+    juce::ToggleButton dontAskAgain{"Don't ask again"};
+
+    Prompt(const juce::String& title, const juce::String& message)
+        : alert(title, message, juce::MessageBoxIconType::QuestionIcon) {}
+};
+
+void writeBackup() {
+    const auto project = ProjectManager::getInstance().getCurrentProjectFile();
+    const auto backup = audio::backupFileFor(project);
+
+    if (project.existsAsFile() && backup != juce::File{})
+        project.copyFileTo(backup);
+}
+
+void convertAndSave() {
+    // Before the conversion, so the copy is the project as it was opened.
+    writeBackup();
+
+    if (audio::convertFourOscDevices(TrackManager::getInstance()) > 0)
+        ProjectManager::getInstance().saveProject();
+}
+
+}  // namespace
+
+void offerFourOscConversion() {
+    if (chosenAudioEngine() != AudioEngineChoice::Magda)
+        return;
+
+    if (Config::getInstance().getSkipFourOscConversionPrompt())
+        return;
+
+    auto& tracks = TrackManager::getInstance();
+    const auto* master = tracks.getTrack(MASTER_TRACK_ID);
+    if (master == nullptr)
+        return;
+
+    const auto candidates = audio::findFourOscDevices(tracks.getTracks(), *master);
+    if (candidates.empty())
+        return;
+
+    auto prompt = std::make_shared<Prompt>("Convert 4OSC?", audio::describeConversion(candidates));
+
+    prompt->dontAskAgain.setSize(200, 24);
+    prompt->alert.addCustomComponent(&prompt->dontAskAgain);
+    prompt->alert.addButton("Convert", 1, juce::KeyPress(juce::KeyPress::returnKey));
+    prompt->alert.addButton("Leave as it is", 0, juce::KeyPress(juce::KeyPress::escapeKey));
+
+    prompt->alert.enterModalState(true, juce::ModalCallbackFunction::create([prompt](int result) {
+                                      // Remembered whichever button was pressed: somebody who ticks
+                                      // it and converts this project does not want asking about the
+                                      // next.
+                                      if (prompt->dontAskAgain.getToggleState())
+                                          Config::getInstance().setSkipFourOscConversionPrompt(
+                                              true);
+
+                                      if (result != 1)
+                                          return;
+
+                                      // Off the modal callback, so the alert is gone before a save
+                                      // dialog or an error of its own can appear behind it.
+                                      juce::MessageManager::callAsync([] { convertAndSave(); });
+                                  }),
+                                  false);
+}
+
+}  // namespace magda::daw::ui

--- a/magda/daw/ui/dialogs/FourOscConversionPrompt.hpp
+++ b/magda/daw/ui/dialogs/FourOscConversionPrompt.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+/**
+ * @file FourOscConversionPrompt.hpp
+ * @brief Offering to convert a project's 4OSC devices (#2437).
+ */
+
+namespace magda::daw::ui {
+
+/**
+ * @brief Offer the conversion, if this project and this engine call for one.
+ *
+ * Does nothing unless the MAGDA engine is the one rendering, the project has
+ * a 4OSC in it, and the prompt has not been switched off. Accepting writes
+ * the project as it stands to a new file, converts, and saves.
+ *
+ * Call after a project opens. Asynchronous: the alert answers on the message
+ * thread and the caller has already returned.
+ */
+void offerFourOscConversion();
+
+}  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -23,6 +23,7 @@
 #include "audio/plugins/SpectrumAnalyzerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
 #include "audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "audio/plugins/engine/EngineDeviceFactory.hpp"
 #include "core/AppPaths.hpp"
 #include "core/Config.hpp"
 #include "core/DeviceInfo.hpp"
@@ -31,6 +32,7 @@
 #include "core/PluginPreferences.hpp"
 #include "core/TrackManager.hpp"
 #include "engine/AudioEngine.hpp"
+#include "engine/AudioEngineChoice.hpp"
 #include "engine/PluginMetadataStore.hpp"
 
 namespace magda::daw::ui {
@@ -560,8 +562,12 @@ std::vector<PluginBrowserInfo> PluginBrowserContent::getInternalPlugins() {
     // Native + TE internal devices: the registry is the single source of truth.
     // A device appears here by setting showInBrowser on its InternalPluginSpec -
     // no separate hand-maintained list to keep in sync.
-    const auto listedInBrowser = [](const audio::InternalPluginSpec* spec) {
-        return spec->showInBrowser;
+    // Under the MAGDA engine a device with no native factory cannot be built
+    // at all, so listing it would offer something that arrives silent (#2437).
+    const auto runnable = chosenAudioEngine() != AudioEngineChoice::Magda;
+    const auto listedInBrowser = [runnable](const audio::InternalPluginSpec* spec) {
+        return spec->showInBrowser &&
+               (runnable || audio::engine_adapter::canCreateEngineDevice(spec->pluginId));
     };
     const auto asBrowserEntry = [](const audio::InternalPluginSpec* spec) {
         return PluginBrowserInfo::createInternal(spec->displayName, spec->pluginId,

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -14,6 +14,7 @@
 #include "../dialogs/AudioSettingsDialog.hpp"
 #include "../dialogs/ControllersDialog.hpp"
 #include "../dialogs/ExportAudioDialog.hpp"
+#include "../dialogs/FourOscConversionPrompt.hpp"
 #include "../dialogs/PreferencesDialog.hpp"
 #include "../dialogs/TrackManagerDialog.hpp"
 #include "../layout/LayoutConfig.hpp"
@@ -518,6 +519,7 @@ void MainWindow::updateWindowTitle() {
 
 void MainWindow::projectOpened(const ProjectInfo&) {
     updateWindowTitle();
+    daw::ui::offerFourOscConversion();
 }
 
 void MainWindow::projectSaved(const ProjectInfo&) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -342,6 +342,7 @@ set(TEST_SOURCES
     audio/test_demucs_separator.cpp
     audio/test_spleeter_separator.cpp
     core/test_device_info_predicates.cpp
+    core/test_four_osc_translation.cpp
     core/test_ranges_helpers.cpp
 )
 

--- a/tests/controllers/test_alias_resolver.cpp
+++ b/tests/controllers/test_alias_resolver.cpp
@@ -175,6 +175,45 @@ TEST_CASE("A pathless alias resolves by parameter name or not at all", "[aliases
     CHECK(found.target.paramIndex == 0);
 }
 
+TEST_CASE("A sigil materialising on a renamed device resolves by name only",
+          "[aliases][resolver]") {
+    // The same rule as resolve(AliasRef), on the @plugin.param path. A device
+    // somebody named keeps that name through a plugin swap, so its name still
+    // matches an alias made against what used to be there; its parameter order
+    // does not.
+    DeviceInfo renamed = makeDevice(10, "Bass", {"Cutoff", "Resonance"});
+
+    FixedChainContext ctx;
+    ctx.addDevice(makePath(1, 10), renamed);
+
+    auto& reg = AliasRegistry::getInstance();
+    reg.clearLayer(AliasLayer::UserProject);
+    reg.clearLayer(AliasLayer::UserGlobal);
+    reg.clearLayer(AliasLayer::Curated);
+    reg.clearLayer(AliasLayer::AutoGen);
+
+    StoredAlias alias;
+    alias.pluginTypeKey = "bass";
+    alias.paramIndex = 1;  // "Resonance" here, something else where it was made
+
+    auto& resolvers = ResolverRegistry::getInstance();
+    TargetResolver resolver{reg, resolvers, ctx};
+
+    reg.set(AliasLayer::UserGlobal, "bass.unison_detune", alias);
+    const auto missing = tryParse("@bass.unison_detune");
+    REQUIRE(missing.has_value());
+    CHECK_FALSE(resolver.resolveSigil(*missing).ok());
+
+    // A name the device does have still resolves, to that parameter's index.
+    reg.set(AliasLayer::UserGlobal, "bass.cutoff", alias);
+    const auto present = tryParse("@bass.cutoff");
+    REQUIRE(present.has_value());
+
+    const auto found = resolver.resolveSigil(*present);
+    REQUIRE(found.ok());
+    CHECK(found.target.paramIndex == 0);
+}
+
 TEST_CASE("@ resolution prefers selected-chain devices over registry", "[aliases][resolver]") {
     // A device named "Serum" lives on the selected track (track 1).
     // The AliasRegistry also has a type-level alias for "serum.cutoff" pointing

--- a/tests/controllers/test_alias_resolver.cpp
+++ b/tests/controllers/test_alias_resolver.cpp
@@ -143,6 +143,38 @@ TEST_CASE("TargetResolver - resolve unknown ResolverRef kind fails", "[aliases][
 // @ sigil - selected-chain device preference
 // ============================================================================
 
+TEST_CASE("A pathless alias resolves by parameter name or not at all", "[aliases][resolver]") {
+    // The device was matched on its name, which says nothing about its
+    // parameter ORDER. Lending it the index the alias stored for whatever it
+    // was made against puts the alias on a neighbouring control.
+    DeviceInfo synth = makeDevice(10, "Poly Synth", {"Cutoff", "Resonance"});
+
+    FixedChainContext ctx;
+    ctx.addDevice(makePath(1, 10), synth);
+
+    auto& reg = AliasRegistry::getInstance();
+    reg.clearLayer(AliasLayer::UserProject);
+    reg.clearLayer(AliasLayer::UserGlobal);
+    reg.clearLayer(AliasLayer::Curated);
+    reg.clearLayer(AliasLayer::AutoGen);
+
+    StoredAlias alias;
+    alias.pluginTypeKey = "polysynth";  // pluginNameToAlias("Poly Synth")
+    alias.paramIndex = 1;               // "Resonance" here, something else where it was made
+
+    auto& resolvers = ResolverRegistry::getInstance();
+    TargetResolver resolver{reg, resolvers, ctx};
+
+    reg.set(AliasLayer::UserGlobal, "detune", alias);
+    CHECK_FALSE(resolver.resolve(Target{AliasRef{"detune", "polysynth"}}).ok());
+
+    // A name the device does have resolves to that parameter's own index.
+    reg.set(AliasLayer::UserGlobal, "cutoff", alias);
+    const auto found = resolver.resolve(Target{AliasRef{"cutoff", "polysynth"}});
+    REQUIRE(found.ok());
+    CHECK(found.target.paramIndex == 0);
+}
+
 TEST_CASE("@ resolution prefers selected-chain devices over registry", "[aliases][resolver]") {
     // A device named "Serum" lives on the selected track (track 1).
     // The AliasRegistry also has a type-level alias for "serum.cutoff" pointing

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -159,6 +159,24 @@ TEST_CASE("A patch that wrote nothing lands on 4OSC's defaults", "[core][4osc]")
     CHECK(translated.gaps.empty());
 }
 
+TEST_CASE("A stock-named 4OSC does not stay called 4OSC", "[core][4osc]") {
+    // A pathless alias materialises against the device whose normalised NAME
+    // matches its key, so a device still called 4OSC answers for 4OSC's
+    // aliases after the swap.
+    auto stock = FourOscPatch{}.build();
+    stock.name = "4OSC";
+    CHECK(magda::daw::audio::translateFourOsc(stock).device.name == "Poly Synth");
+
+    auto registered = FourOscPatch{}.build();
+    registered.name = "4OSC Synth";
+    CHECK(magda::daw::audio::translateFourOsc(registered).device.name == "Poly Synth");
+
+    // A name somebody chose is theirs.
+    auto named = FourOscPatch{}.build();
+    named.name = "Bass";
+    CHECK(magda::daw::audio::translateFourOsc(named).device.name == "Bass");
+}
+
 TEST_CASE("What the host owns on the slot survives the swap", "[core][4osc]") {
     // The gain knob, the macros and the modulators belong to the device in the
     // chain, not to the plugin being replaced underneath it. Building the

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -1,9 +1,11 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "magda/daw/audio/FourOscMigration.hpp"
 #include "magda/daw/audio/FourOscTranslation.hpp"
 #include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
 #include "magda/daw/core/DeviceState.hpp"
+#include "magda/daw/core/TrackInfo.hpp"
 
 /**
  * 4OSC to Poly Synth (#2437).
@@ -245,4 +247,86 @@ TEST_CASE("A patch using nothing Poly Synth lacks reports no gaps", "[core][4osc
                            .build();
 
     CHECK(magda::daw::audio::translateFourOsc(patch).gaps.empty());
+}
+
+TEST_CASE("Every 4OSC in a project is found, pads included", "[core][4osc]") {
+    magda::TrackInfo track;
+    track.id = magda::TrackId{1};
+    track.chain.fxChainElements.emplace_back(FourOscPatch{}.property("waveShape1", 3).build());
+
+    magda::DeviceInfo other;
+    other.id = magda::DeviceId{9};
+    other.pluginId = PolySynth::xmlTypeName;
+    track.chain.fxChainElements.emplace_back(std::move(other));
+
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+
+    const auto found = magda::daw::audio::findFourOscDevices({track}, master);
+    REQUIRE(found.size() == 1);
+    CHECK(found.front().deviceName == "4OSC");
+}
+
+TEST_CASE("A project with no 4OSC has nothing to ask about", "[core][4osc]") {
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+
+    CHECK(magda::daw::audio::findFourOscDevices({}, master).empty());
+    CHECK(magda::daw::audio::describeConversion({}).isEmpty());
+}
+
+TEST_CASE("The conversion prompt names what will be lost", "[core][4osc]") {
+    // "Some settings may change" tells somebody to expect a difference
+    // without telling them what to listen for.
+    magda::TrackInfo track;
+    track.id = magda::TrackId{1};
+    track.chain.fxChainElements.emplace_back(
+        FourOscPatch{}.property("waveShape1", 3).property("voices1", 4).build());
+
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+
+    const auto text = magda::daw::audio::describeConversion(
+        magda::daw::audio::findFourOscDevices({track}, master));
+
+    CHECK(text.contains("Poly Synth"));
+    CHECK(text.contains("Unison"));
+    CHECK(text.contains("saved alongside"));
+}
+
+TEST_CASE("A patch losing nothing is not warned about", "[core][4osc]") {
+    magda::TrackInfo track;
+    track.id = magda::TrackId{1};
+    track.chain.fxChainElements.emplace_back(FourOscPatch{}.property("waveShape1", 3).build());
+
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+
+    const auto text = magda::daw::audio::describeConversion(
+        magda::daw::audio::findFourOscDevices({track}, master));
+
+    CHECK(text.contains("somewhere to go"));
+    CHECK_FALSE(text.contains("will be lost"));
+}
+
+TEST_CASE("The backup sits beside the project and never overwrites", "[core][4osc]") {
+    const auto project = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                             .getChildFile("FourOscMigration")
+                             .getChildFile("Song.mgd");
+    project.getParentDirectory().createDirectory();
+
+    const auto backup = magda::daw::audio::backupFileFor(project);
+    CHECK(backup.getParentDirectory() == project.getParentDirectory());
+    CHECK(backup.getFileName() == "Song (4OSC).mgd");
+
+    // Converting twice must not take the first copy with it.
+    backup.replaceWithText("first");
+    CHECK(magda::daw::audio::backupFileFor(project).getFileName() != backup.getFileName());
+
+    backup.deleteFile();
+    project.getParentDirectory().deleteRecursively();
+}
+
+TEST_CASE("A project that was never saved has no backup to write", "[core][4osc]") {
+    CHECK(magda::daw::audio::backupFileFor(juce::File{}) == juce::File{});
 }

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -8,6 +8,7 @@
 #include "magda/daw/core/DeviceState.hpp"
 #include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/TrackInfo.hpp"
+#include "magda/daw/core/TrackManager.hpp"
 
 /**
  * 4OSC to Poly Synth (#2437).
@@ -284,7 +285,8 @@ TEST_CASE("The conversion prompt names what will be lost", "[core][4osc]") {
 
     CHECK(text.contains("Poly Synth"));
     CHECK(text.contains("Unison"));
-    CHECK(text.contains("saved alongside"));
+    CHECK(text.contains("saved as a new file"));
+    CHECK(text.contains("cannot be turned"));
 }
 
 TEST_CASE("A patch losing nothing is not warned about", "[core][4osc]") {
@@ -392,4 +394,37 @@ TEST_CASE("4OSC's master level becomes the synth's output gain", "[core][4osc]")
 
     CHECK(slotValue(magda::daw::audio::translateFourOsc(patch).device,
                     PolySynth::kOutputGainSlot) == Catch::Approx(-6.0f));
+}
+
+TEST_CASE("Converting a project replaces the synth and adds its effects",
+          "[core][4osc][.singleton]") {
+    auto& tracks = magda::TrackManager::getInstance();
+    const auto trackId = tracks.createTrack("Synth");
+
+    tracks.addDeviceToTrack(
+        trackId, FourOscPatch{}.property("waveShape1", 3).property("reverbOn", 1).build());
+
+    // addDeviceToTrack hands out the id, so read it back rather than assume.
+    const auto* placed = tracks.getTrack(trackId);
+    REQUIRE(placed != nullptr);
+    REQUIRE(placed->chain.fxChainElements.size() == 1);
+    const auto synthId = magda::getDevice(placed->chain.fxChainElements.front()).id;
+
+    CHECK(magda::daw::audio::convertFourOscDevices(tracks) == 1);
+
+    const auto* track = tracks.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    const auto& elements = track->chain.fxChainElements;
+    REQUIRE(elements.size() == 2);
+
+    // The synth keeps its place and its id; the rack goes directly after it,
+    // so it reaches the same signal 4OSC's own effects did.
+    CHECK(magda::getDevice(elements[0]).pluginId == juce::String(PolySynth::xmlTypeName));
+    CHECK(magda::getDevice(elements[0]).id == synthId);
+    REQUIRE(magda::isRack(elements[1]));
+    CHECK(magda::getRack(elements[1]).name == "4OSC FX");
+
+    // And a second pass finds nothing left to do.
+    CHECK(magda::daw::audio::convertFourOscDevices(tracks) == 0);
 }

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -366,7 +366,7 @@ TEST_CASE("A project with no 4OSC has nothing to ask about", "[core][4osc]") {
     master.id = magda::MASTER_TRACK_ID;
 
     CHECK(magda::daw::audio::findFourOscDevices({}, master).empty());
-    CHECK(magda::daw::audio::describeMigration({}).contains("Tracktion engine"));
+    CHECK(magda::daw::audio::describeMigration({}).contains("Tracktion Engine"));
 }
 
 TEST_CASE("The conversion prompt names what will be lost", "[core][4osc]") {
@@ -413,7 +413,7 @@ TEST_CASE("The converted project is a new project beside the old one", "[core][4
     // Unwrapped: saveProjectAs() makes the folder, and skips making it when
     // the file already looks wrapped.
     const auto converted = magda::daw::audio::convertedProjectFileFor(project);
-    CHECK(converted.getFileName() == "Song (magda engine).mgd");
+    CHECK(converted.getFileName() == "Song (MAGDA Engine).mgd");
     CHECK(converted.getParentDirectory() == root);
 
     root.deleteRecursively();

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -522,7 +522,7 @@ TEST_CASE("4OSC's master level becomes the synth's output gain", "[core][4osc]")
                     PolySynth::kOutputGainSlot) == Catch::Approx(-6.0f));
 }
 
-TEST_CASE("A patch with effects puts both gains after the rack", "[core][4osc]") {
+TEST_CASE("A patch with effects puts both gains after the effects", "[core][4osc]") {
     // 4OSC applies its master level after all four effects, and the slot's own
     // trim after the whole plugin. Left on the synth, both would sit in front
     // of the distortion and change its drive.
@@ -539,11 +539,48 @@ TEST_CASE("A patch with effects puts both gains after the rack", "[core][4osc]")
     const auto translated = magda::daw::audio::translateFourOsc(source, nextEffectId);
 
     REQUIRE(translated.effects != nullptr);
-    CHECK(translated.effects->volume == Catch::Approx(-9.0f));
+    const auto& chain = translated.effects->chains.front();
+    CHECK(chain.volume == Catch::Approx(-6.0f));
+
+    const auto& last = magda::getDevice(chain.elements.back());
+    CHECK(last.gainDb == Catch::Approx(-3.0f));
+    CHECK(last.gainValue == Catch::Approx(0.7f));
 
     CHECK(slotValue(translated.device, PolySynth::kOutputGainSlot) == Catch::Approx(0.0f));
     CHECK(translated.device.gainDb == Catch::Approx(0.0f));
     CHECK(translated.device.gainValue == Catch::Approx(1.0f));
+}
+
+TEST_CASE("A silent patch with effects stays silent", "[core][4osc]") {
+    // 4OSC's master level reaches -100 dB, which is silence, and no parameter
+    // slot in MAGDA goes below -60. The chain fader does: -100 is the engine's
+    // minus infinity (PlanValues.cpp).
+    const auto patch =
+        FourOscPatch{}.property("reverbOn", 1).parameter("masterLevel", -100.0f).build();
+
+    auto next = magda::DeviceId{100};
+    const auto nextEffectId = [&next] { return next++; };
+    const auto translated = magda::daw::audio::translateFourOsc(patch, nextEffectId);
+
+    REQUIRE(translated.effects != nullptr);
+    CHECK(translated.effects->chains.front().volume == Catch::Approx(-100.0f));
+}
+
+TEST_CASE("A trim above what a fader holds survives the move", "[core][4osc]") {
+    // A device trim reaches +12 dB where every fader stops at +6, which is why
+    // the trim moves to another device's trim rather than onto the rack.
+    auto source = FourOscPatch{}.property("reverbOn", 1).build();
+    source.gainDb = 12.0f;
+    source.gainValue = 3.98f;
+
+    auto next = magda::DeviceId{100};
+    const auto nextEffectId = [&next] { return next++; };
+    const auto translated = magda::daw::audio::translateFourOsc(source, nextEffectId);
+
+    REQUIRE(translated.effects != nullptr);
+    const auto& last = magda::getDevice(translated.effects->chains.front().elements.back());
+    CHECK(last.gainDb == Catch::Approx(12.0f));
+    CHECK(last.gainValue == Catch::Approx(3.98f));
 }
 
 TEST_CASE("Converting a project replaces the synth and adds its effects",

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -133,6 +133,25 @@ TEST_CASE("The translation keeps the device's identity", "[core][4osc]") {
     CHECK(translated.device.isInstrument);
 }
 
+TEST_CASE("A patch that wrote nothing lands on 4OSC's defaults", "[core][4osc]") {
+    // TE writes only what differs from a property's default, so a patch left
+    // alone arrives with no parameters and no properties at all. Poly Synth's
+    // own defaults are a different sound: osc 1 sits at -12 dB where 4OSC
+    // sits at 0, and the amp envelope is 5/200/70%/400 ms against 100/100/80%/
+    // 100 ms.
+    const auto translated = magda::daw::audio::translateFourOsc(FourOscPatch{}.build());
+    const auto& device = translated.device;
+
+    CHECK(slotValue(device, oscSlot(1, 1)) == Catch::Approx(0.0f));
+    CHECK(slotValue(device, PolySynth::kAmpAttackSlot) == Catch::Approx(100.0f));
+    CHECK(slotValue(device, PolySynth::kAmpDecaySlot) == Catch::Approx(100.0f));
+    CHECK(slotValue(device, PolySynth::kAmpSustainSlot) == Catch::Approx(0.8f));
+    CHECK(slotValue(device, PolySynth::kAmpReleaseSlot) == Catch::Approx(100.0f));
+
+    // Nothing was set, so nothing is worth reporting as lost.
+    CHECK(translated.gaps.empty());
+}
+
 TEST_CASE("An oscillator's wave, tune and level carry over", "[core][4osc]") {
     const auto patch = FourOscPatch{}
                            .property("waveShape1", 5)  // square

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -419,7 +419,8 @@ TEST_CASE("The built-in effects become a rack of MAGDA devices", "[core][4osc]")
                            .build();
 
     auto next = magda::DeviceId{100};
-    const auto translated = magda::daw::audio::translateFourOsc(patch, [&next] { return next++; });
+    const auto nextEffectId = [&next] { return next++; };
+    const auto translated = magda::daw::audio::translateFourOsc(patch, nextEffectId);
 
     REQUIRE(translated.effects != nullptr);
     REQUIRE(translated.effects->chains.size() == 1);
@@ -453,8 +454,8 @@ TEST_CASE("The delay is synced to the beat value 4OSC held", "[core][4osc]") {
             patch.floatProperty("delay", beats);
 
         auto next = magda::DeviceId{100};
-        const auto translated =
-            magda::daw::audio::translateFourOsc(patch.build(), [&next] { return next++; });
+        const auto nextEffectId = [&next] { return next++; };
+        const auto translated = magda::daw::audio::translateFourOsc(patch.build(), nextEffectId);
 
         REQUIRE(translated.effects != nullptr);
         const auto& elements = translated.effects->chains.front().elements;
@@ -486,7 +487,8 @@ TEST_CASE("Only the effects that were switched on are built", "[core][4osc]") {
     const auto patch = FourOscPatch{}.property("reverbOn", 1).build();
 
     auto next = magda::DeviceId{100};
-    const auto translated = magda::daw::audio::translateFourOsc(patch, [&next] { return next++; });
+    const auto nextEffectId = [&next] { return next++; };
+    const auto translated = magda::daw::audio::translateFourOsc(patch, nextEffectId);
 
     REQUIRE(translated.effects != nullptr);
     REQUIRE(translated.effects->chains.front().elements.size() == 1);
@@ -497,8 +499,8 @@ TEST_CASE("A patch with no effects on builds no rack", "[core][4osc]") {
     const auto patch = FourOscPatch{}.property("waveShape1", 3).build();
 
     auto next = magda::DeviceId{100};
-    CHECK(magda::daw::audio::translateFourOsc(patch, [&next] { return next++; }).effects ==
-          nullptr);
+    const auto nextEffectId = [&next] { return next++; };
+    CHECK(magda::daw::audio::translateFourOsc(patch, nextEffectId).effects == nullptr);
 }
 
 TEST_CASE("The effects are no longer reported as losses", "[core][4osc]") {
@@ -506,7 +508,8 @@ TEST_CASE("The effects are no longer reported as losses", "[core][4osc]") {
     const auto patch = FourOscPatch{}.property("reverbOn", 1).property("delayOn", 1).build();
 
     auto next = magda::DeviceId{100};
-    const auto translated = magda::daw::audio::translateFourOsc(patch, [&next] { return next++; });
+    const auto nextEffectId = [&next] { return next++; };
+    const auto translated = magda::daw::audio::translateFourOsc(patch, nextEffectId);
 
     CHECK_FALSE(mentions(translated.gaps, "Reverb"));
     CHECK_FALSE(mentions(translated.gaps, "Delay"));

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -5,6 +5,7 @@
 #include "magda/daw/audio/FourOscMigration.hpp"
 #include "magda/daw/audio/FourOscTranslation.hpp"
 #include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
+#include "magda/daw/core/ChainWalk.hpp"
 #include "magda/daw/core/DeviceState.hpp"
 #include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/TrackInfo.hpp"
@@ -474,6 +475,48 @@ TEST_CASE("Converting a project replaces the synth and adds its effects",
 
     // And a second pass finds nothing left to do.
     CHECK(magda::daw::audio::convertFourOscDevices(tracks) == 0);
+}
+
+TEST_CASE("A link into the 4OSC's parameters goes with the 4OSC", "[core][4osc][.singleton]") {
+    // Poly Synth's parameters are different controls at the same indices, so a
+    // link the conversion left behind would drive the wrong one: 4OSC's Tune 1
+    // is Poly Synth's Osc 1 Wave.
+    auto& tracks = magda::TrackManager::getInstance();
+    const auto trackId = tracks.createTrack("Synth");
+
+    tracks.addDeviceToTrack(trackId, FourOscPatch{}.property("waveShape1", 3).build());
+
+    magda::DeviceInfo other;
+    other.name = "Utility";
+    other.pluginId = "magda_utility";
+    other.format = magda::PluginFormat::Internal;
+    tracks.addDeviceToTrack(trackId, other);
+
+    auto* placed = tracks.getTrack(trackId);
+    REQUIRE(placed != nullptr);
+    REQUIRE(placed->chain.fxChainElements.size() == 2);
+
+    const auto synthPath =
+        magda::chain_walk::deviceIn(magda::ChainNodePath::trackLevel(trackId),
+                                    magda::getDevice(placed->chain.fxChainElements[0]).id);
+    const auto otherPath =
+        magda::chain_walk::deviceIn(magda::ChainNodePath::trackLevel(trackId),
+                                    magda::getDevice(placed->chain.fxChainElements[1]).id);
+
+    placed->macros[0].links.push_back({magda::ControlTarget::pluginParam(synthPath, 0), 1.0f});
+    placed->macros[0].links.push_back({magda::ControlTarget::pluginParam(otherPath, 0), 1.0f});
+    placed->macros[1].links.push_back({magda::ControlTarget::deviceMacro(synthPath, 0), 1.0f});
+
+    CHECK(magda::daw::audio::convertFourOscDevices(tracks) == 1);
+
+    const auto* track = tracks.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    REQUIRE(track->macros[0].links.size() == 1);
+    CHECK(track->macros[0].links.front().target.devicePath == otherPath);
+
+    // A macro knob is a macro knob on either device, so that link stays.
+    CHECK(track->macros[1].links.size() == 1);
 }
 
 TEST_CASE("A 4OSC saved as legacy engine XML still translates", "[core][4osc]") {

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -285,8 +285,7 @@ TEST_CASE("The conversion prompt names what will be lost", "[core][4osc]") {
 
     CHECK(text.contains("Poly Synth"));
     CHECK(text.contains("Unison"));
-    CHECK(text.contains("saved as a new file"));
-    CHECK(text.contains("cannot be turned"));
+    CHECK(text.contains("saved alongside this one"));
 }
 
 TEST_CASE("A patch losing nothing is not warned about", "[core][4osc]") {
@@ -304,26 +303,24 @@ TEST_CASE("A patch losing nothing is not warned about", "[core][4osc]") {
     CHECK_FALSE(text.contains("will be lost"));
 }
 
-TEST_CASE("The backup sits beside the project and never overwrites", "[core][4osc]") {
-    const auto project = juce::File::getSpecialLocation(juce::File::tempDirectory)
-                             .getChildFile("FourOscMigration")
-                             .getChildFile("Song.mgd");
+TEST_CASE("The converted project is a new project beside the old one", "[core][4osc]") {
+    // A MAGDA project is a folder holding its .mgd, so the new one is the
+    // folder's neighbour rather than a stray file inside it.
+    const auto root =
+        juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("FourOscMigration");
+    const auto project = root.getChildFile("Song").getChildFile("Song.mgd");
     project.getParentDirectory().createDirectory();
 
-    const auto backup = magda::daw::audio::backupFileFor(project);
-    CHECK(backup.getParentDirectory() == project.getParentDirectory());
-    CHECK(backup.getFileName() == "Song (4OSC).mgd");
+    const auto converted = magda::daw::audio::convertedProjectFileFor(project);
+    CHECK(converted.getFileName() == "Song (Poly Synth).mgd");
+    CHECK(converted.getParentDirectory().getFileName() == "Song (Poly Synth)");
+    CHECK(converted.getParentDirectory().getParentDirectory() == root);
 
-    // Converting twice must not take the first copy with it.
-    backup.replaceWithText("first");
-    CHECK(magda::daw::audio::backupFileFor(project).getFileName() != backup.getFileName());
-
-    backup.deleteFile();
-    project.getParentDirectory().deleteRecursively();
+    root.deleteRecursively();
 }
 
-TEST_CASE("A project that was never saved has no backup to write", "[core][4osc]") {
-    CHECK(magda::daw::audio::backupFileFor(juce::File{}) == juce::File{});
+TEST_CASE("A project that was never saved has nowhere to sit beside", "[core][4osc]") {
+    CHECK(magda::daw::audio::convertedProjectFileFor(juce::File{}) == juce::File{});
 }
 
 TEST_CASE("The built-in effects become a rack of MAGDA devices", "[core][4osc]") {
@@ -427,4 +424,38 @@ TEST_CASE("Converting a project replaces the synth and adds its effects",
 
     // And a second pass finds nothing left to do.
     CHECK(magda::daw::audio::convertFourOscDevices(tracks) == 0);
+}
+
+TEST_CASE("A 4OSC saved as legacy engine XML still translates", "[core][4osc]") {
+    // The format a project old enough to hold a 4OSC actually uses.
+    // device_state::decode() refuses it, and reading nothing there left every
+    // oscillator looking like "none" and the converted synth silent.
+    magda::DeviceInfo device;
+    device.id = magda::DeviceId{3};
+    device.name = "4OSC";
+    device.pluginId = "4osc";
+    device.isInstrument = true;
+    device.format = magda::PluginFormat::Internal;
+    device.pluginState = R"(<PLUGIN type="4osc" waveShape1="3" waveShape2="1" filterType="1"
+                                    voiceMode="0"/>)";
+
+    const auto translated = magda::daw::audio::translateFourOsc(device);
+
+    CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot) == 1.0f);
+    CHECK(slotValue(translated.device, oscSlot(1, 0)) == 1.0f);  // sawUp -> Saw
+    CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot + 1) == 1.0f);
+    CHECK(slotValue(translated.device, oscSlot(2, 0)) == 0.0f);              // sine
+    CHECK(slotValue(translated.device, PolySynth::kVoiceModeSlot) == 1.0f);  // mono
+}
+
+TEST_CASE("A patch whose oscillators are all off is not silently enabled", "[core][4osc]") {
+    // The other side of the same bug: "none" everywhere really does mean
+    // silence, and must not be confused with state that could not be read.
+    magda::DeviceInfo device;
+    device.pluginId = "4osc";
+    device.pluginState = R"(<PLUGIN type="4osc" waveShape1="0"/>)";
+
+    const auto translated = magda::daw::audio::translateFourOsc(device);
+    for (auto osc = 0; osc < 4; ++osc)
+        CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot + osc) == 0.0f);
 }

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -4,6 +4,7 @@
 
 #include "magda/daw/audio/FourOscMigration.hpp"
 #include "magda/daw/audio/FourOscTranslation.hpp"
+#include "magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.hpp"
 #include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
 #include "magda/daw/core/ChainWalk.hpp"
 #include "magda/daw/core/DeviceState.hpp"
@@ -82,6 +83,11 @@ class FourOscPatch {
         return *this;
     }
 
+    FourOscPatch& floatProperty(const juce::String& name, float value) {
+        props_.set(name, value);
+        return *this;
+    }
+
     DeviceInfo build() {
         magda::device_state::Doc doc;
         doc.deviceType = "4osc";
@@ -151,6 +157,31 @@ TEST_CASE("A patch that wrote nothing lands on 4OSC's defaults", "[core][4osc]")
 
     // Nothing was set, so nothing is worth reporting as lost.
     CHECK(translated.gaps.empty());
+}
+
+TEST_CASE("What the host owns on the slot survives the swap", "[core][4osc]") {
+    // The gain knob, the macros and the modulators belong to the device in the
+    // chain, not to the plugin being replaced underneath it. Building the
+    // replacement from nothing put a slot trimmed to -6 dB back at unity.
+    auto source = FourOscPatch{}.build();
+    source.gainValue = 0.5f;
+    source.gainDb = -6.0f;
+    source.macros[0].name = "Brightness";
+    source.macros[0].value = 0.25f;
+    source.modPanelOpen = true;
+
+    const auto translated = magda::daw::audio::translateFourOsc(source);
+
+    CHECK(translated.device.gainValue == Catch::Approx(0.5f));
+    CHECK(translated.device.gainDb == Catch::Approx(-6.0f));
+    CHECK(translated.device.macros[0].name == "Brightness");
+    CHECK(translated.device.macros[0].value == Catch::Approx(0.25f));
+    CHECK(translated.device.modPanelOpen);
+
+    // And nothing of 4OSC's own goes with it.
+    CHECK(translated.device.pluginState.isEmpty());
+    CHECK(translated.device.parameters.size() ==
+          static_cast<std::size_t>(PolySynth{}.parameterCount()));
 }
 
 TEST_CASE("An oscillator's wave, tune and level carry over", "[core][4osc]") {
@@ -405,6 +436,50 @@ TEST_CASE("The built-in effects become a rack of MAGDA devices", "[core][4osc]")
     std::set<magda::DeviceId> ids{patch.id};
     for (const auto& element : elements)
         CHECK(ids.insert(magda::getDevice(element).id).second);
+}
+
+TEST_CASE("The delay is synced to the beat value 4OSC held", "[core][4osc]") {
+    // 4OSC divides its delay by the tempo when it renders, so its number is
+    // beats. The Division slot stores the menu entry's POSITION, not the
+    // quarter-note multiplier the entry carries, and 4OSC's default of one
+    // beat has to reach the entry whose multiplier is 1.0 rather than the
+    // second entry in the list.
+    using Delay = magda::daw::audio::compiled::MagdaDelayCompiledPlugin;
+
+    const auto divisionFor = [](float beats) {
+        juce::NamedValueSet props;
+        auto patch = FourOscPatch{}.property("delayOn", 1);
+        if (beats != 1.0f)
+            patch.floatProperty("delay", beats);
+
+        auto next = magda::DeviceId{100};
+        const auto translated =
+            magda::daw::audio::translateFourOsc(patch.build(), [&next] { return next++; });
+
+        REQUIRE(translated.effects != nullptr);
+        const auto& elements = translated.effects->chains.front().elements;
+        REQUIRE(elements.size() == 1);
+
+        const auto& delay = magda::getDevice(elements.front());
+        CHECK(slotValue(delay, Delay::kSyncSlot) == 1.0f);
+        return static_cast<int>(slotValue(delay, Delay::kDivisionSlot));
+    };
+
+    const Delay metadata;
+    const auto values = metadata.menuValuesForIdx(Delay::kDivisionSlot);
+    REQUIRE(!values.empty());
+
+    const auto indexOfMultiplier = [&values](float multiplier) {
+        for (auto index = 0; index < static_cast<int>(values.size()); ++index)
+            if (std::abs(values[static_cast<std::size_t>(index)] - multiplier) < 1e-3f)
+                return index;
+        FAIL("no division worth " << multiplier);
+        return -1;
+    };
+
+    CHECK(divisionFor(1.0f) == indexOfMultiplier(1.0f));
+    CHECK(divisionFor(0.5f) == indexOfMultiplier(0.5f));
+    CHECK(divisionFor(4.0f) == indexOfMultiplier(4.0f));
 }
 
 TEST_CASE("Only the effects that were switched on are built", "[core][4osc]") {

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -522,6 +522,30 @@ TEST_CASE("4OSC's master level becomes the synth's output gain", "[core][4osc]")
                     PolySynth::kOutputGainSlot) == Catch::Approx(-6.0f));
 }
 
+TEST_CASE("A patch with effects puts both gains after the rack", "[core][4osc]") {
+    // 4OSC applies its master level after all four effects, and the slot's own
+    // trim after the whole plugin. Left on the synth, both would sit in front
+    // of the distortion and change its drive.
+    auto source = FourOscPatch{}
+                      .property("distortionOn", 1)
+                      .parameter("masterLevel", -6.0f)
+                      .parameter("distortion", 0.5f)
+                      .build();
+    source.gainDb = -3.0f;
+    source.gainValue = 0.7f;
+
+    auto next = magda::DeviceId{100};
+    const auto nextEffectId = [&next] { return next++; };
+    const auto translated = magda::daw::audio::translateFourOsc(source, nextEffectId);
+
+    REQUIRE(translated.effects != nullptr);
+    CHECK(translated.effects->volume == Catch::Approx(-9.0f));
+
+    CHECK(slotValue(translated.device, PolySynth::kOutputGainSlot) == Catch::Approx(0.0f));
+    CHECK(translated.device.gainDb == Catch::Approx(0.0f));
+    CHECK(translated.device.gainValue == Catch::Approx(1.0f));
+}
+
 TEST_CASE("Converting a project replaces the synth and adds its effects",
           "[core][4osc][.singleton]") {
     auto& tracks = magda::TrackManager::getInstance();

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -1,10 +1,12 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <set>
 
 #include "magda/daw/audio/FourOscMigration.hpp"
 #include "magda/daw/audio/FourOscTranslation.hpp"
 #include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
 #include "magda/daw/core/DeviceState.hpp"
+#include "magda/daw/core/RackInfo.hpp"
 #include "magda/daw/core/TrackInfo.hpp"
 
 /**
@@ -229,15 +231,6 @@ TEST_CASE("Unison is reported rather than translated into something thinner", "[
     CHECK(mentions(magda::daw::audio::translateFourOsc(patch).gaps, "Unison"));
 }
 
-TEST_CASE("The built-in effects are reported as devices to add", "[core][4osc]") {
-    const auto patch = FourOscPatch{}.property("reverbOn", 1).property("delayOn", 1).build();
-    const auto translated = magda::daw::audio::translateFourOsc(patch);
-
-    CHECK(mentions(translated.gaps, "Reverb"));
-    CHECK(mentions(translated.gaps, "Delay"));
-    CHECK_FALSE(mentions(translated.gaps, "Chorus"));
-}
-
 TEST_CASE("A patch using nothing Poly Synth lacks reports no gaps", "[core][4osc]") {
     const auto patch = FourOscPatch{}
                            .property("waveShape1", 3)
@@ -329,4 +322,74 @@ TEST_CASE("The backup sits beside the project and never overwrites", "[core][4os
 
 TEST_CASE("A project that was never saved has no backup to write", "[core][4osc]") {
     CHECK(magda::daw::audio::backupFileFor(juce::File{}) == juce::File{});
+}
+
+TEST_CASE("The built-in effects become a rack of MAGDA devices", "[core][4osc]") {
+    // 4OSC processes distortion, chorus, delay then reverb, and the rack has
+    // to keep that order: a reverb before a delay is a different sound.
+    const auto patch = FourOscPatch{}
+                           .property("distortionOn", 1)
+                           .property("chorusOn", 1)
+                           .property("delayOn", 1)
+                           .property("reverbOn", 1)
+                           .parameter("distortion", 0.5f)
+                           .parameter("chorusMix", 0.4f)
+                           .parameter("reverbSize", 0.8f)
+                           .build();
+
+    auto next = magda::DeviceId{100};
+    const auto translated = magda::daw::audio::translateFourOsc(patch, [&next] { return next++; });
+
+    REQUIRE(translated.effects != nullptr);
+    REQUIRE(translated.effects->chains.size() == 1);
+
+    const auto& elements = translated.effects->chains.front().elements;
+    REQUIRE(elements.size() == 4);
+    CHECK(magda::getDevice(elements[0]).name == "Clipper");
+    CHECK(magda::getDevice(elements[1]).name == "Chorus");
+    CHECK(magda::getDevice(elements[2]).name == "Delay");
+    CHECK(magda::getDevice(elements[3]).name == "Reverb");
+
+    // Each is a device of its own in the project, so none may share the
+    // synth's id or another effect's.
+    std::set<magda::DeviceId> ids{patch.id};
+    for (const auto& element : elements)
+        CHECK(ids.insert(magda::getDevice(element).id).second);
+}
+
+TEST_CASE("Only the effects that were switched on are built", "[core][4osc]") {
+    const auto patch = FourOscPatch{}.property("reverbOn", 1).build();
+
+    auto next = magda::DeviceId{100};
+    const auto translated = magda::daw::audio::translateFourOsc(patch, [&next] { return next++; });
+
+    REQUIRE(translated.effects != nullptr);
+    REQUIRE(translated.effects->chains.front().elements.size() == 1);
+    CHECK(magda::getDevice(translated.effects->chains.front().elements.front()).name == "Reverb");
+}
+
+TEST_CASE("A patch with no effects on builds no rack", "[core][4osc]") {
+    const auto patch = FourOscPatch{}.property("waveShape1", 3).build();
+
+    auto next = magda::DeviceId{100};
+    CHECK(magda::daw::audio::translateFourOsc(patch, [&next] { return next++; }).effects ==
+          nullptr);
+}
+
+TEST_CASE("The effects are no longer reported as losses", "[core][4osc]") {
+    // They were gaps until the rack carried them.
+    const auto patch = FourOscPatch{}.property("reverbOn", 1).property("delayOn", 1).build();
+
+    auto next = magda::DeviceId{100};
+    const auto translated = magda::daw::audio::translateFourOsc(patch, [&next] { return next++; });
+
+    CHECK_FALSE(mentions(translated.gaps, "Reverb"));
+    CHECK_FALSE(mentions(translated.gaps, "Delay"));
+}
+
+TEST_CASE("4OSC's master level becomes the synth's output gain", "[core][4osc]") {
+    const auto patch = FourOscPatch{}.parameter("masterLevel", -6.0f).build();
+
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(patch).device,
+                    PolySynth::kOutputGainSlot) == Catch::Approx(-6.0f));
 }

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -1,0 +1,248 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/audio/FourOscTranslation.hpp"
+#include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
+#include "magda/daw/core/DeviceState.hpp"
+
+/**
+ * 4OSC to Poly Synth (#2437).
+ *
+ * 4OSC is Tracktion Engine's synth and is never ported, so a project holding
+ * one opens on the native engine as the translation these cases describe.
+ */
+
+namespace {
+
+using magda::DeviceInfo;
+using magda::ParameterInfo;
+using PolySynth = magda::daw::audio::compiled::MagdaPolySynthCompiledPlugin;
+
+/// A 4OSC device as a project saves one: parameters under the ids TE gave
+/// them, and wave shape, filter type and voice mode as ValueTree properties.
+class FourOscPatch {
+  public:
+    FourOscPatch() {
+        device_.id = magda::DeviceId{7};
+        device_.name = "4OSC";
+        device_.pluginId = "4osc";
+        device_.deviceType = magda::DeviceType::Instrument;
+        device_.isInstrument = true;
+        device_.format = magda::PluginFormat::Internal;
+    }
+
+    FourOscPatch& parameter(const juce::String& name, float value) {
+        ParameterInfo info;
+        info.paramIndex = static_cast<int>(device_.parameters.size());
+        info.name = name;
+        info.currentValue = value;
+        device_.parameters.push_back(std::move(info));
+        return *this;
+    }
+
+    FourOscPatch& property(const juce::String& name, int value) {
+        props_.set(name, value);
+        return *this;
+    }
+
+    DeviceInfo build() {
+        magda::device_state::Doc doc;
+        doc.deviceType = "4osc";
+        doc.root.props = props_;
+        device_.pluginState = magda::device_state::encode(doc);
+        return device_;
+    }
+
+  private:
+    DeviceInfo device_;
+    juce::NamedValueSet props_;
+};
+
+float slotValue(const DeviceInfo& device, int slot) {
+    for (const auto& parameter : device.parameters)
+        if (parameter.paramIndex == slot)
+            return parameter.currentValue;
+
+    FAIL("no slot " << slot);
+    return 0.0f;
+}
+
+bool mentions(const std::vector<magda::daw::audio::FourOscGap>& gaps, const juce::String& text) {
+    return std::ranges::any_of(
+        gaps, [&text](const auto& gap) { return gap.control.containsIgnoreCase(text); });
+}
+
+int oscSlot(int osc, int offset) {
+    return PolySynth::kOscBaseSlot + (osc - 1) * PolySynth::kOscSlotCount + offset;
+}
+
+}  // namespace
+
+TEST_CASE("A 4OSC device is recognised by the id a project saves", "[core][4osc]") {
+    CHECK(magda::daw::audio::isFourOscDevice(FourOscPatch{}.build()));
+
+    DeviceInfo other;
+    other.pluginId = PolySynth::xmlTypeName;
+    CHECK_FALSE(magda::daw::audio::isFourOscDevice(other));
+}
+
+TEST_CASE("The translation keeps the device's identity", "[core][4osc]") {
+    // The same DeviceId in the same slot, so every macro link, modifier and
+    // automation lane that names this device still names it.
+    const auto patch = FourOscPatch{}.build();
+    const auto translated = magda::daw::audio::translateFourOsc(patch);
+
+    CHECK(translated.device.id == patch.id);
+    CHECK(translated.device.pluginId == juce::String(PolySynth::xmlTypeName));
+    CHECK(translated.device.isInstrument);
+}
+
+TEST_CASE("An oscillator's wave, tune and level carry over", "[core][4osc]") {
+    const auto patch = FourOscPatch{}
+                           .property("waveShape1", 5)  // square
+                           .parameter("tune1", 7.0f)
+                           .parameter("fineTune1", -25.0f)
+                           .parameter("level1", -6.0f)
+                           .build();
+
+    const auto translated = magda::daw::audio::translateFourOsc(patch);
+
+    CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot) == 1.0f);
+    CHECK(slotValue(translated.device, oscSlot(1, 0)) == 2.0f);  // Poly Synth's Square
+    CHECK(slotValue(translated.device, oscSlot(1, 2)) == Catch::Approx(7.0f));
+    CHECK(slotValue(translated.device, oscSlot(1, 3)) == Catch::Approx(-25.0f));
+    CHECK(slotValue(translated.device, oscSlot(1, 1)) == Catch::Approx(-6.0f));
+}
+
+TEST_CASE("A tune past Poly Synth's range is clamped rather than wrapped", "[core][4osc]") {
+    // 4OSC tunes +/-36 semitones and Poly Synth +/-24. Clamping detunes the
+    // patch; wrapping would transpose it into another key.
+    const auto patch = FourOscPatch{}.property("waveShape1", 1).parameter("tune1", 36.0f).build();
+
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(patch).device, oscSlot(1, 2)) ==
+          Catch::Approx(24.0f));
+}
+
+TEST_CASE("An oscillator set to none is silenced rather than left playing", "[core][4osc]") {
+    // Poly Synth's oscillators are always in the dsp, so "off" is the enable
+    // slot. Left alone, osc 1 defaults audible and the patch gains a voice it
+    // never had.
+    const auto patch = FourOscPatch{}.property("waveShape1", 0).build();
+
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(patch).device,
+                    PolySynth::kOscEnableBaseSlot) == 0.0f);
+}
+
+TEST_CASE("A noise oscillator is reported rather than approximated", "[core][4osc]") {
+    const auto patch = FourOscPatch{}.property("waveShape2", 6).build();
+    const auto translated = magda::daw::audio::translateFourOsc(patch);
+
+    CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot + 1) == 0.0f);
+    CHECK(mentions(translated.gaps, "noise"));
+}
+
+TEST_CASE("Envelope times reach Poly Synth in milliseconds", "[core][4osc]") {
+    // 4OSC holds them in seconds and its sustain as a percentage. A straight
+    // copy would give a 250 ms decay a value of 0.25 ms and a full sustain 100.
+    const auto patch = FourOscPatch{}
+                           .parameter("ampAttack", 0.25f)
+                           .parameter("ampDecay", 0.5f)
+                           .parameter("ampSustain", 80.0f)
+                           .parameter("ampRelease", 1.5f)
+                           .build();
+
+    const auto translated = magda::daw::audio::translateFourOsc(patch);
+
+    CHECK(slotValue(translated.device, PolySynth::kAmpAttackSlot) == Catch::Approx(250.0f));
+    CHECK(slotValue(translated.device, PolySynth::kAmpDecaySlot) == Catch::Approx(500.0f));
+    CHECK(slotValue(translated.device, PolySynth::kAmpSustainSlot) == Catch::Approx(0.8f));
+    CHECK(slotValue(translated.device, PolySynth::kAmpReleaseSlot) == Catch::Approx(1500.0f));
+}
+
+TEST_CASE("An envelope longer than Poly Synth holds is clamped", "[core][4osc]") {
+    // 4OSC reaches 60 seconds; Poly Synth's attack stops at two.
+    const auto patch = FourOscPatch{}.parameter("ampAttack", 60.0f).build();
+
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(patch).device, PolySynth::kAmpAttackSlot) ==
+          Catch::Approx(2000.0f));
+}
+
+TEST_CASE("The filter cutoff is read as a MIDI note and written as Hz", "[core][4osc]") {
+    // 4OSC's filterFreq is a note number, 0 to 135.076232, which is how it
+    // spaces the control logarithmically. Read as Hz it would put every patch
+    // at the bottom of Poly Synth's range.
+    const auto patch = FourOscPatch{}
+                           .property("filterType", 1)  // lowpass
+                           .parameter("filterFreq", 69.0f)
+                           .build();
+
+    const auto translated = magda::daw::audio::translateFourOsc(patch);
+
+    CHECK(slotValue(translated.device, PolySynth::kFilterTypeSlot) == 0.0f);
+    CHECK(slotValue(translated.device, PolySynth::kCutoffSlot) == Catch::Approx(440.0f));
+}
+
+TEST_CASE("A 4OSC patch with its filter off gets one out of the way", "[core][4osc]") {
+    // 4OSC bypasses the filter entirely at type 0 and Poly Synth's is always
+    // in the path, so the cutoff goes to the top rather than wherever
+    // filterFreq happened to sit under a filter nobody heard.
+    const auto patch =
+        FourOscPatch{}.property("filterType", 0).parameter("filterFreq", 40.0f).build();
+
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(patch).device, PolySynth::kCutoffSlot) >
+          17000.0f);
+}
+
+TEST_CASE("Resonance and envelope amount are scaled into their ranges", "[core][4osc]") {
+    const auto patch = FourOscPatch{}
+                           .property("filterType", 1)
+                           .parameter("filterResonance", 50.0f)
+                           .parameter("filterAmount", 0.5f)
+                           .build();
+
+    const auto translated = magda::daw::audio::translateFourOsc(patch);
+
+    CHECK(slotValue(translated.device, PolySynth::kResonanceSlot) == Catch::Approx(0.475f));
+    CHECK(slotValue(translated.device, PolySynth::kFilterEnvAmtSlot) == Catch::Approx(2.0f));
+}
+
+TEST_CASE("Voice mode is reordered rather than copied", "[core][4osc]") {
+    // 4OSC counts mono, legato, poly; Poly Synth counts poly, mono, legato.
+    // Copied across, every mono patch would come back polyphonic.
+    const auto mono = FourOscPatch{}.property("voiceMode", 0).build();
+    const auto legato = FourOscPatch{}.property("voiceMode", 1).build();
+    const auto poly = FourOscPatch{}.property("voiceMode", 2).build();
+
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(mono).device, PolySynth::kVoiceModeSlot) ==
+          1.0f);
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(legato).device,
+                    PolySynth::kVoiceModeSlot) == 2.0f);
+    CHECK(slotValue(magda::daw::audio::translateFourOsc(poly).device, PolySynth::kVoiceModeSlot) ==
+          0.0f);
+}
+
+TEST_CASE("Unison is reported rather than translated into something thinner", "[core][4osc]") {
+    const auto patch = FourOscPatch{}.property("waveShape1", 3).property("voices1", 4).build();
+
+    CHECK(mentions(magda::daw::audio::translateFourOsc(patch).gaps, "Unison"));
+}
+
+TEST_CASE("The built-in effects are reported as devices to add", "[core][4osc]") {
+    const auto patch = FourOscPatch{}.property("reverbOn", 1).property("delayOn", 1).build();
+    const auto translated = magda::daw::audio::translateFourOsc(patch);
+
+    CHECK(mentions(translated.gaps, "Reverb"));
+    CHECK(mentions(translated.gaps, "Delay"));
+    CHECK_FALSE(mentions(translated.gaps, "Chorus"));
+}
+
+TEST_CASE("A patch using nothing Poly Synth lacks reports no gaps", "[core][4osc]") {
+    const auto patch = FourOscPatch{}
+                           .property("waveShape1", 3)
+                           .property("filterType", 1)
+                           .parameter("tune1", 0.0f)
+                           .parameter("ampAttack", 0.01f)
+                           .build();
+
+    CHECK(magda::daw::audio::translateFourOsc(patch).gaps.empty());
+}

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -36,10 +36,41 @@ class FourOscPatch {
         device_.format = magda::PluginFormat::Internal;
     }
 
-    FourOscPatch& parameter(const juce::String& name, float value) {
+    /// @p id is 4OSC's own parameter id. A project stores the display name
+    /// ("Tune 1") and addresses the parameter by index, so the fixture does
+    /// the same: matching on the id would pass against code no real project
+    /// exercises.
+    FourOscPatch& parameter(const juce::String& id, float value) {
+        static const juce::StringArray order{"tune1",          "fineTune1",   "level1",
+                                             "pulseWidth1",    "detune1",     "spread1",
+                                             "pan1",           "tune2",       "fineTune2",
+                                             "level2",         "pulseWidth2", "detune2",
+                                             "spread2",        "pan2",        "tune3",
+                                             "fineTune3",      "level3",      "pulseWidth3",
+                                             "detune3",        "spread3",     "pan3",
+                                             "tune4",          "fineTune4",   "level4",
+                                             "pulseWidth4",    "detune4",     "spread4",
+                                             "pan4",           "lfoRate1",    "lfoDepth1",
+                                             "lfoRate2",       "lfoDepth2",   "modAttack1",
+                                             "modDecay1",      "modSustain1", "modRelease1",
+                                             "modAttack2",     "modDecay2",   "modSustain2",
+                                             "modRelease2",    "ampAttack",   "ampDecay",
+                                             "ampSustain",     "ampRelease",  "ampVelocity",
+                                             "filterAttack",   "filterDecay", "filterSustain",
+                                             "filterRelease",  "filterFreq",  "filterResonance",
+                                             "filterAmount",   "filterKey",   "filterVelocity",
+                                             "distortion",     "reverbSize",  "reverbDamping",
+                                             "reverbWidth",    "reverbMix",   "delayFeedback",
+                                             "delayCrossfeed", "delayMix",    "chorusSpeed",
+                                             "chorusDepth",    "chorusWidth", "chorusMix",
+                                             "legato",         "masterLevel"};
+
+        const auto index = order.indexOf(id);
+        REQUIRE(index >= 0);
+
         ParameterInfo info;
-        info.paramIndex = static_cast<int>(device_.parameters.size());
-        info.name = name;
+        info.paramIndex = index;
+        info.name = id;  // a project stores a display name; nothing reads it
         info.currentValue = value;
         device_.parameters.push_back(std::move(info));
         return *this;
@@ -311,10 +342,11 @@ TEST_CASE("The converted project is a new project beside the old one", "[core][4
     const auto project = root.getChildFile("Song").getChildFile("Song.mgd");
     project.getParentDirectory().createDirectory();
 
+    // Unwrapped: saveProjectAs() makes the folder, and skips making it when
+    // the file already looks wrapped.
     const auto converted = magda::daw::audio::convertedProjectFileFor(project);
     CHECK(converted.getFileName() == "Song (Poly Synth).mgd");
-    CHECK(converted.getParentDirectory().getFileName() == "Song (Poly Synth)");
-    CHECK(converted.getParentDirectory().getParentDirectory() == root);
+    CHECK(converted.getParentDirectory() == root);
 
     root.deleteRecursively();
 }
@@ -457,5 +489,24 @@ TEST_CASE("A patch whose oscillators are all off is not silently enabled", "[cor
 
     const auto translated = magda::daw::audio::translateFourOsc(device);
     for (auto osc = 0; osc < 4; ++osc)
+        CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot + osc) == 0.0f);
+}
+
+TEST_CASE("A patch left on 4OSC's defaults still makes a sound", "[core][4osc]") {
+    // TE writes only what differs from a property's default, so a patch
+    // nobody changed carries no waveShape at all. Ten of the 4OSC devices in
+    // a real project folder look like this, and defaulting them to "none"
+    // converted every one of them to silence.
+    magda::DeviceInfo device;
+    device.pluginId = "4osc";
+    device.pluginState = R"(<PLUGIN type="4osc" ampSustain="80.5"/>)";
+
+    const auto translated = magda::daw::audio::translateFourOsc(device);
+
+    CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot) == 1.0f);
+    CHECK(slotValue(translated.device, oscSlot(1, 0)) == 0.0f);  // 4OSC's default sine
+
+    // And the other three stay off, which is also 4OSC's default.
+    for (auto osc = 1; osc < 4; ++osc)
         CHECK(slotValue(translated.device, PolySynth::kOscEnableBaseSlot + osc) == 0.0f);
 }

--- a/tests/core/test_four_osc_translation.cpp
+++ b/tests/core/test_four_osc_translation.cpp
@@ -297,7 +297,7 @@ TEST_CASE("A project with no 4OSC has nothing to ask about", "[core][4osc]") {
     master.id = magda::MASTER_TRACK_ID;
 
     CHECK(magda::daw::audio::findFourOscDevices({}, master).empty());
-    CHECK(magda::daw::audio::describeConversion({}).isEmpty());
+    CHECK(magda::daw::audio::describeMigration({}).contains("Tracktion engine"));
 }
 
 TEST_CASE("The conversion prompt names what will be lost", "[core][4osc]") {
@@ -311,12 +311,12 @@ TEST_CASE("The conversion prompt names what will be lost", "[core][4osc]") {
     magda::TrackInfo master;
     master.id = magda::MASTER_TRACK_ID;
 
-    const auto text = magda::daw::audio::describeConversion(
+    const auto text = magda::daw::audio::describeMigration(
         magda::daw::audio::findFourOscDevices({track}, master));
 
     CHECK(text.contains("Poly Synth"));
     CHECK(text.contains("Unison"));
-    CHECK(text.contains("saved alongside this one"));
+    CHECK(text.contains("original is left alone"));
 }
 
 TEST_CASE("A patch losing nothing is not warned about", "[core][4osc]") {
@@ -327,10 +327,9 @@ TEST_CASE("A patch losing nothing is not warned about", "[core][4osc]") {
     magda::TrackInfo master;
     master.id = magda::MASTER_TRACK_ID;
 
-    const auto text = magda::daw::audio::describeConversion(
+    const auto text = magda::daw::audio::describeMigration(
         magda::daw::audio::findFourOscDevices({track}, master));
 
-    CHECK(text.contains("somewhere to go"));
     CHECK_FALSE(text.contains("will be lost"));
 }
 
@@ -345,7 +344,7 @@ TEST_CASE("The converted project is a new project beside the old one", "[core][4
     // Unwrapped: saveProjectAs() makes the folder, and skips making it when
     // the file already looks wrapped.
     const auto converted = magda::daw::audio::convertedProjectFileFor(project);
-    CHECK(converted.getFileName() == "Song (Poly Synth).mgd");
+    CHECK(converted.getFileName() == "Song (magda engine).mgd");
     CHECK(converted.getParentDirectory() == root);
 
     root.deleteRecursively();


### PR DESCRIPTION
Closes #2437.

4OSC is Tracktion Engine's synth and is never ported, so a project carrying one
has nothing to play on the MAGDA engine. This translates the patch into a Poly
Synth patch and offers the whole thing as a migration when a Tracktion project
is opened on the native leg.

## Translation

`FourOscTranslation` reads a saved 4OSC state and writes Poly Synth host slots:
four oscillators (wave, level, coarse, fine), filter type, cutoff, resonance and
envelope amount, both ADSRs, voice mode, glide, bend range and the velocity
amounts. 4OSC's built-in chorus, reverb, delay and distortion become a rack of
MAGDA devices behind the synth, since Poly Synth has no effects of its own.

A parameter the saved state never wrote takes 4OSC's own default rather than
zero, and the state is addressed by parameter index, which is what 4OSC writes.

Unison is the gap: Poly Synth has no equivalent, so a patch that uses it is
named in the prompt rather than translated into something thinner.

## The prompt

Opening a project that was last written by Tracktion offers to reopen it as a
copy on the MAGDA engine. It fires whether or not there is a 4OSC in it, because
the two engines do not render every device the same way, and it folds the 4OSC
translation in when there is one. The copy is saved beside the original as
"<name> (magda engine)" and the original is never written to.

`ProjectInfo::savedWithEngine` records which engine last wrote the project, so a
project already through the migration is not asked again. An empty word is a
project saved before the field existed, which is Tracktion by definition. A
"don't ask again" tickbox turns the prompt off for good.

## Under the MAGDA engine

- The 4OSC custom UI does not open: every control writes through a
  `te::FourOscPlugin` that the native engine never builds, so the slot shows the
  device and nothing to turn.
- The plugin browser hides any internal device with no native factory, rather
  than offering one that arrives silent.

## Tests

`tests/core/test_four_osc_translation.cpp`: the slot mapping, the defaults, the
effects rack, the gap reporting, the prompt text and the name of the copy.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF
