### PR TITLE
Re-apply a plugin's parameter config when its parameter array is rebuilt

### DIFF
--- a/magda/daw/audio/processors/base/DeviceProcessor.cpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.cpp
@@ -2,6 +2,8 @@
 
 #include <utility>
 
+#include "core/PluginParameterConfigStore.hpp"
+
 namespace magda {
 
 DeviceProcessor::DeviceProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
@@ -97,30 +99,35 @@ bool DeviceProcessor::isDeltaSolo() const {
 void DeviceProcessor::populateParameters(DeviceInfo& info, ValueSource source) const {
     if (source == ValueSource::Engine || info.format != PluginFormat::Internal) {
         populateParametersFromEngine(info);
-        return;
+    } else {
+        const auto model = std::move(info.parameters);
+        populateParametersFromEngine(info);
+
+        auto sameParameter = [](const ParameterInfo& kept, const ParameterInfo& fresh) {
+            if (kept.paramIndex != fresh.paramIndex)
+                return false;
+            // A minimal hydrated entry (value and saved id only, named after
+            // that id) has no metadata to compare; its frozen index is all it
+            // has.
+            if (kept.name == kept.stableId)
+                return true;
+            if (kept.stableId.isNotEmpty() && fresh.stableId.isNotEmpty())
+                return kept.stableId == fresh.stableId;
+            return kept.name == fresh.name;
+        };
+
+        for (auto& fresh : info.parameters)
+            for (const auto& kept : model)
+                if (sameParameter(kept, fresh)) {
+                    fresh.currentValue = kept.currentValue;
+                    break;
+                }
     }
 
-    const auto model = std::move(info.parameters);
-    populateParametersFromEngine(info);
-
-    auto sameParameter = [](const ParameterInfo& kept, const ParameterInfo& fresh) {
-        if (kept.paramIndex != fresh.paramIndex)
-            return false;
-        // A minimal hydrated entry (value and saved id only, named after that
-        // id) has no metadata to compare; its frozen index is all it has.
-        if (kept.name == kept.stableId)
-            return true;
-        if (kept.stableId.isNotEmpty() && fresh.stableId.isNotEmpty())
-            return kept.stableId == fresh.stableId;
-        return kept.name == fresh.name;
-    };
-
-    for (auto& fresh : info.parameters)
-        for (const auto& kept : model)
-            if (sameParameter(kept, fresh)) {
-                fresh.currentValue = kept.currentValue;
-                break;
-            }
+    // What the plugin's parameters were detected to mean, over the bare records
+    // the engine reports. The array is rebuilt on every load, so this has to be
+    // here; EngineHost::applyLoadedDevice is the native engine's match (#2601).
+    PluginParameterConfigStore::applyToDevice(info);
 }
 
 void DeviceProcessor::syncFromDeviceInfo(const DeviceInfo& info) {

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 
+#include "magda/daw/audio/processors/base/DeviceProcessor.hpp"
 #include "magda/daw/core/AppPaths.hpp"
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/PluginParameterConfigStore.hpp"
@@ -72,6 +73,25 @@ magda::DeviceInfo makeExternalDevice() {
     device.parameters[2].stableId = "mode";
     return device;
 }
+
+/// A processor whose engine read is a fixed list, standing in for whatever the
+/// fork rebuilds a device's parameter array from.
+class StubProcessor : public magda::DeviceProcessor {
+  public:
+    explicit StubProcessor(std::vector<magda::ParameterInfo> parameters)
+        : magda::DeviceProcessor(1, nullptr), parameters_(std::move(parameters)) {}
+
+    int getParameterCount() const override {
+        return static_cast<int>(parameters_.size());
+    }
+
+    magda::ParameterInfo getParameterInfo(int index) const override {
+        return parameters_[static_cast<std::size_t>(index)];
+    }
+
+  private:
+    std::vector<magda::ParameterInfo> parameters_;
+};
 
 }  // namespace
 
@@ -300,4 +320,56 @@ TEST_CASE("hasAiSoundDesignerParameters reflects the saved AI selection", "[para
     config.entries[1].aiAgent = true;
     REQUIRE(store::save(device.uniqueId, config));
     REQUIRE(store::hasAiSoundDesignerParameters(device.uniqueId));
+}
+
+TEST_CASE("A rebuilt parameter array carries the plugin's stored config",
+          "[param-config-store][2601]") {
+    // Both engines rebuild an external plugin's array wholesale on load, so a
+    // detected unit that is not re-applied there lasts until the next rebuild
+    // and no longer.
+    TempDataDir temp;
+    const auto configured = makeExternalDevice();
+
+    auto config = store::fromDevice(configured);
+    config.entries[0].visible = true;
+    config.entries[0].unit = "kHz";
+    config.entries[0].rangeMax = 20.0f;
+    REQUIRE(store::save(configured.uniqueId, config));
+
+    const StubProcessor processor(configured.parameters);
+
+    magda::DeviceInfo device;
+    device.uniqueId = configured.uniqueId;
+    device.format = magda::PluginFormat::VST3;
+    processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Engine);
+
+    REQUIRE(device.parameters.size() == 3);
+    CHECK(device.parameters[0].unit == "kHz");
+    CHECK(device.parameters[0].maxValue == 20.0f);
+    CHECK(device.visibleParameters == std::vector<int>{0});
+}
+
+TEST_CASE("A model-first refresh keeps its values and still gains the config",
+          "[param-config-store][2601]") {
+    // An internal device takes the other branch of populateParameters: values
+    // stay the model's, metadata is re-read, and the overlay goes over both.
+    TempDataDir temp;
+    const auto configured = makeExternalDevice();
+
+    auto config = store::fromDevice(configured);
+    config.entries[1].unit = "Q";
+    REQUIRE(store::save("magda_stub_device", config));
+
+    const StubProcessor processor(configured.parameters);
+
+    magda::DeviceInfo device;
+    device.pluginId = "magda_stub_device";
+    device.format = magda::PluginFormat::Internal;
+    device.parameters = configured.parameters;
+    device.parameters[1].currentValue = 42.0f;
+    processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Model);
+
+    REQUIRE(device.parameters.size() == 3);
+    CHECK(device.parameters[1].currentValue == 42.0f);
+    CHECK(device.parameters[1].unit == "Q");
 }


### PR DESCRIPTION
Item 1 of the three left on #2601. `Refs`, not `Closes` — the other two are
listed at the bottom.

Configure a VST3's cutoff as 20–20000 Hz, and the units hold until the device
is next rebuilt. Then they are gone: the fork rebuilds a device's parameter
array wholesale on load (`populateParametersFromEngine` clears both buckets),
and nothing re-applied the stored config afterwards. Only the native path did,
in `EngineHost::applyLoadedDevice`. On the fork the units came back only where
`MiniChainRow` and `DeviceSlotParameterPaging` apply the config at draw time —
which is why the selections reappeared and the units did not.

## What changed

`DeviceProcessor::populateParameters()` applies the stored config after the
array is built, whichever branch it took. That is the fork's match for
`applyLoadedDevice`, and putting it at the one place the array is rebuilt means
every caller gets it rather than each one remembering: plugin load, rack
registration, `refreshDeviceParameters`, `loadDeviceAsPlugin`, drum-grid
capture, and the custom-UI refresh.

The Engine branch's early `return` became an `if`/`else`, which is most of the
diff's size — the reindented model-merge block is otherwise unchanged.

`applyToDevice` does not touch `currentValue`, so the model-first merge (#2317)
still decides every value; the overlay is metadata and the three selection
lists only.

## On clearing `visibleParameters`

`applyToDevice` rebuilds the visible / mini-mixer / AI selections rather than
merging them, and `DeviceSlotParameterPaging` guards against writing an empty
visible list back. That guard turns out to be unnecessary:
`TrackManager::setDeviceVisibleParameters` has exactly one caller, fed from the
config store itself, so nothing else ever writes that list and there is no
per-instance selection to lose.

## Tests

Two cases in `tests/devices/test_plugin_parameter_config_store.cpp`, one per
branch of `populateParameters`, over a stub processor with a fixed parameter
list:

- An external device rebuilt from the engine comes back carrying the detected
  unit, the overridden range and the visible selection.
- An internal device refreshed model-first keeps its model value and still
  gains the stored unit.

Both fail with the call removed — `Hz` not `kHz`, `20000` not `20`, an empty
`visibleParameters` — and nothing else does.

`make test` (3998 passed, 13 skipped) and `make test-juce` green.
`make lint-changed` reports nothing on either file.

## Left on #2601

- `MiniChainRow` and `DeviceSlotParameterPaging` still apply the config at draw
  time — redundant on both engines now, but removing them needs a hands-on
  check.
- `scanPluginParameters` opens its own instance rather than asking whichever
  engine holds the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
