### PR TITLE
Keep a hosted plugin's detected units, and agree on what its value means

### DIFF
--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -4,7 +4,6 @@
 #include <map>
 
 #include "../Vst3Preset.hpp"
-#include "core/ParameterUtils.hpp"
 
 namespace magda {
 
@@ -88,6 +87,30 @@ void applyVst3Records(DeviceInfo& device, const Vst3PresetRead& read) {
         device.vst3ClassId = vst3::classIdFromPreset(read.preset);
 
     device.vst3Preset = juce::Base64::toBase64(read.preset.getData(), read.preset.getSize());
+}
+
+/// Where @p info's stored value sits in [0, 1], as the plugin takes it.
+///
+/// A hosted plugin's parameters are stored in the plugin's own normalised
+/// domain whatever display range has been detected over them, and
+/// teMinValue/teMaxValue is the record of that domain. Deliberately not
+/// ParameterUtils::modelToNormalizedValue(), which tells a display-mapped
+/// internal device from a hosted plugin by whether a display-text provider is
+/// attached: no project serialises that provider, so the same device would
+/// answer one way on the load that opens a project and another once the host
+/// had attached one (#2601).
+float normalisedFrom(const ParameterInfo& info) {
+    const auto teSpan = info.teMaxValue - info.teMinValue;
+    const auto normalised =
+        teSpan > 0.0f ? (info.currentValue - info.teMinValue) / teSpan : info.currentValue;
+
+    return std::clamp(normalised, 0.0f, 1.0f);
+}
+
+/// The inverse: what the model stores for a plugin reporting @p normalised.
+float modelValueFrom(float normalised, const ParameterInfo& info) {
+    const auto teSpan = info.teMaxValue - info.teMinValue;
+    return teSpan > 0.0f ? info.teMinValue + normalised * teSpan : normalised;
 }
 
 /// The length the fork asks a plugin for its parameter names at.
@@ -227,14 +250,7 @@ SavedStateOutcome applySavedPluginState(juce::AudioPluginInstance& instance,
         if (info == nullptr)
             continue;
 
-        // Through the pair that knows which domain the model stores a value in,
-        // rather than assuming the display one. They differ once a plugin has a
-        // configured display range: the model keeps the plugin's own normalised
-        // number and the range is what the UI draws it against (#2601).
-        parameter->setValue(std::clamp(
-            ParameterUtils::modelToNormalizedValue(ParameterModelValue{info->currentValue}, *info)
-                .value,
-            0.0f, 1.0f));
+        parameter->setValue(normalisedFrom(*info));
     }
 
     // The portable preset is asked first, because a project only carries one
@@ -304,15 +320,11 @@ void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParam
         for (auto* bucket : {&device.parameters, &device.wrapperParameters})
             for (auto& info : *bucket)
                 if (info.paramIndex == parameter.paramIndex)
-                    // The inverse of what applySavedPluginState() wrote, and
-                    // the same pair the plan, the UI and automation read
-                    // through: converting to the display range unconditionally
-                    // would put a real value in a field everything else reads
-                    // as normalised (#2601).
-                    info.currentValue =
-                        ParameterUtils::normalizedToModelValue(
-                            ParameterNormalizedValue::clamped(parameter.value), info)
-                            .value;
+                    // The inverse of what applySavedPluginState() wrote.
+                    // Converting to the display range instead would put a
+                    // frequency in a field everything else reads as
+                    // normalised (#2601).
+                    info.currentValue = modelValueFrom(parameter.value, info);
 }
 
 Vst3PresetRead readVst3Preset(const juce::AudioPluginInstance& instance) {

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -227,8 +227,14 @@ SavedStateOutcome applySavedPluginState(juce::AudioPluginInstance& instance,
         if (info == nullptr)
             continue;
 
-        parameter->setValue(
-            std::clamp(ParameterUtils::realToNormalized(info->currentValue, *info), 0.0f, 1.0f));
+        // Through the pair that knows which domain the model stores a value in,
+        // rather than assuming the display one. They differ once a plugin has a
+        // configured display range: the model keeps the plugin's own normalised
+        // number and the range is what the UI draws it against (#2601).
+        parameter->setValue(std::clamp(
+            ParameterUtils::modelToNormalizedValue(ParameterModelValue{info->currentValue}, *info)
+                .value,
+            0.0f, 1.0f));
     }
 
     // The portable preset is asked first, because a project only carries one
@@ -298,8 +304,15 @@ void applyRestoredParameters(DeviceInfo& device, const std::vector<RestoredParam
         for (auto* bucket : {&device.parameters, &device.wrapperParameters})
             for (auto& info : *bucket)
                 if (info.paramIndex == parameter.paramIndex)
-                    info.currentValue = ParameterUtils::normalizedToReal(
-                        parameter.value, ParameterUtils::domainOf(info));
+                    // The inverse of what applySavedPluginState() wrote, and
+                    // the same pair the plan, the UI and automation read
+                    // through: converting to the display range unconditionally
+                    // would put a real value in a field everything else reads
+                    // as normalised (#2601).
+                    info.currentValue =
+                        ParameterUtils::normalizedToModelValue(
+                            ParameterNormalizedValue::clamped(parameter.value), info)
+                            .value;
 }
 
 Vst3PresetRead readVst3Preset(const juce::AudioPluginInstance& instance) {

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -268,6 +268,10 @@ bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device) {
     return true;
 }
 
+bool applyToDevice(DeviceInfo& device) {
+    return applyToDevice(configIdFor(device), device);
+}
+
 bool hasAiSoundDesignerParameters(const juce::String& uniqueId) {
     const auto config = load(uniqueId);
     if (!config)

--- a/magda/daw/core/PluginParameterConfigStore.hpp
+++ b/magda/daw/core/PluginParameterConfigStore.hpp
@@ -77,6 +77,10 @@ PluginParameterConfig fromDevice(const DeviceInfo& device);
 /// exists or it does not parse.
 bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device);
 
+/// @overload Filed under the device's own id, which is its `uniqueId` where it
+/// has one and its `pluginId` otherwise -- older devices carry only the latter.
+bool applyToDevice(DeviceInfo& device);
+
 /// Whether any parameter is opted in to AI/agent control, without a device.
 bool hasAiSoundDesignerParameters(const juce::String& uniqueId);
 

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -684,7 +684,10 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
                              ? ParameterScale::Boolean
                              : (numStates > 0 && numStates <= 12 ? ParameterScale::Discrete
                                                                  : ParameterScale::Linear);
-            info.scanInput.paramIndex = i;
+            // The position in this list, not the loop counter: a parameter
+            // skipped above leaves the two apart, and a detection result is
+            // applied by position.
+            info.scanInput.paramIndex = static_cast<int>(result.size());
             info.scanInput.name = info.name;
             info.scanInput.label = parameter->getLabel();
             info.scanInput.rangeMin = info.rangeMin;
@@ -727,6 +730,10 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
     const auto order = magda::hostParameterOrder(*instance);
 
     for (const auto& model : described.parameters) {
+        // The host slot addresses the live parameter; the position in this list
+        // is what a scan result is addressed by. The two differ by the wrapper
+        // pair, and everything downstream -- the dialog's rows, the config
+        // file's entries -- counts positions.
         auto* parameter = order[static_cast<std::size_t>(model.paramIndex)];
 
         ScannedPluginParameter info;
@@ -736,7 +743,7 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
         info.unit = rawLabel.length() <= 6 && !rawLabel.contains("[") && !rawLabel.contains("(")
                         ? (rawLabel.isEmpty() ? juce::String("%") : rawLabel)
                         : juce::String("%");
-        info.scanInput.paramIndex = model.paramIndex;
+        info.scanInput.paramIndex = static_cast<int>(result.size());
         info.scanInput.name = info.name;
         info.scanInput.label = rawLabel;
 

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -13,6 +13,7 @@
 #endif
 
 #include "../audio/AudioBridge.hpp"
+#include "../audio/plugin_manager/ExternalPluginState.hpp"
 #include "../audio/plugin_manager/ExternalPluginStateUtil.hpp"
 #include "../audio/plugins/InternalPluginRegistry.hpp"
 #include "../audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
@@ -715,22 +716,27 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
     if (instance == nullptr)
         return result;
 
-    const auto parameters = instance->getParameters();
-    for (int i = 0; i < parameters.size(); ++i) {
-        auto* parameter = parameters[i];
-        if (parameter == nullptr || !parameter->isAutomatable())
-            continue;
+    // The host's own list rather than the plugin's raw array, because that is
+    // what DeviceInfo::parameters is built from: same filter, same order, same
+    // names. A config entry is stored by its position in the list, so a scan
+    // that filtered differently -- this one dropped unnamed parameters, which
+    // the model keeps -- saved every later override onto the wrong control
+    // (#2601). The wrapper pair is the host's own and is not configurable, so
+    // it is not offered.
+    const auto described = magda::describeHostParameters(*instance, magda::DeviceInfo{});
+    const auto order = magda::hostParameterOrder(*instance);
+
+    for (const auto& model : described.parameters) {
+        auto* parameter = order[static_cast<std::size_t>(model.paramIndex)];
 
         ScannedPluginParameter info;
-        info.name = parameter->getName(128);
-        if (info.name.isEmpty())
-            continue;
+        info.name = model.name;
         info.defaultValue = parameter->getDefaultValue();
         const auto rawLabel = parameter->getLabel().trim();
         info.unit = rawLabel.length() <= 6 && !rawLabel.contains("[") && !rawLabel.contains("(")
                         ? (rawLabel.isEmpty() ? juce::String("%") : rawLabel)
                         : juce::String("%");
-        info.scanInput.paramIndex = i;
+        info.scanInput.paramIndex = model.paramIndex;
         info.scanInput.name = info.name;
         info.scanInput.label = rawLabel;
 

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -20,6 +20,7 @@
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ChainWalk.hpp"
 #include "../../core/ClipManager.hpp"
+#include "../../core/PluginParameterConfigStore.hpp"
 #include "../../core/TempoMap.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../project/ProjectManager.hpp"
@@ -794,6 +795,12 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         // Asked with the segment, because a DeviceId is section-local and on
         // its own names up to three devices (#1899).
         const auto path = TrackManager::getInstance().findDevicePath(key.deviceId, key.segment);
+
+        // What the plugin's parameters were detected to mean, over the bare
+        // normalised records the adapter builds from the instance. Here because
+        // the array is rebuilt on every load, and a unit that only survived
+        // until the next one is a unit nobody configured twice (#2601).
+        PluginParameterConfigStore::applyToDevice(*device);
 
         // Here rather than where the parameters were described, because this is
         // where the device's address is known: a DeviceInfo does not say which

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -150,6 +150,35 @@ TEST_CASE("applyToDevice rebuilds selections and applies overrides", "[param-con
     REQUIRE_FALSE(store::applyToDevice("VST3-Not-Configured", other));
 }
 
+TEST_CASE("applyToDevice finds a device's own config file", "[param-config-store][2601]") {
+    // The id a config is filed under is the device's, and every caller derived
+    // it by hand -- most of them by reading `uniqueId` alone, which is empty on
+    // the older devices that carry only a `pluginId`.
+    TempDataDir temp;
+    auto device = makeExternalDevice();
+
+    auto config = store::fromDevice(device);
+    config.entries[0].unit = "kHz";
+    REQUIRE(store::save(device.uniqueId, config));
+
+    REQUIRE(store::applyToDevice(device));
+    CHECK(device.parameters[0].unit == "kHz");
+}
+
+TEST_CASE("A device with no uniqueId is filed under its plugin id", "[param-config-store][2601]") {
+    TempDataDir temp;
+    auto device = makeExternalDevice();
+    device.uniqueId = {};
+    device.pluginId = "magda_older_device";
+
+    auto config = store::fromDevice(device);
+    config.entries[1].unit = "dB";
+    REQUIRE(store::save(device.pluginId, config));
+
+    REQUIRE(store::applyToDevice(device));
+    CHECK(device.parameters[1].unit == "dB");
+}
+
 TEST_CASE("legacy visible-only config files still load", "[param-config-store]") {
     TempDataDir temp;
     const juce::String uniqueId = "VST3-Legacy-Plugin";

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -1993,6 +1993,39 @@ TEST_CASE("Resolved parameters carry no text provider of their own", "[engine][e
     CHECK(tone->displayText == nullptr);
 }
 
+TEST_CASE("A configured display range survives the restore round trip",
+          "[engine][external][2601]") {
+    // Detection gives a hosted parameter a real range to be drawn against, and
+    // the model goes on holding the plugin's own normalised number underneath.
+    // The write to the plugin and the read back have to agree on which of the
+    // two they are in, or opening a project moves every configured parameter.
+    magda::installDeviceParameterDisplayTextProviderFactory();
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto model = externalDevice();
+    auto& tone = model.parameters[1];  // plan slot three, the stub's Tone
+    tone.minValue = 20.0f;
+    tone.maxValue = 20000.0f;
+    tone.scale = magda::ParameterScale::Logarithmic;
+    tone.displayText = magda::makeParameterDisplayTextProvider({}, model.id, tone.paramIndex);
+    tone.currentValue = 0.7f;
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    // The plugin was handed the position the model holds, not that number read
+    // as a frequency and squashed against the bottom of 20 Hz.
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+
+    // And what came back is the same number, rather than the 20 Hz a conversion
+    // through the display range would have written into a field the plan, the
+    // UI and automation all read as normalised.
+    magda::applyRestoredParameters(model, result.restoredParameters);
+    CHECK(model.parameters[1].currentValue == Catch::Approx(0.7f));
+}
+
 TEST_CASE("Successful adaptation reports live buses and MIDI capabilities", "[engine][external]") {
     auto plugin = std::make_unique<StubPlugin>(2, 2, 1, 2);
     plugin->emitsMidi = true;

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -788,6 +788,21 @@ const magda::ParameterInfo* resolvedParameterAt(const adapter::ExternalDeviceRes
     return result.resolvedDevice->findParameterByIndex(index);
 }
 
+/// The model of a hosted plugin whose Tone has been detected as a frequency.
+///
+/// `displayText` is deliberately absent, which is the shape a project load
+/// produces: the provider is not serialised, and the host attaches one only
+/// after the plugin has been restored.
+magda::DeviceInfo externalDeviceWithDetectedRange(float tone) {
+    auto device = externalDevice();
+    auto& detected = device.parameters[1];
+    detected.minValue = 20.0f;
+    detected.maxValue = 20000.0f;
+    detected.scale = magda::ParameterScale::Logarithmic;
+    detected.currentValue = tone;
+    return device;
+}
+
 }  // namespace
 
 TEST_CASE("External device reports the instance's latency", "[engine][external]") {
@@ -1993,24 +2008,16 @@ TEST_CASE("Resolved parameters carry no text provider of their own", "[engine][e
     CHECK(tone->displayText == nullptr);
 }
 
-TEST_CASE("A configured display range survives the restore round trip",
+TEST_CASE("A detected display range does not move the value it is drawn against",
           "[engine][external][2601]") {
     // Detection gives a hosted parameter a real range to be drawn against, and
     // the model goes on holding the plugin's own normalised number underneath.
     // The write to the plugin and the read back have to agree on which of the
-    // two they are in, or opening a project moves every configured parameter.
-    magda::installDeviceParameterDisplayTextProviderFactory();
+    // two they are in, or opening a project moves every detected parameter.
+    auto model = externalDeviceWithDetectedRange(0.7f);
 
     auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
     auto* raw = plugin.get();
-
-    auto model = externalDevice();
-    auto& tone = model.parameters[1];  // plan slot three, the stub's Tone
-    tone.minValue = 20.0f;
-    tone.maxValue = 20000.0f;
-    tone.scale = magda::ParameterScale::Logarithmic;
-    tone.displayText = magda::makeParameterDisplayTextProvider({}, model.id, tone.paramIndex);
-    tone.currentValue = 0.7f;
 
     const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
     REQUIRE(result.device != nullptr);
@@ -2022,6 +2029,30 @@ TEST_CASE("A configured display range survives the restore round trip",
     // And what came back is the same number, rather than the 20 Hz a conversion
     // through the display range would have written into a field the plan, the
     // UI and automation all read as normalised.
+    magda::applyRestoredParameters(model, result.restoredParameters);
+    CHECK(model.parameters[1].currentValue == Catch::Approx(0.7f));
+}
+
+TEST_CASE("The answer does not depend on a provider no project carries",
+          "[engine][external][2601]") {
+    // ParameterInfo::displayText is not serialised, so the same device has one
+    // an hour into a session and none on the load that opened it. A restore
+    // that read it would move a detected parameter on every project open and
+    // leave it alone on every reload of the same slot.
+    magda::installDeviceParameterDisplayTextProviderFactory();
+
+    auto model = externalDeviceWithDetectedRange(0.7f);
+    model.parameters[1].displayText =
+        magda::makeParameterDisplayTextProvider({}, model.id, model.parameters[1].paramIndex);
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+
     magda::applyRestoredParameters(model, result.restoredParameters);
     CHECK(model.parameters[1].currentValue == Catch::Approx(0.7f));
 }


### PR DESCRIPTION
First slice of #2601. Not `Closes` — the issue's item 4 and the draw-time
appliers are still open, listed at the bottom.

MAGDA already detects a hosted plugin's real units: `ParameterDetector::detect`
plus an AI pass, driven from the Configure Parameters dialog, fed by a scan that
opens its own instance and samples `getText()`, stored per plugin in
`PluginParameterConfigStore`. Nothing kept the result.

## The units survive a rebuild

Both engines rebuild an external plugin's parameter array wholesale on load —
`populateParametersFromEngine` clears both buckets, `describeHostParameters`
returns fresh records — and nothing re-applied the stored config, so a detected
unit lasted until the next device rebuild and no longer. `applyToDevice` was only
ever called from the dialog's save, the MCP write path, and two draw-time UI
sites.

`EngineHost::applyLoadedDevice` applies it now, beside the text providers from
#2605 and for the same reason: that is where a published device is assembled and
where its identity is known.

`PluginParameterConfigStore::applyToDevice` gains an overload addressed by the
device. The id a config is filed under is the device's own — `uniqueId` where it
has one, `pluginId` otherwise — and every caller derived that by hand, most of
them reading `uniqueId` alone and so missing older devices entirely.

## They land on the parameter they were saved for

A `PluginParameterConfigEntry` is stored by its position in the device's
parameter list. The dialog's scan built a *different* list: it walked the
plugin's raw array and dropped unnamed automatable parameters, which the model
keeps. One such parameter shifted every later override onto the wrong control,
silently.

The scan now walks the host list `describeHostParameters()` builds, so the two
agree by construction rather than by both happening to filter the same way. It
also inherits the fork's naming, so a dialog row and a grid cell read the same.

## The value keeps one meaning

A detected range puts the model and the plugin in different units.
`applySavedPluginState()` and `applyRestoredParameters()` were the one pair
converting through the display range unconditionally, while the plan, the UI,
automation, baking and controller writes all go through
`modelToNormalizedValue()` / `normalizedToModelValue()`, which pick the domain by
`isDisplayMappedInternalValue()`. With a range configured, a load wrote a
frequency into a field everything else reads as normalised — a bug that only
bites once units persist, which is what the first half of this PR does.

Both directions use that pair now. This corrects what I originally wrote into
#2601: dropping the `displayText` gate from the predicate would have changed
which domain automation and controllers use for *internal* devices too, since
`NativeDeviceProcessors` attaches providers as well. The predicate stays; the
restore was the thing out of step. (Commented on the issue.)

## Tests

- The round trip with a configured range: a model holding 0.7 against a
  20 Hz–20 kHz log range reaches the plugin as 0.7 and comes back as 0.7. Both
  assertions fail with the old conversion restored — it hands the plugin 0.0 and
  writes 20 back.
- The device-addressed `applyToDevice`, including a device with no `uniqueId`
  falling back to its `pluginId`.

The scan alignment is structural rather than asserted: it now shares
`describeHostParameters()`'s list, and the unnamed-parameter retention that used
to differ is already pinned by "Repeated and missing parameter names are the
fork's". Testing the scan directly needs a real installed plugin.

`make test` (3953 passed, 13 skipped) and `make test-juce` green, corpus
included. `make lint-changed` reports nothing on the new code.

## Left for #2601

- The fork loses the config on rebuild the same way; only the native path is
  fixed here.
- `MiniChainRow` and `DeviceSlotParameterPaging` still apply the config at draw
  time. Now redundant on the native path, but removing them touches UI I cannot
  drive to verify.
- Item 4: the scan's index space is aligned, but `stableId` is still not the
  stored identity — a config written before a plugin update still addresses by
  position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN