### PR TITLE
Stop the device slot and mini-chain row applying a plugin's parameter config

### DIFF
--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "AppPaths.hpp"
+#include "ChainWalk.hpp"
 #include "DeviceInfo.hpp"
 #include "RackInfo.hpp"
 #include "TrackManager.hpp"
@@ -26,14 +27,15 @@ bool applyConfigToMatchingDevice(const juce::String& uniqueId, DeviceInfo& devic
 bool refreshElementParameterConfig(const juce::String& uniqueId,
                                    std::vector<ChainElement>& elements) {
     bool changed = false;
-    for (auto& element : elements) {
-        if (isDevice(element)) {
-            changed = applyConfigToMatchingDevice(uniqueId, getDevice(element)) || changed;
-        } else if (isRack(element)) {
-            for (auto& chain : getRack(element).chains)
-                changed = refreshElementParameterConfig(uniqueId, chain.elements) || changed;
-        }
-    }
+    // Pads entered: a device on a Drum Grid pad is configured from the same
+    // dialog as any other, and the walk is shared so that adding a container to
+    // the model does not leave this one behind (#2204).
+    chain_walk::forEachDevice(elements, {}, chain_walk::Pads::Enter,
+                              [&changed, &uniqueId](DeviceInfo& device, const ChainNodePath&) {
+                                  changed =
+                                      applyConfigToMatchingDevice(uniqueId, device) || changed;
+                                  return true;
+                              });
     return changed;
 }
 

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -535,8 +535,6 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     }
 
     updateParameterPagination();
-    applySavedParameterConfig();
-    updateParameterPagination();
 
     // Load parameters for current page
     updateParameterSlots();
@@ -764,10 +762,6 @@ void DeviceSlotComponent::setNodePath(const magda::ChainNodePath& path) {
     customUI_.setDevicePath(path);
     updateDeviceSlotInlineUi(device_, compiledPanel_.get(), customUI_);
 
-    if (applySavedParameterConfig()) {
-        updateParameterPagination();
-        updateParameterSlots();
-    }
     refreshDeviceTraits(device_);
 
     // Hide power / preset / delete for post-FX analysis devices (the getters
@@ -947,8 +941,6 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     // Update multi-out button visibility
     if (multiOutButton_)
         multiOutButton_->setVisible(device_.multiOut.isMultiOut);
-
-    applySavedParameterConfig();
 
     // Update pagination based on visible parameter count, then clamp current page
     updateParameterPagination();
@@ -1527,10 +1519,6 @@ void DeviceSlotComponent::refreshFaustMeterPanel() {
 
 void DeviceSlotComponent::updateParameterValues() {
     updateDeviceSlotParameterValues(device_, *paramGrid_);
-}
-
-bool DeviceSlotComponent::applySavedParameterConfig() {
-    return applyDeviceSlotSavedParameterConfig(device_, nodePath_, paramGrid_.get());
 }
 
 void DeviceSlotComponent::updateParameterPagination() {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -320,7 +320,6 @@ class DeviceSlotComponent : public NodeComponent,
 
     void updateParameterSlots();   // Reload parameter data for current page
     void updateParameterValues();  // Update only parameter values (for polling)
-    bool applySavedParameterConfig();
     void updateParameterPagination();
     void goToPrevPage();
     void goToNextPage();

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
@@ -4,7 +4,6 @@
 #include <utility>
 
 #include "compiled/CompiledPluginPresentation.hpp"
-#include "core/PluginParameterConfigStore.hpp"
 #include "core/TrackManager.hpp"
 #include "params/ParamHostComponent.hpp"
 #include "slot/DeviceParameterChangeHandler.hpp"
@@ -66,42 +65,6 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
 void updateDeviceSlotParameterValues(const magda::DeviceInfo& device,
                                      ParamHostComponent& paramGrid) {
     paramGrid.updateParameterValues(device, paramGrid.getCurrentPage());
-}
-
-bool applyDeviceSlotSavedParameterConfig(magda::DeviceInfo& device,
-                                         const magda::ChainNodePath& nodePath,
-                                         ParamHostComponent* paramGrid) {
-    if (paramGrid == nullptr || device.uniqueId.isEmpty() || device.parameters.empty())
-        return false;
-
-    magda::DeviceInfo tempDevice = device;
-    if (!magda::PluginParameterConfigStore::applyToDevice(tempDevice.uniqueId, tempDevice))
-        return false;
-
-    if (!tempDevice.visibleParameters.empty()) {
-        if (nodePath.isValid())
-            magda::TrackManager::getInstance().setDeviceVisibleParameters(
-                nodePath, tempDevice.visibleParameters);
-        device.visibleParameters = tempDevice.visibleParameters;
-    }
-
-    if (nodePath.isValid())
-        magda::TrackManager::getInstance().setDeviceMiniMixerParameters(
-            nodePath, tempDevice.miniMixerParameters);
-    device.miniMixerParameters = tempDevice.miniMixerParameters;
-
-    if (nodePath.isValid())
-        magda::TrackManager::getInstance().setDeviceAiSoundDesignerParameters(
-            nodePath, tempDevice.aiSoundDesignerParameters);
-    device.aiSoundDesignerParameters = tempDevice.aiSoundDesignerParameters;
-
-    if (nodePath.isValid())
-        magda::TrackManager::getInstance().setDeviceAiSoundDesignerPrompt(
-            nodePath, tempDevice.aiSoundDesignerPrompt);
-    device.aiSoundDesignerPrompt = tempDevice.aiSoundDesignerPrompt;
-
-    device.parameters = tempDevice.parameters;
-    return true;
 }
 
 void updateDeviceSlotParameterPagination(const magda::DeviceInfo& device,

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
@@ -26,10 +26,6 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
 void updateDeviceSlotParameterValues(const magda::DeviceInfo& device,
                                      ParamHostComponent& paramGrid);
 
-bool applyDeviceSlotSavedParameterConfig(magda::DeviceInfo& device,
-                                         const magda::ChainNodePath& nodePath,
-                                         ParamHostComponent* paramGrid);
-
 void updateDeviceSlotParameterPagination(const magda::DeviceInfo& device,
                                          ParamHostComponent* paramGrid);
 

--- a/magda/daw/ui/components/mixer/MiniChainRow.cpp
+++ b/magda/daw/ui/components/mixer/MiniChainRow.cpp
@@ -10,7 +10,6 @@
 #include "../common/SvgButton.hpp"
 #include "../common/TextSlider.hpp"
 #include "core/ChainNodePath.hpp"
-#include "core/PluginParameterConfigStore.hpp"
 #include "core/TrackManager.hpp"
 #include "core/UndoManager.hpp"
 
@@ -137,8 +136,6 @@ void MiniChainRow::resolveParams() {
     auto* devInfo = TrackManager::getInstance().getDeviceInChainByPath(devicePath_);
     if (devInfo == nullptr)
         return;
-    if (devInfo->uniqueId.isNotEmpty())
-        magda::PluginParameterConfigStore::applyToDevice(devInfo->uniqueId, *devInfo);
     const auto path = devicePath_;
 
     auto addParamSlider = [&](const ParameterInfo& paramInfo) {

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -5,6 +5,7 @@
 
 #include "magda/daw/audio/processors/base/DeviceProcessor.hpp"
 #include "magda/daw/core/AppPaths.hpp"
+#include "magda/daw/core/ChainWalk.hpp"
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/PluginParameterConfigStore.hpp"
 #include "magda/daw/core/RackInfo.hpp"
@@ -404,6 +405,53 @@ TEST_CASE("A saved config reaches a live device without a rebuild", "[param-conf
     CHECK(device.parameters[0].unit == "kHz");
     CHECK(device.visibleParameters == std::vector<int>{0});
     CHECK(device.miniMixerParameters == std::vector<int>{1});
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("A saved config reaches a device on a Drum Grid pad", "[param-config-store][2601]") {
+    // A pad device is configured from the same dialog as any other, and a
+    // device is not a leaf when it owns pads (#2204).
+    TempDataDir temp;
+    auto& tm = magda::TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+
+    magda::DeviceInfo grid;
+    grid.name = "Grid";
+    grid.pluginId = "drumgrid";
+    grid.format = magda::PluginFormat::Internal;
+    grid.isInstrument = true;
+    grid.deviceType = magda::DeviceType::Instrument;
+    const auto gridId = tm.addDeviceToTrack(trackId, grid);
+
+    const auto gridPath = magda::ChainNodePath::topLevelDevice(trackId, gridId);
+    const auto padChainId = tm.ensurePad(gridPath, 0);
+    REQUIRE(padChainId != magda::INVALID_CHAIN_ID);
+    REQUIRE(tm.addDeviceToPad(gridPath, padChainId, makeExternalDevice()) !=
+            magda::INVALID_DEVICE_ID);
+
+    auto config = store::fromDevice(makeExternalDevice());
+    config.entries[0].visible = true;
+    config.entries[0].unit = "kHz";
+    REQUIRE(store::save("VST3-Surge-XT-1a2b3c4d", config));
+
+    store::refreshLiveDevices("VST3-Surge-XT-1a2b3c4d");
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+
+    const magda::DeviceInfo* onPad = magda::chain_walk::findDevice(
+        track->chain.fxChainElements, magda::ChainNodePath::trackLevel(trackId),
+        magda::chain_walk::Pads::Enter,
+        [](const magda::DeviceInfo& device, const magda::ChainNodePath&) {
+            return device.uniqueId == "VST3-Surge-XT-1a2b3c4d";
+        });
+    REQUIRE(onPad != nullptr);
+
+    CHECK(onPad->parameters[0].unit == "kHz");
+    CHECK(onPad->visibleParameters == std::vector<int>{0});
 
     tm.clearAllTracks();
 }

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -7,6 +7,8 @@
 #include "magda/daw/core/AppPaths.hpp"
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/PluginParameterConfigStore.hpp"
+#include "magda/daw/core/RackInfo.hpp"
+#include "magda/daw/core/TrackManager.hpp"
 
 namespace store = magda::PluginParameterConfigStore;
 
@@ -372,4 +374,36 @@ TEST_CASE("A model-first refresh keeps its values and still gains the config",
     REQUIRE(device.parameters.size() == 3);
     CHECK(device.parameters[1].currentValue == 42.0f);
     CHECK(device.parameters[1].unit == "Q");
+}
+
+TEST_CASE("A saved config reaches a live device without a rebuild", "[param-config-store][2601]") {
+    // What Configure Parameters leans on. The device is already built, so
+    // nothing repopulates its array on save, and since the device slot stopped
+    // applying the config itself this is the only thing that puts a new one on
+    // a device already on screen.
+    TempDataDir temp;
+    auto& tm = magda::TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+    tm.addDeviceToTrack(trackId, makeExternalDevice());
+
+    auto config = store::fromDevice(makeExternalDevice());
+    config.entries[0].visible = true;
+    config.entries[0].unit = "kHz";
+    config.entries[1].miniMixer = true;
+    REQUIRE(store::save("VST3-Surge-XT-1a2b3c4d", config));
+
+    store::refreshLiveDevices("VST3-Surge-XT-1a2b3c4d");
+
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->chain.fxChainElements.size() == 1);
+
+    const auto& device = magda::getDevice(track->chain.fxChainElements[0]);
+    CHECK(device.parameters[0].unit == "kHz");
+    CHECK(device.visibleParameters == std::vector<int>{0});
+    CHECK(device.miniMixerParameters == std::vector<int>{1});
+
+    tm.clearAllTracks();
 }


### PR DESCRIPTION
The last of the three items on #2601. **This one needs a click-through before
merge** — the change is in the UI layer and I cannot drive it; what I could
test is below, and what I could not is at the bottom.

Since #2608 the stored config goes on where a device's parameter array is
built, under both engines. The two UI paths that also applied it were
re-reading the config file from disk on every device refresh and writing the
selections back into the model from the UI layer.

## What changed

`DeviceSlotComponent` applied it three times over — construction, `setNodePath`
and `updateFromDevice` — through `applyDeviceSlotSavedParameterConfig`, which
copied the device, applied the config to the copy, and pushed the visible /
mini-mixer / AI selections and the prompt back through `TrackManager`.
`MiniChainRow::resolveParams` applied it once per resolve, straight onto the
live model device. Both are gone, along with the helper and its declaration. A
device slot now renders what it is handed.

## What holds it up

- **A device that is built or rebuilt** takes the config in
  `populateParameters` on the fork (#2608) and `EngineHost::applyLoadedDevice`
  on the native engine (#2606). Every path that makes a processor goes through
  one of them: plugin load, rack registration, `refreshDeviceParameters`,
  `loadDeviceAsPlugin`, drum-grid capture, the custom-UI refresh.
- **A device already on screen when a config is saved** is reached by
  `PluginParameterConfigStore::refreshLiveDevices`, which both writers call —
  the dialog on save and the MCP `devices.setParameterConfig` path.
- **A device whose plugin never loaded** has no processor, but
  `serializeParameterInfo` writes `unit`, `minValue`, `maxValue`, `scale`,
  `choices` and `valueTable` per parameter, and `visibleParameters` /
  `miniMixerParameters` per device, so it keeps what the project saved.

## Tests

`refreshLiveDevices` is now the only thing that applies a config to a device
already built, and it had no test at all. It has one: a device in a track
chain, a config saved against its id, and the unit, the visible selection and
the mini-mixer selection all arrive without a rebuild. It fails with
`refreshLiveDevices` stubbed out.

`make test` (4010 passed, 13 skipped) and `make test-juce` green.
`make lint-changed` reports nothing on the changed files.

## What I could not test

No test drives a `DeviceSlotComponent` or a `MiniChainRow`, so the removal
itself is covered only by the reasoning above. Worth clicking before merge:

1. Configure a VST3's cutoff as Hz with a couple of Visible and one Mini
   ticked, and **Save** — the slot should pick it up without reopening the
   project.
2. Close and reopen the project — units and selections still there.
3. The mixer's mini-chain row shows the Mini-ticked parameter.
4. Drag the device to another track and into a rack — `setNodePath` was a
   re-apply point, so this is where I would expect a gap if there is one.
5. Same project under the other engine.
6. A configured device on a Drum Grid pad.

Closes #2601 once that passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
