### PR TITLE
Read a device's saved state in both formats on the native engine

### DIFF
--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -103,25 +103,48 @@ std::unique_ptr<MagdaDevice> createSdkDevice(const juce::String& pluginId) {
     return {};
 }
 
+/// The device's own state as a tree, in whichever format the project holds it.
+///
+/// Most internal devices in a project folder are still saved as the engine's
+/// v1 XML, which `decode()` refuses by design, so reading only v2 took every
+/// one of them and ran its defaults (#2602).
+juce::ValueTree savedStateTree(const juce::String& savedState) {
+    if (magda::device_state::looksLikeLegacyEngineState(savedState)) {
+        auto tree = magda::device_state::legacyEngineStateTree(savedState);
+        adoptCanonicalPluginType(tree);
+        return tree;
+    }
+
+    const auto doc = magda::device_state::decode(savedState);
+    if (!doc)
+        return {};
+
+    auto tree = magda::device_state::toValueTree(doc->root);
+    tree.setProperty(typeProperty(), doc->deviceType, nullptr);
+    return tree;
+}
+
 /// Hand the device whatever the project saved for it.
 ///
 /// Parameters are not this: the plan's value layer resolves every one of them
 /// per block and the adapter writes them before each process() call. What this
 /// carries is everything else -- the runtime Faust device's dsp source, an EQ's
 /// collapsed curve -- without which a device built here runs its defaults and
-/// renders a project nobody saved. A device with no saved state, or state from a
-/// schema this build refuses, keeps those defaults, which is what the fork does
-/// with the same document.
-void restoreSavedState(MagdaDevice& device, const juce::String& savedState) {
+/// renders a project nobody saved.
+void restoreSavedState(MagdaDevice& device, const juce::String& pluginId,
+                       const juce::String& savedState) {
     if (savedState.isEmpty())
         return;
 
-    const auto doc = magda::device_state::decode(savedState);
-    if (!doc)
+    const auto tree = savedStateTree(savedState);
+    if (!tree.isValid()) {
+        // Said out loud. #2602 went unnoticed for as long as it did because
+        // this path dropped a project's state without a word.
+        juce::Logger::writeToLog("EngineDeviceFactory: unreadable saved state for " + pluginId +
+                                 ", running its defaults");
         return;
+    }
 
-    auto tree = magda::device_state::toValueTree(doc->root);
-    tree.setProperty(typeProperty(), doc->deviceType, nullptr);
     device.restoreState(tree);
 }
 
@@ -250,7 +273,7 @@ std::unique_ptr<magda::engine::EngineDevice> createEngineDevice(const magda::Dev
     // Before the adapter, not after. EngineMagdaDevice snapshots the device's
     // parameter metadata when it is constructed, so a device that restores its
     // state later would be mapped against the parameters it had before.
-    restoreSavedState(*sdkDevice, device.pluginState);
+    restoreSavedState(*sdkDevice, device.pluginId, device.pluginState);
 
     return std::make_unique<EngineMagdaDevice>(std::move(sdkDevice), offlineRender);
 }

--- a/magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.cpp
+++ b/magda/daw/audio/plugins/tracktion/TracktionDeviceStateBridge.cpp
@@ -120,16 +120,10 @@ juce::String canonicalDeviceType(const juce::String& pluginType) {
 }
 
 juce::ValueTree legacyPluginTree(const juce::String& savedState) {
-    auto xml = juce::parseXML(savedState);
-    if (!xml)
-        return {};
-
-    auto tree = juce::ValueTree::fromXml(*xml);
+    auto tree = ds::legacyEngineStateTree(savedState);
     if (!tree.isValid())
         return {};
 
-    stripTracktionIdsRecursive(tree);
-    stripModifierAssignmentsRecursive(tree);
     adoptCanonicalPluginType(tree);
     return tree;
 }

--- a/magda/daw/core/DeviceState.cpp
+++ b/magda/daw/core/DeviceState.cpp
@@ -200,6 +200,43 @@ std::optional<Doc> decode(const juce::String& text) {
     return doc;
 }
 
+namespace {
+
+/// The engine's own, on a v1 tree: the object id it stamps on every node, and
+/// the assignments MAGDA rebuilds from its own modifier list after a restore.
+void dropEngineOwned(juce::ValueTree tree) {
+    static const juce::Identifier kObjectId("id");
+    static const juce::Identifier kModifierAssignments("MODIFIERASSIGNMENTS");
+
+    tree.removeProperty(kObjectId, nullptr);
+
+    for (auto index = tree.getNumChildren() - 1; index >= 0; --index) {
+        auto child = tree.getChild(index);
+        if (child.hasType(kModifierAssignments))
+            tree.removeChild(index, nullptr);
+        else
+            dropEngineOwned(child);
+    }
+}
+
+}  // namespace
+
+juce::ValueTree legacyEngineStateTree(const juce::String& text) {
+    if (!looksLikeLegacyEngineState(text))
+        return {};
+
+    const auto xml = juce::parseXML(text);
+    if (xml == nullptr)
+        return {};
+
+    auto tree = juce::ValueTree::fromXml(*xml);
+    if (!tree.isValid())
+        return {};
+
+    dropEngineOwned(tree);
+    return tree;
+}
+
 bool looksLikeLegacyEngineState(const juce::String& text) {
     return text.trimStart().startsWithChar('<');
 }

--- a/magda/daw/core/DeviceState.cpp
+++ b/magda/daw/core/DeviceState.cpp
@@ -221,6 +221,45 @@ void dropEngineOwned(juce::ValueTree tree) {
 
 }  // namespace
 
+namespace {
+
+Node nodeFrom(const juce::ValueTree& tree) {
+    Node node;
+    node.type = tree.getType().toString();
+
+    for (int i = 0; i < tree.getNumProperties(); ++i) {
+        const auto name = tree.getPropertyName(i);
+        node.props.set(name, tree.getProperty(name));
+    }
+
+    for (int i = 0; i < tree.getNumChildren(); ++i)
+        node.children.push_back(nodeFrom(tree.getChild(i)));
+
+    return node;
+}
+
+}  // namespace
+
+std::optional<Doc> decodeSavedState(const juce::String& text) {
+    if (!looksLikeLegacyEngineState(text))
+        return decode(text);
+
+    const auto tree = legacyEngineStateTree(text);
+    if (!tree.isValid())
+        return std::nullopt;
+
+    static const juce::Identifier kType("type");
+
+    Doc doc;
+    doc.version = 1;
+    doc.deviceType = tree.getProperty(kType).toString();
+    doc.root = nodeFrom(tree);
+    // The root element name is the engine's, not the device's, which is what
+    // v2 records in deviceType.
+    doc.root.type = {};
+    return doc;
+}
+
 juce::ValueTree legacyEngineStateTree(const juce::String& text) {
     if (!looksLikeLegacyEngineState(text))
         return {};

--- a/magda/daw/core/DeviceState.hpp
+++ b/magda/daw/core/DeviceState.hpp
@@ -136,6 +136,15 @@ void forEachNode(const Node& root, const std::function<void(const Node&)>& visit
 juce::ValueTree toValueTree(const Node& node);
 
 /**
+ * @brief A saved document in whichever format the project holds it.
+ *
+ * `decode()` is the v2 codec and refuses v1 by design. Anything reading a
+ * device's own saved state wants this instead: most internal devices in a
+ * project folder are still v1 (#2602).
+ */
+std::optional<Doc> decodeSavedState(const juce::String& text);
+
+/**
  * @brief A v1 document as the same tree, for the engine that reads it.
  *
  * The engine's object ids and the modifier assignments it hangs on every

--- a/magda/daw/core/DeviceState.hpp
+++ b/magda/daw/core/DeviceState.hpp
@@ -135,4 +135,13 @@ void forEachNode(const Node& root, const std::function<void(const Node&)>& visit
  */
 juce::ValueTree toValueTree(const Node& node);
 
+/**
+ * @brief A v1 document as the same tree, for the engine that reads it.
+ *
+ * The engine's object ids and the modifier assignments it hangs on every
+ * plugin are dropped; what is left is the device's own state. Invalid when
+ * @p text is not a v1 document or does not parse.
+ */
+juce::ValueTree legacyEngineStateTree(const juce::String& text);
+
 }  // namespace magda::device_state

--- a/magda/daw/core/StepPatternState.cpp
+++ b/magda/daw/core/StepPatternState.cpp
@@ -182,13 +182,17 @@ void writePoly(device_state::Doc& doc, const PolyPattern& pattern) {
 }
 
 MonoPattern monoPatternOf(const juce::String& deviceStateText) {
-    if (auto doc = device_state::decode(deviceStateText))
+    // Either format. The step and note spellings above are frozen, so a v1
+    // document carries the same pattern in the same words; reading only v2 put
+    // an empty pattern on the faceplate of a device that was playing the right
+    // one (#2602).
+    if (auto doc = device_state::decodeSavedState(deviceStateText))
         return readMono(*doc);
     return {};
 }
 
 PolyPattern polyPatternOf(const juce::String& deviceStateText) {
-    if (auto doc = device_state::decode(deviceStateText))
+    if (auto doc = device_state::decodeSavedState(deviceStateText))
         return readPoly(*doc);
     return {};
 }

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -1233,14 +1233,19 @@ void PolyStepSequencerUI::updateFromParameters(const std::vector<magda::Paramete
 }
 
 void PolyStepSequencerUI::setPattern(const step_pattern::PolyPattern& pattern) {
-    if (pattern == pattern_)
-        return;
+    // See StepSequencerUI::setPattern: the controls are written whether or not
+    // the pattern moved, and only the redraw is skipped.
+    const bool changed = !(pattern == pattern_);
 
     pattern_ = pattern;
     const int steps = pattern_.playingLength();
     stepsSlider_.setValue(static_cast<double>(steps), juce::dontSendNotification);
     rampCurveDisplay_.setNumTicks(steps);
     cyclesSlider_.setRange(1.0, static_cast<double>(steps), 1.0);
+
+    if (!changed)
+        return;
+
     pushViewContext();
     patternView_->patternChanged();
     repaint();

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -216,15 +216,20 @@ void StepSequencerUI::updateFromParameters(const std::vector<magda::ParameterInf
 }
 
 void StepSequencerUI::setPattern(const step_pattern::MonoPattern& pattern) {
-    if (pattern == pattern_)
-        return;
+    // The controls are written whether or not the pattern moved. Returning
+    // early on an unchanged pattern left them at their own defaults for a
+    // pattern that happens to equal the default one, which reads as a 16-step
+    // pattern under a Steps of 1 (#2602). Only the repaint is worth skipping.
+    const bool changed = !(pattern == pattern_);
 
     pattern_ = pattern;
     const int steps = pattern_.playingLength();
     stepsSlider_.setValue(static_cast<double>(steps), juce::dontSendNotification);
     rampCurveDisplay_.setNumTicks(steps);
     cyclesSlider_.setRange(1.0, static_cast<double>(steps), 1.0);
-    repaint();
+
+    if (changed)
+        repaint();
 }
 
 void StepSequencerUI::syncSettingsFromDevice() {

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -833,6 +833,14 @@ void DeviceCustomUIManager::refreshParameterValues(const magda::DeviceInfo& devi
     if (arpeggiatorUI_ &&
         device.pluginId.equalsIgnoreCase(daw::audio::ArpeggiatorPlugin::xmlTypeName))
         arpeggiatorUI_->updateFromParameters(device.parameters);
+    refreshSequencerState(device);
+    if (impulseResponseUI_ && device.pluginId == daw::audio::MagdaConvolutionPlugin::xmlTypeName)
+        impulseResponseUI_->updateFromParameters(device.parameters);
+    if (fourOscUI_ && device.pluginId.containsIgnoreCase("4osc"))
+        fourOscUI_->updateFromParameters(device.parameters);
+}
+
+void DeviceCustomUIManager::refreshSequencerState(const magda::DeviceInfo& device) {
     if (stepSequencerUI_ &&
         device.pluginId.equalsIgnoreCase(daw::audio::StepSequencerPlugin::xmlTypeName)) {
         stepSequencerUI_->setPattern(magda::step_pattern::monoPatternOf(device.pluginState));
@@ -843,10 +851,6 @@ void DeviceCustomUIManager::refreshParameterValues(const magda::DeviceInfo& devi
         polyStepSequencerUI_->setPattern(magda::step_pattern::polyPatternOf(device.pluginState));
         polyStepSequencerUI_->updateFromParameters(device.parameters);
     }
-    if (impulseResponseUI_ && device.pluginId == daw::audio::MagdaConvolutionPlugin::xmlTypeName)
-        impulseResponseUI_->updateFromParameters(device.parameters);
-    if (fourOscUI_ && device.pluginId.containsIgnoreCase("4osc"))
-        fourOscUI_->updateFromParameters(device.parameters);
 }
 
 // =============================================================================
@@ -2363,6 +2367,10 @@ void DeviceCustomUIManager::bindAnalyzerPlugins() {
 // =============================================================================
 
 void DeviceCustomUIManager::update(const magda::DeviceInfo& device) {
+    // Native-engine faceplates have no Tracktion plugin to poll. Populate the
+    // saved pattern on creation/full updates, not only after a parameter edit.
+    refreshSequencerState(device);
+
     if (deviceUiContext_ != nullptr) {
         if (auto* controller =
                 dynamic_cast<CallbackDeviceParameterController*>(deviceUiContext_->parameters())) {

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.hpp
@@ -244,6 +244,7 @@ class DeviceCustomUIManager {
     }
 
   private:
+    void refreshSequencerState(const magda::DeviceInfo& device);
     // (Re-)resolve the live plugin for the oscilloscope / spectrum analyzer UIs
     // from the current devicePath_ and hand it to them. Safe to call before the
     // path or plugin exists (it simply binds nothing).

--- a/tests/engine/test_engine_device_layer.cpp
+++ b/tests/engine/test_engine_device_layer.cpp
@@ -10,6 +10,7 @@
 #include "NullDiffGain.hpp"
 #include "core/DeviceState.hpp"
 #include "core/ParameterUtils.hpp"
+#include "core/StepPatternState.hpp"
 #include "exec/EngineDevice.hpp"
 #include "exec/PlanExecutor.hpp"
 #include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
@@ -994,6 +995,22 @@ TEST_CASE("a device saved as the engine's own XML is restored too", "[engine][de
     CHECK(arp->quantize.load() == Catch::Approx(0.75f));
     CHECK(arp->quantizeSub.load() == 32);
     CHECK(arp->hardAngle.load());
+}
+
+TEST_CASE("a step sequencer's pattern is read out of either format", "[engine][devices][2602]") {
+    // The faceplate reads the pattern from the model rather than the running
+    // device, so reading only v2 drew an empty pattern over a sequencer that
+    // was playing the right one.
+    const auto pattern = magda::step_pattern::monoPatternOf(
+        R"(<PLUGIN type="stepsequencer" id="9" seqNumSteps="4">
+             <STEP idx="0" note="62" gate="1" accent="1"/>
+             <STEP idx="1" note="65" gate="1"/>
+           </PLUGIN>)");
+
+    CHECK(pattern.length == 4);
+    CHECK(pattern.steps[0].noteNumber == 62);
+    CHECK(pattern.steps[0].accent);
+    CHECK(pattern.steps[1].noteNumber == 65);
 }
 
 TEST_CASE("the engine's own ids and assignments do not reach the device",

--- a/tests/engine/test_engine_device_layer.cpp
+++ b/tests/engine/test_engine_device_layer.cpp
@@ -967,6 +967,56 @@ TEST_CASE("an engine-built arpeggiator gets the settings the model saved",
     CHECK(arp->hardAngle.load());
 }
 
+TEST_CASE("a device saved as the engine's own XML is restored too", "[engine][devices][2602]") {
+    // Every other fixture here builds its state with device_state::encode, so
+    // they all exercise the one format that already worked. Most internal
+    // devices in a project folder are still saved as the engine's v1 XML,
+    // which decode() refuses by design: read only v2 and every one of them
+    // came up running its defaults (#2602).
+    magda::DeviceInfo model;
+    model.pluginId = "arpeggiator";
+    model.pluginState = R"(<PLUGIN type="arpeggiator" id="1042" arpRampCycles="5"
+                                  arpQuantize="0.75" arpQuantizeSub="32" arpHardAngle="1">
+                             <MODIFIERASSIGNMENTS/>
+                           </PLUGIN>)";
+    REQUIRE(magda::device_state::looksLikeLegacyEngineState(model.pluginState));
+
+    auto device = adapter::createEngineDevice(model);
+    REQUIRE(device != nullptr);
+
+    auto* hosted = dynamic_cast<adapter::EngineMagdaDevice*>(device.get());
+    REQUIRE(hosted != nullptr);
+
+    auto* arp = dynamic_cast<magda::daw::audio::ArpeggiatorPlugin*>(&hosted->device());
+    REQUIRE(arp != nullptr);
+
+    CHECK(arp->rampCycles.load() == 5);
+    CHECK(arp->quantize.load() == Catch::Approx(0.75f));
+    CHECK(arp->quantizeSub.load() == 32);
+    CHECK(arp->hardAngle.load());
+}
+
+TEST_CASE("the engine's own ids and assignments do not reach the device",
+          "[engine][devices][2602]") {
+    // The id the engine stamps on every node and the assignments MAGDA rebuilds
+    // from its own modifier list are the engine's, not the device's.
+    const auto tree = magda::device_state::legacyEngineStateTree(
+        R"(<PLUGIN type="arpeggiator" id="1042" arpRampCycles="5">
+             <MODIFIERASSIGNMENTS><LFO id="7"/></MODIFIERASSIGNMENTS>
+             <NESTED id="99" keep="yes"/>
+           </PLUGIN>)");
+
+    REQUIRE(tree.isValid());
+    CHECK_FALSE(tree.hasProperty("id"));
+    CHECK(tree.getProperty("arpRampCycles").toString() == "5");
+    CHECK(tree.getChildWithName("MODIFIERASSIGNMENTS") == juce::ValueTree{});
+
+    const auto nested = tree.getChildWithName("NESTED");
+    REQUIRE(nested.isValid());
+    CHECK_FALSE(nested.hasProperty("id"));
+    CHECK(nested.getProperty("keep").toString() == "yes");
+}
+
 TEST_CASE("the Rings resonator renders through the engine's device op", "[engine][devices][2299]") {
     // The first hand-written device to cross for #2299. What earns it a named
     // case next to the generic sweep above is its shape: a MIDI-excited synth


### PR DESCRIPTION
Closes #2602.

`restoreSavedState()` read only the v2 document, and `decode()` refuses the
engine's v1 XML by design, so every device saved in v1 took the early return and
ran its defaults. Counted over a working project folder that is 456 of 498
internal devices: an arpeggiator came up with no pattern, and anything whose
sound is not carried by its parameter array came up wrong.

## Reading both formats

The format branch the fork already makes moves into `device_state`, where both
engines can reach it rather than the native factory reaching through the
Tracktion adapter:

- `legacyEngineStateTree()` parses a v1 document and drops the engine's object
  ids and the `MODIFIERASSIGNMENTS` it hangs on every plugin. What is left is the
  device's own state.
- `decodeSavedState()` answers with a `Doc` for either format, for the readers
  that want a document rather than a tree.

`TracktionDeviceStateBridge::legacyPluginTree()` now calls the first of those, so
there is one implementation of the v1 read rather than two.

State that cannot be read at all writes a line naming the device, through
`juce::Logger` so it reaches the release log. This was invisible for as long as
it was because nothing said anything.

## The step sequencer faceplate

Found while verifying the above, and three separate faults behind one symptom: a
sequencer that played the right melody under a faceplate showing sixteen C3s and
a step count of 1.

- The block that hands a sequencer its pattern and its controls lived only in
  `refreshParameterValues()`, which runs on a parameter edit. `update()` runs
  when the faceplate is built, and did not carry it, so the faceplate opened on
  nothing and came right the moment any control was touched. Both paths now call
  `refreshSequencerState()`.
- `monoPatternOf()` / `polyPatternOf()` decoded v2 only, so a v1 project's
  pattern read as empty. The step and note spellings are frozen across both
  formats, so only the container needed handling.
- `setPattern()` returned early on an unchanged pattern, which left the Steps
  slider at its range minimum of 1 whenever the pattern equalled the default one.
  The controls are written on every call now; only the redraw is skipped.

The fork hid all three: its faceplate polls the running plugin every 30 ms, so
the first tick filled in whatever creation had not. Under the MAGDA engine there
is no plugin to poll (#2585).

## Tests

`tests/engine/test_engine_device_layer.cpp`: a device restored from v1 XML, the
stripping itself, and a sequencer pattern read out of v1. Every asserted value
differs from the device's default, so each fails without the fix rather than
passing by coincidence.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF
