### PR TITLE
Address a plugin's parameter config by the parameter's own id

### DIFF
--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -299,9 +299,37 @@ bool DeviceApiLive::setDeviceParameterConfig(const ChainNodePath& devicePath,
     auto config = PluginParameterConfigStore::fromDevice(*device);
     if (const auto saved = PluginParameterConfigStore::load(uniqueId)) {
         config.aiPrompt = saved->aiPrompt;
-        for (const auto& entry : saved->entries) {
-            if (entry.index >= 0 && entry.index < count)
-                config.entries[static_cast<size_t>(entry.index)] = entry;
+
+        std::vector<juce::String> currentIds;
+        currentIds.reserve(config.entries.size());
+        for (const auto& entry : config.entries)
+            currentIds.push_back(entry.id);
+
+        // Field by field onto the entry the parameter has now, rather than
+        // replacing it: the fresh entry carries the device's current position
+        // and id, and assigning the saved one over it would put back the
+        // position it was written at and erase an id a legacy file never had —
+        // so a save through here would never migrate the file.
+        const auto positions = PluginParameterConfigStore::entryPositions(*saved, currentIds);
+
+        for (size_t at = 0; at < saved->entries.size(); ++at) {
+            const auto index = positions[at];
+            if (index < 0 || index >= count)
+                continue;
+
+            const auto& from = saved->entries[at];
+            auto& into = config.entries[static_cast<size_t>(index)];
+            into.name = from.name;
+            into.visible = from.visible;
+            into.miniMixer = from.miniMixer;
+            into.aiAgent = from.aiAgent;
+            into.unit = from.unit;
+            into.scale = from.scale;
+            into.rangeMin = from.rangeMin;
+            into.rangeMax = from.rangeMax;
+            into.rangeCenter = from.rangeCenter;
+            into.choices = from.choices;
+            into.valueTable = from.valueTable;
         }
     }
 

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.cpp
@@ -144,13 +144,25 @@ juce::String hostParameterName(const juce::AudioProcessorParameter& parameter,
     return seen > 1 ? declared + " (" + juce::String(seen) + ")" : declared;
 }
 
-/// The fork's id for @p parameter: the plugin's own where it declares one, and
-/// its index otherwise.
+/// The id @p parameter declares, or empty.
+///
+/// juce::HostedAudioProcessorParameter is the interface every hosted format
+/// answers this through -- a VST3 returns its Steinberg ParamID, an AU its
+/// AudioUnitParameterID -- and it is the only identity that survives the plugin
+/// renumbering its parameters in an update. Not
+/// AudioProcessorParameterWithID, which the formats' own parameters do not
+/// derive from: the fork casts to that and so ends up with the index for every
+/// real plugin (ExternalPlugin::buildParameterList), which is an identity that
+/// matches whatever moved into the slot.
+///
+/// Empty rather than the index for a parameter that declares nothing, so a
+/// caller can tell "this is its id" from "it has none" instead of being handed
+/// a number that looks like one.
 juce::String hostParameterId(const juce::AudioProcessorParameter& parameter) {
-    if (const auto* withId = dynamic_cast<const juce::AudioProcessorParameterWithID*>(&parameter))
-        return withId->paramID;
+    if (const auto* hosted = dynamic_cast<const juce::HostedAudioProcessorParameter*>(&parameter))
+        return hosted->getParameterID();
 
-    return juce::String(parameter.getParameterIndex());
+    return {};
 }
 
 /// One of the wrapper pair, at the value @p device holds for it.

--- a/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginState.hpp
@@ -94,9 +94,11 @@ struct HostParameters {
  * hosted plugin's parameters, and everything that addresses one reads the model
  * (#2595).
  *
- * Names, ids, ranges and defaults are the fork's
+ * Names, ranges and defaults are the fork's
  * (ExternalPlugin::buildParameterList), de-duplicating suffix included, so a
  * project moved between engines finds the same parameter under the same name.
+ * The id is the one the plugin's own format declares, which the fork does not
+ * reach -- see hostParameterId().
  * The range is normalised because that is the space the fork wraps an external
  * parameter in, and the plan converts through it (ParameterUtils::domainOf).
  *

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -79,6 +79,31 @@ ParameterScale scaleFromString(const juce::String& name) {
     return ParameterScale::Linear;
 }
 
+std::vector<int> entryPositions(const PluginParameterConfig& config,
+                                const std::vector<juce::String>& currentIds) {
+    std::unordered_map<std::string, int> byId;
+    for (int at = 0; at < static_cast<int>(currentIds.size()); ++at)
+        if (const auto& id = currentIds[static_cast<size_t>(at)]; id.isNotEmpty())
+            byId.emplace(id.toStdString(), at);
+
+    const auto matchable = !byId.empty();
+
+    std::vector<int> positions;
+    positions.reserve(config.entries.size());
+
+    for (const auto& entry : config.entries) {
+        if (entry.id.isEmpty() || !matchable) {
+            positions.push_back(entry.index);
+            continue;
+        }
+
+        const auto found = byId.find(entry.id.toStdString());
+        positions.push_back(found != byId.end() ? found->second : -1);
+    }
+
+    return positions;
+}
+
 juce::File configFileFor(const juce::String& uniqueId) {
     return paths::pluginConfigsDir().getChildFile(uniqueId.replaceCharacters(":/\\,; ", "______") +
                                                   ".xml");
@@ -247,31 +272,16 @@ bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device) {
     // to be re-saved.)
     const auto count = static_cast<int>(device.parameters.size());
 
-    std::unordered_map<std::string, int> byId;
-    for (int at = 0; at < count; ++at)
-        if (const auto& id = device.parameters[static_cast<size_t>(at)].stableId; id.isNotEmpty())
-            byId.emplace(id.toStdString(), at);
+    std::vector<juce::String> currentIds;
+    currentIds.reserve(device.parameters.size());
+    for (const auto& parameter : device.parameters)
+        currentIds.push_back(parameter.stableId);
 
-    // The id where there is one to match on, so a plugin that gained or lost a
-    // parameter since the config was written still finds the ones it kept. A
-    // miss is then a parameter the plugin no longer has, and is dropped rather
-    // than falling back: the position it used to hold belongs to something else
-    // now, and that something else has an entry of its own.
-    //
-    // The position is the answer only when nothing can be matched -- a file
-    // written before ids were stored, or a plugin whose parameters declare
-    // none.
-    const auto matchable = !byId.empty();
-    const auto positionOf = [&byId, matchable](const PluginParameterConfigEntry& entry) {
-        if (entry.id.isEmpty() || !matchable)
-            return entry.index;
+    const auto positions = entryPositions(*config, currentIds);
 
-        const auto found = byId.find(entry.id.toStdString());
-        return found != byId.end() ? found->second : -1;
-    };
-
-    for (const auto& entry : config->entries) {
-        const auto index = positionOf(entry);
+    for (size_t at = 0; at < config->entries.size(); ++at) {
+        const auto& entry = config->entries[at];
+        const auto index = positions[at];
         if (index < 0 || index >= count)
             continue;
         if (entry.visible)

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -1,6 +1,7 @@
 #include "PluginParameterConfigStore.hpp"
 
 #include <algorithm>
+#include <unordered_map>
 
 #include "AppPaths.hpp"
 #include "DeviceInfo.hpp"
@@ -106,6 +107,7 @@ std::optional<PluginParameterConfig> load(const juce::String& uniqueId) {
             entry.index = paramElem->getIntAttribute("index", -1);
             if (entry.index < 0)
                 continue;
+            entry.id = paramElem->getStringAttribute("id");
             entry.name = paramElem->getStringAttribute("name");
             entry.visible = paramElem->getBoolAttribute("visible", false);
             entry.miniMixer = paramElem->getBoolAttribute("mini", false);
@@ -165,6 +167,8 @@ bool save(const juce::String& uniqueId, const PluginParameterConfig& config) {
     for (const auto& entry : config.entries) {
         auto* paramElem = paramsElem->createNewChildElement("Param");
         paramElem->setAttribute("index", entry.index);
+        if (entry.id.isNotEmpty())
+            paramElem->setAttribute("id", entry.id);
         paramElem->setAttribute("name", entry.name);
         paramElem->setAttribute("visible", entry.visible);
         paramElem->setAttribute("mini", entry.miniMixer);
@@ -210,6 +214,7 @@ PluginParameterConfig fromDevice(const DeviceInfo& device) {
         const auto& info = device.parameters[i];
         PluginParameterConfigEntry entry;
         entry.index = static_cast<int>(i);
+        entry.id = info.stableId;
         entry.name = info.name;
         entry.unit = info.unit;
         entry.scale = info.scale;
@@ -241,17 +246,42 @@ bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device) {
     // indices 0/1 were dry/wet; those resolve to the wrong slots once and need
     // to be re-saved.)
     const auto count = static_cast<int>(device.parameters.size());
+
+    std::unordered_map<std::string, int> byId;
+    for (int at = 0; at < count; ++at)
+        if (const auto& id = device.parameters[static_cast<size_t>(at)].stableId; id.isNotEmpty())
+            byId.emplace(id.toStdString(), at);
+
+    // The id where there is one to match on, so a plugin that gained or lost a
+    // parameter since the config was written still finds the ones it kept. A
+    // miss is then a parameter the plugin no longer has, and is dropped rather
+    // than falling back: the position it used to hold belongs to something else
+    // now, and that something else has an entry of its own.
+    //
+    // The position is the answer only when nothing can be matched -- a file
+    // written before ids were stored, or a plugin whose parameters declare
+    // none.
+    const auto matchable = !byId.empty();
+    const auto positionOf = [&byId, matchable](const PluginParameterConfigEntry& entry) {
+        if (entry.id.isEmpty() || !matchable)
+            return entry.index;
+
+        const auto found = byId.find(entry.id.toStdString());
+        return found != byId.end() ? found->second : -1;
+    };
+
     for (const auto& entry : config->entries) {
-        if (entry.index < 0 || entry.index >= count)
+        const auto index = positionOf(entry);
+        if (index < 0 || index >= count)
             continue;
         if (entry.visible)
-            device.visibleParameters.push_back(entry.index);
+            device.visibleParameters.push_back(index);
         if (entry.miniMixer)
-            device.miniMixerParameters.push_back(entry.index);
+            device.miniMixerParameters.push_back(index);
         if (entry.aiAgent)
-            device.aiSoundDesignerParameters.push_back(entry.index);
+            device.aiSoundDesignerParameters.push_back(index);
 
-        auto& parameter = device.parameters[static_cast<size_t>(entry.index)];
+        auto& parameter = device.parameters[static_cast<size_t>(index)];
         if (entry.unit)
             parameter.unit = *entry.unit;
         if (entry.scale)

--- a/magda/daw/core/PluginParameterConfigStore.hpp
+++ b/magda/daw/core/PluginParameterConfigStore.hpp
@@ -15,13 +15,23 @@ struct DeviceInfo;
  * @brief One parameter's saved customization, as stored in the per-plugin
  * config XML.
  *
- * `index` is the position in `DeviceInfo::parameters`. The optional fields are
+ * `index` is the position in `DeviceInfo::parameters`, used when `id` cannot
+ * answer. The optional fields are
  * detection overrides (unit, scale, range, choices, value table): absent means
  * "leave whatever the device reports", which is how legacy files that predate
  * detection data keep working.
  */
 struct PluginParameterConfigEntry {
     int index = -1;
+
+    /// The parameter's own id (ParameterInfo::stableId), which for a hosted
+    /// plugin is the `paramID` it declares. What an entry is matched by, with
+    /// `index` as the fallback for the files written before this existed and
+    /// for plugins that declare no ids: a plugin that gains a parameter in an
+    /// update renumbers everything after it, and a config addressed by
+    /// position then describes the wrong controls.
+    juce::String id;
+
     juce::String name;
     bool visible = false;
     bool miniMixer = false;

--- a/magda/daw/core/PluginParameterConfigStore.hpp
+++ b/magda/daw/core/PluginParameterConfigStore.hpp
@@ -68,6 +68,23 @@ namespace PluginParameterConfigStore {
 juce::String scaleToString(ParameterScale scale);
 ParameterScale scaleFromString(const juce::String& name);
 
+/**
+ * @brief Where each of @p config's entries lands among @p currentIds.
+ *
+ * One answer for every reader of a config file, because a stored entry and a
+ * live parameter list can disagree: a plugin update inserts a parameter and
+ * everything after it moves. Parallel to `config.entries`; -1 for an entry
+ * whose parameter the plugin no longer has.
+ *
+ * The id decides where it can. A miss is a parameter that is gone, and is
+ * dropped rather than falling back -- the position it held belongs to
+ * something else now, and that something else has an entry of its own.
+ * Position is the answer only when nothing can be matched: a file written
+ * before ids were stored, or a plugin whose parameters declare none.
+ */
+std::vector<int> entryPositions(const PluginParameterConfig& config,
+                                const std::vector<juce::String>& currentIds);
+
 /// The config file for `uniqueId`, whether or not it exists yet.
 juce::File configFileFor(const juce::String& uniqueId);
 

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -49,6 +49,12 @@ struct GrooveTemplateData {
 
 struct ScannedPluginParameter {
     juce::String name;
+
+    /// The parameter's own id, which is what a saved config is matched by
+    /// (PluginParameterConfigEntry::id). Empty for a parameter that declares
+    /// none, which falls back to its position.
+    juce::String stableId;
+
     float defaultValue = 0.5f;
     juce::String unit;
     float rangeMin = 0.0f;

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -675,6 +675,7 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
             const int numStates = parameter->getNumberOfStates();
             ScannedPluginParameter info;
             info.name = parameter->getParameterName();
+            info.stableId = parameter->paramID;
             info.defaultValue = parameter->getDefaultValue().value_or(range.getStart());
             info.unit = "%";
             info.rangeMin = range.getStart();
@@ -738,6 +739,7 @@ std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters
 
         ScannedPluginParameter info;
         info.name = model.name;
+        info.stableId = model.stableId;
         info.defaultValue = parameter->getDefaultValue();
         const auto rawLabel = parameter->getLabel().trim();
         info.unit = rawLabel.length() <= 6 && !rawLabel.contains("[") && !rawLabel.contains("(")

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -1302,11 +1302,25 @@ void ParameterConfigDialog::loadParameterConfiguration() {
         param.isVisible = false;
     }
 
+    // By the same rule applyToDevice() reads one: the row a saved entry
+    // describes is the one whose parameter it names, not the one it sat at when
+    // it was written. Overlaying by position would show an old customization
+    // against the wrong control, and this dialog's save would then write that
+    // row's id over it and make the mistake permanent.
+    std::vector<juce::String> currentIds;
+    currentIds.reserve(parameters_.size());
+    for (const auto& parameter : parameters_)
+        currentIds.push_back(parameter.stableId);
+
+    const auto positions = magda::PluginParameterConfigStore::entryPositions(*config, currentIds);
+
     int loadedCount = 0;
-    for (const auto& entry : config->entries) {
-        if (entry.index < 0 || entry.index >= static_cast<int>(parameters_.size()))
+    for (size_t at = 0; at < config->entries.size(); ++at) {
+        const auto& entry = config->entries[at];
+        const auto index = positions[at];
+        if (index < 0 || index >= static_cast<int>(parameters_.size()))
             continue;
-        auto& p = parameters_[static_cast<size_t>(entry.index)];
+        auto& p = parameters_[static_cast<size_t>(index)];
         p.isVisible = entry.visible;
         p.inMiniMixer = entry.miniMixer;
         p.inAiSoundDesigner = entry.aiAgent;

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -915,6 +915,7 @@ void ParameterConfigDialog::loadParameters(const juce::String& uniqueId) {
     for (auto& scanned : audioEngine->scanPluginParameters(uniqueId, false)) {
         MockParameterInfo info;
         info.name = scanned.name;
+        info.stableId = scanned.stableId;
         info.defaultValue = scanned.defaultValue;
         info.isVisible = true;
         info.unit = scanned.unit;
@@ -948,6 +949,7 @@ bool ParameterConfigDialog::scanInternalParameters(const juce::String& pluginId)
     for (auto& scanned : audioEngine->scanPluginParameters(pluginId, true)) {
         MockParameterInfo info;
         info.name = scanned.name;
+        info.stableId = scanned.stableId;
         info.isVisible = true;
         info.defaultValue = scanned.defaultValue;
         info.rangeMin = scanned.rangeMin;
@@ -1252,6 +1254,7 @@ void ParameterConfigDialog::saveParameterConfiguration() {
         const auto& p = parameters_[i];
         magda::PluginParameterConfigEntry entry;
         entry.index = static_cast<int>(i);
+        entry.id = p.stableId;
         entry.name = p.name;
         // Internal devices intentionally expose no Visible params (only Mini FX),
         // so never persist visibility for them regardless of the default state.

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.hpp
@@ -21,6 +21,9 @@ namespace magda::daw::ui {
  */
 struct MockParameterInfo {
     juce::String name;
+    /// The parameter's own id, carried from the scan so the config this dialog
+    /// writes is addressed by identity rather than by row.
+    juce::String stableId;
     float defaultValue = 0.5f;
     bool isVisible = true;
     juce::String unit;  // Hz, dB, ms, %, semitones, custom

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -65,6 +65,11 @@ magda::DeviceInfo makeExternalDevice() {
     device.parameters.emplace_back(2, "Mode", "", 0.0f, 2.0f, 0.0f,
                                    magda::ParameterScale::Discrete);
     device.parameters[2].choices = {"LP", "BP", "HP"};
+
+    // The ids the plugin declares, which is what an entry is matched by.
+    device.parameters[0].stableId = "cutoff";
+    device.parameters[1].stableId = "res";
+    device.parameters[2].stableId = "mode";
     return device;
 }
 
@@ -177,6 +182,86 @@ TEST_CASE("A device with no uniqueId is filed under its plugin id", "[param-conf
 
     REQUIRE(store::applyToDevice(device));
     CHECK(device.parameters[1].unit == "dB");
+}
+
+TEST_CASE("A config follows its parameter when the plugin renumbers",
+          "[param-config-store][2601]") {
+    // What a plugin update does: a parameter appears, and everything after it
+    // moves down one. Addressed by position, every override past the new one
+    // would describe the wrong control from then on.
+    TempDataDir temp;
+    const auto configured = makeExternalDevice();
+
+    auto config = store::fromDevice(configured);
+    config.entries[2].visible = true;
+    config.entries[2].unit = "shape";
+    REQUIRE(store::save(configured.uniqueId, config));
+
+    auto updated = makeExternalDevice();
+    magda::ParameterInfo added(0, "Drive", "", 0.0f, 1.0f, 0.0f);
+    added.stableId = "drive";
+    updated.parameters.insert(updated.parameters.begin(), added);
+
+    REQUIRE(store::applyToDevice(updated));
+
+    // Mode is at three now, and that is where its override landed.
+    CHECK(updated.parameters[3].name == "Mode");
+    CHECK(updated.parameters[3].unit == "shape");
+    CHECK(updated.visibleParameters == std::vector<int>{3});
+
+    // The parameter that took the old position is untouched.
+    CHECK(updated.parameters[2].unit == "%");
+}
+
+TEST_CASE("An entry for a parameter the plugin dropped is ignored", "[param-config-store][2601]") {
+    TempDataDir temp;
+    const auto configured = makeExternalDevice();
+
+    auto config = store::fromDevice(configured);
+    config.entries[1].visible = true;
+    config.entries[1].unit = "Q";
+    REQUIRE(store::save(configured.uniqueId, config));
+
+    auto updated = makeExternalDevice();
+    updated.parameters.erase(updated.parameters.begin() + 1);  // Resonance is gone
+
+    REQUIRE(store::applyToDevice(updated));
+
+    // Nothing inherits the missing parameter's override, and Mode -- which now
+    // sits where it used to -- keeps its own.
+    CHECK(updated.parameters[1].name == "Mode");
+    CHECK(updated.parameters[1].unit.isEmpty());
+    CHECK(updated.visibleParameters.empty());
+}
+
+TEST_CASE("A config written before ids is still addressed by position",
+          "[param-config-store][2601]") {
+    // Every file on disk today. The id is what a re-save adds.
+    TempDataDir temp;
+    auto device = makeExternalDevice();
+
+    auto config = store::fromDevice(device);
+    for (auto& entry : config.entries)
+        entry.id = {};
+    config.entries[1].unit = "Q";
+    REQUIRE(store::save(device.uniqueId, config));
+
+    REQUIRE(store::applyToDevice(device));
+    CHECK(device.parameters[1].unit == "Q");
+}
+
+TEST_CASE("A parameter that declares no id keeps its position", "[param-config-store][2601]") {
+    TempDataDir temp;
+    auto device = makeExternalDevice();
+    for (auto& parameter : device.parameters)
+        parameter.stableId = {};
+
+    auto config = store::fromDevice(device);
+    config.entries[2].unit = "shape";
+    REQUIRE(store::save(device.uniqueId, config));
+
+    REQUIRE(store::applyToDevice(device));
+    CHECK(device.parameters[2].unit == "shape");
 }
 
 TEST_CASE("legacy visible-only config files still load", "[param-config-store]") {

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -102,6 +102,54 @@ class StubParameter final : public juce::AudioProcessorParameterWithID {
     float value_ = 0.0f;
 };
 
+/**
+ * @brief A parameter shaped the way a real hosted plugin's is.
+ *
+ * JUCE's own VST3 and AU parameters derive from HostedAudioProcessorParameter
+ * and answer getParameterID(); they are not AudioProcessorParameterWithID,
+ * which is the class a plugin written against JUCE uses for parameters of its
+ * own. A stub built from the latter would let an id read through the wrong
+ * interface look like it worked.
+ */
+class HostedStubParameter final : public juce::HostedAudioProcessorParameter {
+  public:
+    HostedStubParameter(juce::String id, juce::String name)
+        : id_(std::move(id)), name_(std::move(name)) {}
+
+    juce::String getParameterID() const override {
+        return id_;
+    }
+
+    float getValue() const override {
+        return value_;
+    }
+
+    void setValue(float newValue) override {
+        value_ = newValue;
+    }
+
+    float getDefaultValue() const override {
+        return 0.0f;
+    }
+
+    juce::String getName(int) const override {
+        return name_;
+    }
+
+    juce::String getLabel() const override {
+        return {};
+    }
+
+    float getValueForText(const juce::String& text) const override {
+        return text.getFloatValue();
+    }
+
+  private:
+    juce::String id_;
+    juce::String name_;
+    float value_ = 0.0f;
+};
+
 /// The class id a stub VST3's preset header carries, which is the identity
 /// another host matches on and the one thing MAGDA reads out of the header.
 constexpr const char* kStubVst3ClassId = "0123456789ABCDEF0123456789ABCDEF";
@@ -2055,6 +2103,23 @@ TEST_CASE("The answer does not depend on a provider no project carries",
 
     magda::applyRestoredParameters(model, result.restoredParameters);
     CHECK(model.parameters[1].currentValue == Catch::Approx(0.7f));
+}
+
+TEST_CASE("A parameter's id is the one its format declares", "[engine][external][2601]") {
+    // What a saved parameter config is matched by, so a plugin that renumbers
+    // its parameters in an update does not hand every override to whatever
+    // moved into the slot. The formats answer this through
+    // HostedAudioProcessorParameter, which their parameters derive from and
+    // AudioProcessorParameterWithID is only one implementation of.
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    plugin->addHostedParameter(std::make_unique<HostedStubParameter>("1701", "Cutoff"));
+
+    const auto result = adapter::adaptExternalPluginInstance(std::move(plugin), externalDevice());
+
+    const auto* cutoff = resolvedParameterAt(result, 4);
+    REQUIRE(cutoff != nullptr);
+    CHECK(cutoff->name == "Cutoff");
+    CHECK(cutoff->stableId == "1701");
 }
 
 TEST_CASE("Successful adaptation reports live buses and MIDI capabilities", "[engine][external]") {


### PR DESCRIPTION
Item 3 of #2601, the second part. `Refs`, not `Closes` — the remaining items are
listed at the bottom.

A `PluginParameterConfigEntry` was stored by its position in the device's
parameter list. A plugin that gains a parameter in an update renumbers
everything after it, and every later override then describes the control that
used to be at that position — a detected `Hz` range landing on a resonance, a
visible-parameter selection pointing at something else. Silently.

## What changed

Entries carry the parameter's own id: `ParameterInfo::stableId`, which for a
hosted plugin is the `paramID` it declares and which #2599 already records.
`applyToDevice` matches on that, and pushes the rebuilt visible / mini-mixer /
AI selections at the position the match found rather than at the one the file
recorded.

**A miss drops the entry** rather than falling back to the position. That was
the first thing my own test caught: a parameter the plugin no longer has would
otherwise hand its override to whatever moved into its slot, which is exactly
the failure this is meant to remove.

**Position is still the answer when nothing can be matched** — a file written
before ids were stored, or a plugin whose parameters declare none — so every
config on disk keeps working unchanged and gains an id on its next save. The
`id` attribute is only written when non-empty, so the format stays readable by
older builds.

The dialog writes ids as well: `ScannedPluginParameter` reports each parameter's
id alongside its name, taken from `describeHostParameters()` on the external
branch and from the parameter's `paramID` on the internal one, and carried
through `MockParameterInfo` into the file the dialog saves.

## Tests

Four cases in `tests/devices/test_plugin_parameter_config_store.cpp`, two of
which fail with position-only matching restored:

- A plugin that inserts a parameter at the front: the override follows `Mode` to
  its new position, and the parameter that took the old one is untouched.
- A plugin that drops a parameter: nothing inherits its override, and the
  parameter that moved into its position keeps its own.
- A config written before ids still applies by position.
- A plugin whose parameters declare no ids still applies by position.

`make test` (3958 passed, 13 skipped) and `make test-juce` green. `make
lint-changed` reports nothing on the new code.

## Left on #2601

- The fork still loses the stored config on rebuild; only the native path
  re-applies it.
- `MiniChainRow` and `DeviceSlotParameterPaging` still apply it at draw time —
  redundant on the native path, but removing them needs a hands-on check.
- `scanPluginParameters` opens its own instance rather than asking whichever
  engine holds the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN