### PR TITLE
Scan a MAGDA device's parameters off the catalog rather than out of an Edit

### DIFF
--- a/magda/daw/audio/plugins/MagdaDevice.hpp
+++ b/magda/daw/audio/plugins/MagdaDevice.hpp
@@ -3,7 +3,9 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_data_structures/juce_data_structures.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <ranges>
 #include <string_view>
 
 #include "core/ParameterInfo.hpp"
@@ -188,6 +190,14 @@ class MagdaDevice {
         return 0.0f;
     }
     virtual void setParameterValue(int, float) {}
+
+    /// Every parameter this device describes, in slot order. Non-virtual, over
+    /// the two above: a device implements nothing extra. The view yields values,
+    /// because parameterInfo() builds one per call.
+    auto parameters() const {
+        return std::views::iota(0, std::max(0, parameterCount())) |
+               std::views::transform([this](int slot) { return parameterInfo(slot); });
+    }
 
     virtual void flushState(juce::ValueTree&) {}
     virtual void restoreState(const juce::ValueTree&) {}

--- a/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineMagdaDevice.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <optional>
+#include <ranges>
 #include <utility>
 
 #include "core/ParameterUtils.hpp"
@@ -145,11 +146,9 @@ EngineMagdaDevice::EngineMagdaDevice(std::unique_ptr<MagdaDevice> device, bool o
     : device_(std::move(device)),
       properties_(propertiesForRequiredDevice(device_)),
       offlineRender_(offlineRender) {
-    const int count = std::max(0, device_->parameterCount());
-    parameters_.reserve(static_cast<std::size_t>(count));
+    parameters_.reserve(static_cast<std::size_t>(std::max(0, device_->parameterCount())));
 
-    for (int index = 0; index < count; ++index) {
-        auto info = device_->parameterInfo(index);
+    for (auto [index, info] : std::views::zip(std::views::iota(0), device_->parameters())) {
         // The plan addresses a device's parameters by ParameterInfo::paramIndex
         // and allocates a slot for every index from zero, so a device that left
         // it unset is addressed by its declaration order. Same fallback the

--- a/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionMagdaDevicePlugin.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <ranges>
 #include <utility>
 
 #include "core/ParameterUtils.hpp"
@@ -428,8 +429,7 @@ void TracktionMagdaDevicePlugin::buildParameters() {
     parameterValues_.reserve(static_cast<std::size_t>(count));
     parameters_.reserve(static_cast<std::size_t>(count));
 
-    for (int index = 0; index < count; ++index) {
-        auto info = device_->parameterInfo(index);
+    for (auto [index, info] : std::views::zip(std::views::iota(0), device_->parameters())) {
         const int stableIndex = info.paramIndex >= 0 ? info.paramIndex : index;
         const auto id = info.stableId.isNotEmpty()
                             ? info.stableId

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -31,12 +31,15 @@ float computeSkew(float anchorPosition) {
     return std::log(anchorPosition) / std::log(0.5f);
 }
 
-// True when the anchor is set and strictly inside (min, max).
-bool hasValidAnchor(const ParameterDomain& domain) {
+}  // namespace
+
+bool hasScaleAnchor(const ParameterDomain& domain) {
     return domain.scaleAnchor > domain.minValue && domain.scaleAnchor < domain.maxValue;
 }
 
-}  // namespace
+bool hasScaleAnchor(const ParameterInfo& info) {
+    return hasScaleAnchor(domainOf(info));
+}
 
 ParameterDomain domainOf(const ParameterInfo& info) {
     ParameterDomain domain;
@@ -64,7 +67,7 @@ float normalizedToReal(float normalized, const ParameterDomain& domain) {
     switch (domain.scale) {
         case ParameterScale::Linear: {
             float range = domain.maxValue - domain.minValue;
-            if (hasValidAnchor(domain) && range > 0.0f) {
+            if (hasScaleAnchor(domain) && range > 0.0f) {
                 float anchorPos = (domain.scaleAnchor - domain.minValue) / range;
                 float skew = computeSkew(anchorPos);
                 normalized = std::pow(normalized, skew);
@@ -78,7 +81,7 @@ float normalizedToReal(float normalized, const ParameterDomain& domain) {
                 return domain.minValue + normalized * (domain.maxValue - domain.minValue);
             }
             float logRange = std::log(domain.maxValue / domain.minValue);
-            if (hasValidAnchor(domain)) {
+            if (hasScaleAnchor(domain)) {
                 // Place anchor at norm=0.5 in log space by skewing norm first.
                 float anchorLogPos = std::log(domain.scaleAnchor / domain.minValue) / logRange;
                 float skew = computeSkew(anchorLogPos);
@@ -148,7 +151,7 @@ float realToNormalized(float real, const ParameterDomain& domain) {
             if (range == 0.0f)
                 return 0.0f;
             float linPos = (real - domain.minValue) / range;
-            if (hasValidAnchor(domain)) {
+            if (hasScaleAnchor(domain)) {
                 float anchorPos = (domain.scaleAnchor - domain.minValue) / range;
                 float skew = computeSkew(anchorPos);
                 // Invert the forward skew (norm -> norm^skew) with norm -> norm^(1/skew).
@@ -169,7 +172,7 @@ float realToNormalized(float real, const ParameterDomain& domain) {
             if (logRange == 0.0f)
                 return 0.0f;
             float logPos = std::log(real / domain.minValue) / logRange;
-            if (hasValidAnchor(domain)) {
+            if (hasScaleAnchor(domain)) {
                 float anchorLogPos = std::log(domain.scaleAnchor / domain.minValue) / logRange;
                 float skew = computeSkew(anchorLogPos);
                 logPos = std::pow(juce::jlimit(0.0f, 1.0f, logPos), 1.0f / skew);

--- a/magda/daw/core/ParameterUtils.hpp
+++ b/magda/daw/core/ParameterUtils.hpp
@@ -76,6 +76,17 @@ float realToNormalized(float real, const ParameterInfo& info);
 float realToNormalized(float real, const ParameterDomain& domain);
 
 /**
+ * @brief Whether a parameter places a chosen real value at normalized 0.5.
+ *
+ * An anchor counts when it is strictly inside the range. 0.0 is the unset
+ * default, but a range that straddles zero makes 0.0 a real value like any
+ * other, and an anchor outside the range is not one -- so neither a sign test
+ * nor a comparison against zero answers this.
+ */
+bool hasScaleAnchor(const ParameterInfo& info);
+bool hasScaleAnchor(const ParameterDomain& domain);
+
+/**
  * @brief A normalized fader position as the linear gain `TrackManager` stores.
  *
  * `TrackInfo::volume` and `SendInfo::level` are linear gains, while the fader

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(magda_daw PRIVATE
     TempoSequenceRippleCommand.cpp
     OfflineRenderHelper.cpp
     AudioEngineChoice.cpp
+    DeviceParameterScan.cpp
     TracktionEngineWrapper.cpp
     TracktionEngineWrapperInit.cpp
     TracktionEngineWrapperDevices.cpp
@@ -25,6 +26,7 @@ target_sources(magda_daw PRIVATE
     PluginWindowManager.cpp
     # Headers (listed for IDE visibility)
     AudioEngine.hpp
+    DeviceParameterScan.hpp
     AudioEngineChoice.hpp
     OfflineRenderHelper.hpp
     TracktionEngineWrapper.hpp

--- a/magda/daw/engine/DeviceParameterScan.cpp
+++ b/magda/daw/engine/DeviceParameterScan.cpp
@@ -37,6 +37,48 @@ std::unique_ptr<audio::MagdaDevice> createDetachedDevice(const juce::String& plu
     return {};
 }
 
+/// One scan record off one parameter's own description. `position` is where the
+/// record lands in the result rather than the slot it was read from: a skipped
+/// parameter leaves the two apart, and a detection result is applied by
+/// position.
+ScannedPluginParameter scanRecord(const ParameterInfo& info, int position) {
+    constexpr std::array<float, 5> samplePoints{0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
+
+    ScannedPluginParameter scanned;
+    scanned.name = info.name;
+    scanned.stableId = info.stableId;
+    scanned.defaultValue = info.defaultValue;
+    scanned.unit = info.unit;
+    scanned.rangeMin = info.minValue;
+    scanned.rangeMax = info.maxValue;
+    // scaleAnchor is the real value a parameter asks to sit at the middle of
+    // its own travel, which is what rangeCenter means.
+    scanned.rangeCenter =
+        info.scaleAnchor > 0.0f ? info.scaleAnchor : (info.minValue + info.maxValue) * 0.5f;
+    scanned.scale = info.scale;
+    scanned.valueTable = info.valueTable.empty() ? info.choices : info.valueTable;
+
+    scanned.scanInput.paramIndex = position;
+    scanned.scanInput.name = info.name;
+    scanned.scanInput.label = info.unit;
+    scanned.scanInput.rangeMin = info.minValue;
+    scanned.scanInput.rangeMax = info.maxValue;
+    scanned.scanInput.stateCount = static_cast<int>(info.choices.size());
+
+    // Through the model's own formatter, which is what the host wraps one of
+    // these parameters in as well, so Detect reads the strings the UI shows
+    // rather than a second opinion about them.
+    if (!info.choices.empty()) {
+        scanned.scanInput.displayTexts = info.choices;
+    } else {
+        for (const auto sample : samplePoints)
+            scanned.scanInput.displayTexts.push_back(
+                ParameterUtils::formatValue(ParameterUtils::normalizedToReal(sample, info), info));
+    }
+
+    return scanned;
+}
+
 }  // namespace
 
 std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& pluginId) {
@@ -45,48 +87,6 @@ std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& plu
     const auto device = createDetachedDevice(pluginId);
     if (device == nullptr)
         return result;
-
-    // One scan record off one parameter's own description. `position` is where
-    // the record lands in the result rather than the slot it was read from: a
-    // skipped parameter leaves the two apart, and a detection result is applied
-    // by position.
-    const auto scanRecord = [](const ParameterInfo& info, int position) {
-        constexpr std::array<float, 5> samplePoints{0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
-
-        ScannedPluginParameter scanned;
-        scanned.name = info.name;
-        scanned.stableId = info.stableId;
-        scanned.defaultValue = info.defaultValue;
-        scanned.unit = info.unit;
-        scanned.rangeMin = info.minValue;
-        scanned.rangeMax = info.maxValue;
-        // scaleAnchor is the real value a parameter asks to sit at the middle
-        // of its own travel, which is what rangeCenter means.
-        scanned.rangeCenter =
-            info.scaleAnchor > 0.0f ? info.scaleAnchor : (info.minValue + info.maxValue) * 0.5f;
-        scanned.scale = info.scale;
-        scanned.valueTable = info.valueTable.empty() ? info.choices : info.valueTable;
-
-        scanned.scanInput.paramIndex = position;
-        scanned.scanInput.name = info.name;
-        scanned.scanInput.label = info.unit;
-        scanned.scanInput.rangeMin = info.minValue;
-        scanned.scanInput.rangeMax = info.maxValue;
-        scanned.scanInput.stateCount = static_cast<int>(info.choices.size());
-
-        // Through the model's own formatter, which is what the host wraps one
-        // of these parameters in as well, so Detect reads the strings the UI
-        // shows rather than a second opinion about them.
-        if (!info.choices.empty()) {
-            scanned.scanInput.displayTexts = info.choices;
-        } else {
-            for (const auto sample : samplePoints)
-                scanned.scanInput.displayTexts.push_back(ParameterUtils::formatValue(
-                    ParameterUtils::normalizedToReal(sample, info), info));
-        }
-
-        return scanned;
-    };
 
     const int count = device->parameterCount();
     for (int index = 0; index < count; ++index) {

--- a/magda/daw/engine/DeviceParameterScan.cpp
+++ b/magda/daw/engine/DeviceParameterScan.cpp
@@ -51,10 +51,12 @@ ScannedPluginParameter scanRecord(const ParameterInfo& info, int position) {
     scanned.unit = info.unit;
     scanned.rangeMin = info.minValue;
     scanned.rangeMax = info.maxValue;
-    // scaleAnchor is the real value a parameter asks to sit at the middle of
-    // its own travel, which is what rangeCenter means.
-    scanned.rangeCenter =
-        info.scaleAnchor > 0.0f ? info.scaleAnchor : (info.minValue + info.maxValue) * 0.5f;
+    // A declared anchor is the real value a parameter asks to sit at the middle
+    // of its own travel, which is what rangeCenter means. Asked rather than
+    // compared against zero: a range that straddles zero has a real value there.
+    scanned.rangeCenter = ParameterUtils::hasScaleAnchor(info)
+                              ? info.scaleAnchor
+                              : (info.minValue + info.maxValue) * 0.5f;
     scanned.scale = info.scale;
     scanned.valueTable = info.valueTable.empty() ? info.choices : info.valueTable;
 

--- a/magda/daw/engine/DeviceParameterScan.cpp
+++ b/magda/daw/engine/DeviceParameterScan.cpp
@@ -88,9 +88,7 @@ std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& plu
     if (device == nullptr)
         return result;
 
-    const int count = device->parameterCount();
-    for (int index = 0; index < count; ++index) {
-        const auto info = device->parameterInfo(index);
+    for (const auto& info : device->parameters()) {
         if (info.name.isEmpty())
             continue;
 

--- a/magda/daw/engine/DeviceParameterScan.cpp
+++ b/magda/daw/engine/DeviceParameterScan.cpp
@@ -46,13 +46,12 @@ std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& plu
     if (device == nullptr)
         return result;
 
-    constexpr std::array<float, 5> samplePoints{0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
-
-    const int count = device->parameterCount();
-    for (int index = 0; index < count; ++index) {
-        const auto info = device->parameterInfo(index);
-        if (info.name.isEmpty())
-            continue;
+    // One scan record off one parameter's own description. `position` is where
+    // the record lands in the result rather than the slot it was read from: a
+    // skipped parameter leaves the two apart, and a detection result is applied
+    // by position.
+    const auto scanRecord = [](const ParameterInfo& info, int position) {
+        constexpr std::array<float, 5> samplePoints{0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
 
         ScannedPluginParameter scanned;
         scanned.name = info.name;
@@ -68,10 +67,7 @@ std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& plu
         scanned.scale = info.scale;
         scanned.valueTable = info.valueTable.empty() ? info.choices : info.valueTable;
 
-        // The position in this list, not the loop counter: a parameter skipped
-        // above leaves the two apart, and a detection result is applied by
-        // position.
-        scanned.scanInput.paramIndex = static_cast<int>(result.size());
+        scanned.scanInput.paramIndex = position;
         scanned.scanInput.name = info.name;
         scanned.scanInput.label = info.unit;
         scanned.scanInput.rangeMin = info.minValue;
@@ -89,7 +85,16 @@ std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& plu
                     ParameterUtils::normalizedToReal(sample, info), info));
         }
 
-        result.push_back(std::move(scanned));
+        return scanned;
+    };
+
+    const int count = device->parameterCount();
+    for (int index = 0; index < count; ++index) {
+        const auto info = device->parameterInfo(index);
+        if (info.name.isEmpty())
+            continue;
+
+        result.push_back(scanRecord(info, static_cast<int>(result.size())));
     }
 
     return result;

--- a/magda/daw/engine/DeviceParameterScan.cpp
+++ b/magda/daw/engine/DeviceParameterScan.cpp
@@ -1,0 +1,98 @@
+#include "DeviceParameterScan.hpp"
+
+#include <array>
+#include <memory>
+#include <utility>
+
+#include "../audio/plugins/InternalPluginRegistry.hpp"
+#include "../audio/plugins/MagdaDevice.hpp"
+#include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "../core/ParameterUtils.hpp"
+
+namespace magda {
+namespace {
+
+namespace audio = daw::audio;
+
+/// A device built to be asked questions and dropped. No session key: the
+/// services behind one are a running engine's, and nothing here may reach them.
+/// EngineDeviceFactory does the same for a device it is about to run, but that
+/// lives in the native engine's own target and the fork cannot link it.
+std::unique_ptr<audio::MagdaDevice> createDetachedDevice(const juce::String& pluginId) {
+    juce::ValueTree state(juce::Identifier("PLUGIN"));
+    state.setProperty(juce::Identifier("type"), pluginId, nullptr);
+    const audio::DevicePluginCreationContext context{
+        .sessionKey = {}, .state = std::move(state), .isNewPlugin = true};
+
+    // The internal registry first, because that is the catalog an id is
+    // canonicalised against; a compiled device is not in it.
+    if (const auto* spec = audio::findInternalPluginSpec(pluginId); spec != nullptr)
+        if (spec->createDevice != nullptr)
+            return spec->createDevice(context);
+
+    if (const auto* spec = audio::compiled::findCompiledPluginSpec(pluginId); spec != nullptr)
+        if (spec->createDevice != nullptr)
+            return spec->createDevice(context);
+
+    return {};
+}
+
+}  // namespace
+
+std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& pluginId) {
+    std::vector<ScannedPluginParameter> result;
+
+    const auto device = createDetachedDevice(pluginId);
+    if (device == nullptr)
+        return result;
+
+    constexpr std::array<float, 5> samplePoints{0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
+
+    const int count = device->parameterCount();
+    for (int index = 0; index < count; ++index) {
+        const auto info = device->parameterInfo(index);
+        if (info.name.isEmpty())
+            continue;
+
+        ScannedPluginParameter scanned;
+        scanned.name = info.name;
+        scanned.stableId = info.stableId;
+        scanned.defaultValue = info.defaultValue;
+        scanned.unit = info.unit;
+        scanned.rangeMin = info.minValue;
+        scanned.rangeMax = info.maxValue;
+        // scaleAnchor is the real value a parameter asks to sit at the middle
+        // of its own travel, which is what rangeCenter means.
+        scanned.rangeCenter =
+            info.scaleAnchor > 0.0f ? info.scaleAnchor : (info.minValue + info.maxValue) * 0.5f;
+        scanned.scale = info.scale;
+        scanned.valueTable = info.valueTable.empty() ? info.choices : info.valueTable;
+
+        // The position in this list, not the loop counter: a parameter skipped
+        // above leaves the two apart, and a detection result is applied by
+        // position.
+        scanned.scanInput.paramIndex = static_cast<int>(result.size());
+        scanned.scanInput.name = info.name;
+        scanned.scanInput.label = info.unit;
+        scanned.scanInput.rangeMin = info.minValue;
+        scanned.scanInput.rangeMax = info.maxValue;
+        scanned.scanInput.stateCount = static_cast<int>(info.choices.size());
+
+        // Through the model's own formatter, which is what the host wraps one
+        // of these parameters in as well, so Detect reads the strings the UI
+        // shows rather than a second opinion about them.
+        if (!info.choices.empty()) {
+            scanned.scanInput.displayTexts = info.choices;
+        } else {
+            for (const auto sample : samplePoints)
+                scanned.scanInput.displayTexts.push_back(ParameterUtils::formatValue(
+                    ParameterUtils::normalizedToReal(sample, info), info));
+        }
+
+        result.push_back(std::move(scanned));
+    }
+
+    return result;
+}
+
+}  // namespace magda

--- a/magda/daw/engine/DeviceParameterScan.hpp
+++ b/magda/daw/engine/DeviceParameterScan.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+
+#include "AudioEngine.hpp"
+
+namespace magda {
+
+/**
+ * @brief Every parameter a registered MAGDA device declares, read off the
+ * device itself.
+ *
+ * Neither engine is asked. The device is built from the catalog, questioned and
+ * dropped, so the answer is the same under both -- and needs no Edit to build a
+ * plugin in, which the native engine does not have (#2601).
+ *
+ * Empty when no registered device answers to @p pluginId, or when the one that
+ * does is still a host plugin rather than a MagdaDevice.
+ */
+std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& pluginId);
+
+}  // namespace magda

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -19,6 +19,7 @@
 #include "../audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "../audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
 #include "../core/AppPaths.hpp"
+#include "DeviceParameterScan.hpp"
 #include "PluginMetadataStore.hpp"
 #include "PluginScanCoordinator.hpp"
 #include "TracktionEngineWrapper.hpp"
@@ -642,6 +643,14 @@ std::vector<std::string> TracktionEngineWrapper::getSystemPluginSearchPaths() co
 std::vector<ScannedPluginParameter> TracktionEngineWrapper::scanPluginParameters(
     const juce::String& pluginId, bool internalPlugin) {
     std::vector<ScannedPluginParameter> result;
+
+    // A MAGDA device answers for itself, off the catalog rather than out of an
+    // Edit. Its own metadata is what the host wraps anyway, and the native
+    // engine builds no Edit to put a plugin in (#2601).
+    if (internalPlugin)
+        if (auto scanned = scanDeviceParameters(pluginId); !scanned.empty())
+            return scanned;
+
     if (!engine_)
         return result;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,6 +300,7 @@ set(TEST_SOURCES
     remote/test_remote_api_host.cpp
     devices/test_device_api.cpp
     devices/test_plugin_parameter_config_store.cpp
+    devices/test_device_parameter_scan.cpp
     # Rack and chain addressing at depth through the facade (issue #1993)
     remote/test_track_api_nested_racks.cpp
     automation/test_automation_api_surface.cpp

--- a/tests/devices/test_device_parameter_scan.cpp
+++ b/tests/devices/test_device_parameter_scan.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 
+#include "magda/daw/audio/plugins/InternalPluginRegistry.hpp"
+#include "magda/daw/audio/plugins/MagdaDevice.hpp"
 #include "magda/daw/engine/DeviceParameterScan.hpp"
 #include "magda/daw/engine/TracktionEngineWrapper.hpp"
 
@@ -11,6 +13,67 @@ const magda::ScannedPluginParameter* findByName(
     const auto match = std::ranges::find(scanned, name, &magda::ScannedPluginParameter::name);
     return match != scanned.end() ? &*match : nullptr;
 }
+
+namespace audio = magda::daw::audio;
+
+constexpr const char* kScanTestDeviceId = "test-scan-device";
+
+/// A device whose parameters are chosen to exercise the scan rather than to
+/// make a sound: an anchor below zero, no anchor at all, and no name.
+class ScanTestDevice : public audio::MagdaDevice {
+  public:
+    audio::DeviceProperties properties() const override {
+        audio::DeviceProperties properties;
+        properties.pluginId = kScanTestDeviceId;
+        properties.name = "Scan Test Device";
+        return properties;
+    }
+
+    void process(audio::DeviceProcessContext&) override {}
+
+    int parameterCount() const override {
+        return 3;
+    }
+
+    magda::ParameterInfo parameterInfo(int index) const override {
+        magda::ParameterInfo info;
+        switch (index) {
+            case 0:
+                info.stableId = "threshold";
+                info.name = "Threshold";
+                info.unit = "dB";
+                info.minValue = -60.0f;
+                info.maxValue = 6.0f;
+                info.scaleAnchor = -12.0f;
+                break;
+            case 1:
+                info.stableId = "mix";
+                info.name = "Mix";
+                info.unit = "%";
+                info.minValue = 0.0f;
+                info.maxValue = 100.0f;
+                break;
+            default:
+                // Nameless, and so not offered for configuration.
+                info.stableId = "reserved";
+                break;
+        }
+        return info;
+    }
+};
+
+void registerScanTestPack(audio::InternalPluginRegistry& registry) {
+    audio::InternalPluginSpec spec;
+    spec.pluginId = kScanTestDeviceId;
+    spec.displayName = "Scan Test Device";
+    spec.createDevice =
+        [](const audio::DevicePluginCreationContext&) -> std::unique_ptr<audio::MagdaDevice> {
+        return std::make_unique<ScanTestDevice>();
+    };
+    registry.registerPlugin(spec);
+}
+
+const bool scanTestPackRegistered = audio::registerDevicePack(registerScanTestPack);
 
 }  // namespace
 
@@ -74,4 +137,34 @@ TEST_CASE("The internal scan needs no Edit to build a plugin in", "[device-param
 
     REQUIRE_FALSE(scanned.empty());
     CHECK(scanned.size() == magda::scanDeviceParameters("arpeggiator").size());
+}
+
+TEST_CASE("A scale anchor below zero is the scanned centre", "[device-parameter-scan][2601]") {
+    // The anchor is a real value, and a range that straddles zero has real
+    // values on both sides of it: a sign test would drop this one and report
+    // the midpoint, -27 dB, as the parameter's centre.
+    REQUIRE(scanTestPackRegistered);
+    const auto scanned = magda::scanDeviceParameters(kScanTestDeviceId);
+
+    const auto* threshold = findByName(scanned, "Threshold");
+    REQUIRE(threshold != nullptr);
+    CHECK(threshold->rangeCenter == -12.0f);
+}
+
+TEST_CASE("A parameter that declares no anchor takes its midpoint",
+          "[device-parameter-scan][2601]") {
+    const auto scanned = magda::scanDeviceParameters(kScanTestDeviceId);
+
+    const auto* mix = findByName(scanned, "Mix");
+    REQUIRE(mix != nullptr);
+    CHECK(mix->rangeCenter == 50.0f);
+}
+
+TEST_CASE("A nameless parameter is left out without shifting the rest",
+          "[device-parameter-scan][2601]") {
+    const auto scanned = magda::scanDeviceParameters(kScanTestDeviceId);
+
+    REQUIRE(scanned.size() == 2);
+    for (std::size_t at = 0; at < scanned.size(); ++at)
+        CHECK(scanned[at].scanInput.paramIndex == static_cast<int>(at));
 }

--- a/tests/devices/test_device_parameter_scan.cpp
+++ b/tests/devices/test_device_parameter_scan.cpp
@@ -1,0 +1,77 @@
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/engine/DeviceParameterScan.hpp"
+#include "magda/daw/engine/TracktionEngineWrapper.hpp"
+
+namespace {
+
+const magda::ScannedPluginParameter* findByName(
+    const std::vector<magda::ScannedPluginParameter>& scanned, const juce::String& name) {
+    const auto match = std::ranges::find(scanned, name, &magda::ScannedPluginParameter::name);
+    return match != scanned.end() ? &*match : nullptr;
+}
+
+}  // namespace
+
+TEST_CASE("A MAGDA device is scanned off the catalog, with no engine",
+          "[device-parameter-scan][2601]") {
+    // Nothing here starts an engine or opens an Edit: the Configure Parameters
+    // dialog used to need the fork's Edit for this, and the native engine has
+    // none, so every MAGDA device fell back to mock parameters there.
+    const auto scanned = magda::scanDeviceParameters("arpeggiator");
+    REQUIRE_FALSE(scanned.empty());
+
+    const auto* octaves = findByName(scanned, "Octaves");
+    REQUIRE(octaves != nullptr);
+    CHECK(octaves->stableId == "octaves");
+
+    // The device's own range, not the 0..1 the host wraps every one of its
+    // parameters in -- which is what a scan through the fork's automatable
+    // list reported.
+    CHECK(octaves->rangeMin == 1.0f);
+    CHECK(octaves->rangeMax == 4.0f);
+}
+
+TEST_CASE("A discrete parameter is scanned with its choices", "[device-parameter-scan][2601]") {
+    const auto scanned = magda::scanDeviceParameters("arpeggiator");
+    const auto* pattern = findByName(scanned, "Pattern");
+    REQUIRE(pattern != nullptr);
+
+    CHECK(pattern->scale == magda::ParameterScale::Discrete);
+    CHECK(pattern->valueTable ==
+          std::vector<juce::String>{"Up", "Down", "Up/Down", "Down/Up", "Random", "As Played"});
+    CHECK(pattern->scanInput.stateCount == 6);
+    CHECK(pattern->scanInput.displayTexts == pattern->valueTable);
+}
+
+TEST_CASE("A scan result is addressed by its position in the list",
+          "[device-parameter-scan][2601]") {
+    // What a detection result is applied by, so the two have to agree.
+    const auto scanned = magda::scanDeviceParameters("arpeggiator");
+    REQUIRE_FALSE(scanned.empty());
+
+    for (std::size_t at = 0; at < scanned.size(); ++at) {
+        CHECK(scanned[at].scanInput.paramIndex == static_cast<int>(at));
+        CHECK(scanned[at].scanInput.name == scanned[at].name);
+    }
+}
+
+TEST_CASE("An id no registered device answers to scans as nothing",
+          "[device-parameter-scan][2601]") {
+    // An external plugin's id reaches here too, and is not this function's to
+    // answer: the caller falls back to opening the plugin.
+    CHECK(magda::scanDeviceParameters("VST3-Surge-XT-1a2b3c4d").empty());
+    CHECK(magda::scanDeviceParameters({}).empty());
+}
+
+TEST_CASE("The internal scan needs no Edit to build a plugin in", "[device-parameter-scan][2601]") {
+    // What the native engine has: the fork's services and no Edit of its own.
+    // Until the device answered for itself this branch returned nothing, and
+    // Configure Parameters fell back to a mock list for every MAGDA device.
+    magda::TracktionEngineWrapper wrapper;
+    const auto scanned = wrapper.scanPluginParameters("arpeggiator", true);
+
+    REQUIRE_FALSE(scanned.empty());
+    CHECK(scanned.size() == magda::scanDeviceParameters("arpeggiator").size());
+}


### PR DESCRIPTION
Item 2 of the three left on #2601. `Refs`, not `Closes` — one is left, at the
bottom.

Open Configure Parameters on a Poly Synth under the native engine and the
dialog shows a mock parameter list. `scanPluginParameters`'s internal branch
builds a throwaway plugin in the fork's Edit, and
`MagdaAudioEngine::initialize` takes the fork's services and no Edit — "an Edit
would come with a playback context, an AudioBridge mirroring every device into
it and a second copy of every external plugin" (#2579). So the branch returned
empty, `scanInternalParameters` reported failure, and the dialog fell back to
`buildMockParameters()`. Silently.

## What changed

`scanDeviceParameters()` asks the device. It builds one straight from the
catalog — `InternalPluginRegistry` first, then the compiled one, the same order
`EngineDeviceFactory` uses — reads `parameterCount()` / `parameterInfo()`, and
drops it. No engine, no Edit, so both engines get the same answer. The fork's
`scanPluginParameters` tries it before anything else and keeps its Edit-based
path for the transitional devices that are still host plugins rather than
`MagdaDevice`s.

**It is the device's own metadata, not the host's mirror of it.**
`TracktionMagdaDevicePlugin::buildParameters` registers every MAGDA parameter
with `NormalisableRange{0, 1}` and a `valueToString` that formats through
`ParameterUtils`, so a scan of the automatable list reported `0..1` and a
hardcoded `"%"` for all of them. `parameterInfo()` has the real unit, range,
scale and choices — an Arpeggiator's Octaves is `1..4`, its Pattern is a
`Discrete` with six named states — and the display texts come from the same
formatter the host wraps the parameter in, so Detect reads the strings the UI
shows rather than a second opinion about them.

`createDetachedDevice` duplicates `EngineDeviceFactory`'s `createSdkDevice`
because that one lives in `magda_engine_devices`, which is gated on
`MAGDA_BUILD_NATIVE_ENGINE` and which the fork cannot link.

## Tests

`tests/devices/test_device_parameter_scan.cpp`, five cases over the
Arpeggiator:

- A device is scanned with no engine anywhere in the picture, and Octaves
  carries `1..4` rather than the host's `0..1`.
- A discrete parameter carries its six choices, as the value table, the state
  count and the sampled display texts.
- Every result's `scanInput.paramIndex` is its position in the list, which is
  what a detection result is applied by.
- An id no registered device answers to — an external plugin's, or an empty one
  — scans as nothing, so the caller still falls back to opening the plugin.
- `TracktionEngineWrapper::scanPluginParameters` answers for an internal device
  with no Edit built. This is the native engine's situation, and it fails with
  the new branch removed.

`make test` (4003 passed, 13 skipped) and `make test-juce` green.
`make lint-changed` reports nothing new on the changed files.

## Left on #2601

- `MiniChainRow` and `DeviceSlotParameterPaging` still apply the config at draw
  time — redundant on both engines since #2608, but removing them needs a
  hands-on check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
