### PR TITLE
Publish a track's live MIDI routing as one snapshot

### DIFF
--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -98,9 +98,8 @@ std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiInputs() const {
     auto devices =
         midiInputs | std::views::transform(asPhysicalDevice) | toStd<std::vector<MidiDeviceInfo>>();
 
-    // The fork's virtual inputs ("All MIDI Ins" and any user-created one) get
-    // no messages under the native engine, so a track routed to one hears
-    // nothing. The QWERTY keyboard is listed under qwertyMidiDeviceId().
+    // Under the native engine, messages arrive under a physical device's
+    // identifier or under qwertyMidiDeviceId(). Those are the ids to offer.
     if (liveSink_.load(std::memory_order_acquire) != nullptr) {
         if (qwertyEnabled_)
             devices.emplace_back(qwertyMidiDeviceId(), kQwertyMidiDeviceName, /*enabled=*/true);

--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -98,6 +98,15 @@ std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiInputs() const {
     auto devices =
         midiInputs | std::views::transform(asPhysicalDevice) | toStd<std::vector<MidiDeviceInfo>>();
 
+    // Nothing feeds a fork virtual input under the native engine -- "All MIDI
+    // Ins" among them -- so listing one offers a route that is silence. The
+    // keyboard goes in here instead, under the id it pushes under.
+    if (liveSink_.load(std::memory_order_acquire) != nullptr) {
+        if (qwertyEnabled_)
+            devices.emplace_back(qwertyMidiDeviceId(), kQwertyMidiDeviceName, /*enabled=*/true);
+        return devices;
+    }
+
     // Include TE virtual MIDI devices only when enabled. The routing
     // selectors refresh via onMidiDeviceListChanged when the device
     // state changes, so the filter is effective.
@@ -117,13 +126,6 @@ std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiInputs() const {
     std::ranges::copy(teDevices | std::views::filter(isEnabledVirtualInput) |
                           std::views::transform(asVirtualDevice),
                       std::back_inserter(devices));
-
-    // No fork virtual device under magda: list the keyboard itself, under the
-    // same visibility rule the fork's device has above.
-    const bool forkDeviceListed = std::ranges::any_of(
-        devices, [id = qwertyMidiDeviceId()](const MidiDeviceInfo& d) { return d.id == id; });
-    if (liveSink_.load(std::memory_order_acquire) && !forkDeviceListed && qwertyEnabled_)
-        devices.emplace_back(qwertyMidiDeviceId(), kQwertyMidiDeviceName, /*enabled=*/true);
 
     return devices;
 }

--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -98,9 +98,9 @@ std::vector<MidiDeviceInfo> MidiBridge::getAvailableMidiInputs() const {
     auto devices =
         midiInputs | std::views::transform(asPhysicalDevice) | toStd<std::vector<MidiDeviceInfo>>();
 
-    // Nothing feeds a fork virtual input under the native engine -- "All MIDI
-    // Ins" among them -- so listing one offers a route that is silence. The
-    // keyboard goes in here instead, under the id it pushes under.
+    // The fork's virtual inputs ("All MIDI Ins" and any user-created one) get
+    // no messages under the native engine, so a track routed to one hears
+    // nothing. The QWERTY keyboard is listed under qwertyMidiDeviceId().
     if (liveSink_.load(std::memory_order_acquire) != nullptr) {
         if (qwertyEnabled_)
             devices.emplace_back(qwertyMidiDeviceId(), kQwertyMidiDeviceName, /*enabled=*/true);

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -55,6 +55,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         host/EngineTrace.cpp
         host/ExternalPluginLoader.cpp
         host/LiveMidiQueue.cpp
+        host/LiveMidiRouting.cpp
         host/LiveMidiSources.cpp
         host/EngineHost.hpp
         host/EngineProject.hpp
@@ -62,6 +63,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
         host/EngineTrace.hpp
         host/ExternalPluginLoader.hpp
         host/LiveMidiQueue.hpp
+        host/LiveMidiRouting.hpp
         host/LiveMidiSources.hpp
     )
     add_library(magda::engine_host ALIAS magda_engine_host)

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -458,8 +458,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         report("values", resolveValues(*livePlan_, tracks, *master, values));
         report("values", session_->publishValues(std::move(values)).messages);
 
-        // A monitor or route change is a track property, so it arrives here
-        // rather than as a plan, off the same reading as the values above.
+        // A monitor or route change arrives as a track property, off the same
+        // reading of the model as the values above.
         publishRouting(tracks);
     }
 

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -464,10 +464,10 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     }
 
     /**
-     * @brief What every track hears of the live MIDI (#2592).
+     * @brief Publish what every track hears of the live MIDI (#2592).
      *
-     * One snapshot per reading of the model, which the inputs the store keeps
-     * across a recompile read.
+     * One snapshot per reading of the model. The store keeps its inputs across
+     * a recompile, and they read this.
      */
     void publishRouting(const std::vector<TrackInfo>& tracks) {
         if (session_ == nullptr)
@@ -1014,9 +1014,9 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     EngineFileReaders files_;
     engine::PrefetchThread reader_;
 
-    /// Who is playing, what they played, and which track hears it. The
-    /// registry is the message and MIDI threads'; the queue is how one reaches
-    /// the other side.
+    /// Who is playing, what they played, and which track hears it. The message
+    /// thread and the MIDI threads share the registry; the queue carries
+    /// messages between them.
     LiveMidiSources sources_;
     LiveMidiRouting routing_{sources_};
     LiveMidiQueue queue_;

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -463,8 +463,12 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         publishRouting(tracks);
     }
 
-    /// What every track hears of the live MIDI: one snapshot per reading of the
-    /// model, which the inputs the store keeps across a recompile read (#2592).
+    /**
+     * @brief What every track hears of the live MIDI (#2592).
+     *
+     * One snapshot per reading of the model, which the inputs the store keeps
+     * across a recompile read.
+     */
     void publishRouting(const std::vector<TrackInfo>& tracks) {
         if (session_ == nullptr)
             return;

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -646,8 +646,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         factory_.attach(session_->clipFeed(), voices_->feed(), session_->launchHandleFeed(),
                         session_->liveInputs());
 
-        // The new feed has never been published to, so the publish below has to
-        // answer in full even for a model that has not moved.
+        // The publish below fills the new feed with a full snapshot.
         routing_.reset();
 
         session_->liveInputs().prepare(inputChannels_.load(std::memory_order_relaxed),

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -29,6 +29,7 @@
 #include "EngineTrace.hpp"
 #include "ExternalPluginLoader.hpp"
 #include "LiveMidiQueue.hpp"
+#include "LiveMidiRouting.hpp"
 #include "LiveMidiSources.hpp"
 #include "clip/ClipSnapshotCompiler.hpp"
 #include "clip/ClipVoicePool.hpp"
@@ -407,6 +408,10 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         sources_.registerAvailableDevices();
         factory_.setModel(tracks, *master);
 
+        // Before the swap, so the new plan's first block renders against
+        // routing resolved from the same reading of the model (#2592).
+        publishRouting(tracks);
+
         if (plan == nullptr)
             plan = compilePlan(tracks, *master);
         report("plan", plan->diagnostics);
@@ -454,9 +459,18 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         report("values", session_->publishValues(std::move(values)).messages);
 
         // A monitor or route change is a track property, so it arrives here
-        // rather than as a plan, and the input the store already holds reads
-        // the table this rewrites.
-        factory_.refreshMidiRoutes(tracks);
+        // rather than as a plan, off the same reading as the values above.
+        publishRouting(tracks);
+    }
+
+    /// What every track hears of the live MIDI: one snapshot per reading of the
+    /// model, which the inputs the store keeps across a recompile read (#2592).
+    void publishRouting(const std::vector<TrackInfo>& tracks) {
+        if (session_ == nullptr)
+            return;
+
+        if (auto routing = routing_.resolve(tracks))
+            session_->liveInputs().publishRouting(std::move(routing));
     }
 
     /// A device plugged in or unplugged since the last structural publish.
@@ -465,7 +479,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     /// would resolve to a source nothing pushes under.
     void refreshLiveMidiDevices() {
         sources_.registerAvailableDevices();
-        factory_.refreshMidiRoutes(TrackManager::getInstance().getTracks());
+        publishRouting(TrackManager::getInstance().getTracks());
     }
 
     /// What every track plays, resolved against the tempo the transport is
@@ -508,6 +522,7 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     /// with devices that are already gone (#2572).
     void projectTeardown() override {
         factory_.forgetBuiltDevices();
+        routing_.reset();
     }
 
     void tracksChanged() override {
@@ -625,7 +640,11 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         // and not one to answer in the same change that first made a sound.
         session_ = std::make_unique<engine::EngineSession>(factory_, nullptr, voices_.get());
         factory_.attach(session_->clipFeed(), voices_->feed(), session_->launchHandleFeed(),
-                        session_->liveInputs(), sources_);
+                        session_->liveInputs());
+
+        // The new feed has never been published to, so the publish below has to
+        // answer in full even for a model that has not moved.
+        routing_.reset();
 
         session_->liveInputs().prepare(inputChannels_.load(std::memory_order_relaxed),
                                        context.maxBlockSize);
@@ -992,10 +1011,11 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
     EngineFileReaders files_;
     engine::PrefetchThread reader_;
 
-    /// Who is playing, and what they played. The registry is the message and
-    /// MIDI threads'; the queue is how one reaches the other side. Before the
-    /// factory, which holds the registry for the length of a publish.
+    /// Who is playing, what they played, and which track hears it. The
+    /// registry is the message and MIDI threads'; the queue is how one reaches
+    /// the other side.
     LiveMidiSources sources_;
+    LiveMidiRouting routing_{sources_};
     LiveMidiQueue queue_;
 
     /// One buffer per source id, indexed by id - 1, and the streams over the

--- a/magda/daw/engine/host/EngineRuntimeFactory.cpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.cpp
@@ -1,6 +1,5 @@
 #include "EngineRuntimeFactory.hpp"
 
-#include <algorithm>
 #include <utility>
 
 #include "../../audio/plugins/engine/EngineDeviceFactory.hpp"
@@ -20,44 +19,6 @@ juce::String deviceIdentityOf(const DeviceInfo& device) {
            device.getFormatString();
 }
 
-/**
- * @brief A track's live MIDI: its own audition, and the devices routed to it.
- *
- * Named sources rather than kAnyLiveMidiSource, which would merge every other
- * track's audition into this one.
- */
-class TrackMidiInput final : public engine::EngineMidiSource {
-  public:
-    TrackMidiInput(const engine::LiveInputFeed& feed, engine::LiveMidiSourceId audition,
-                   std::shared_ptr<const EngineRuntimeFactory::MidiRouteTable> routed)
-        : feed_(feed), audition_(audition), routed_(std::move(routed)) {}
-
-    void render(const engine::BlockInfo& /*block*/, juce::MidiBuffer& out) override {
-        feed_.appendEvents(audition_, out, engine::kMaxMidiBytesPerPort);
-
-        const auto count = routed_->count.load(std::memory_order_acquire);
-        for (auto i = 0; i < count; ++i)
-            feed_.appendEvents(
-                routed_->sources[static_cast<std::size_t>(i)].load(std::memory_order_relaxed), out,
-                engine::kMaxMidiBytesPerPort);
-
-        // A source that has gone will never send the note-off for what it is
-        // still holding, and a route change publishes no topology, so this is
-        // the only panic the instrument gets (#2418).
-        dropped_ = routed_->dropped.exchange(false, std::memory_order_acq_rel);
-    }
-
-    bool raisedAllNotesOff() const override {
-        return dropped_;
-    }
-
-  private:
-    const engine::LiveInputFeed& feed_;
-    engine::LiveMidiSourceId audition_ = engine::kAnyLiveMidiSource;
-    std::shared_ptr<const EngineRuntimeFactory::MidiRouteTable> routed_;
-    bool dropped_ = false;
-};
-
 }  // namespace
 
 EngineFileReaders::EngineFileReaders() {
@@ -75,20 +36,16 @@ std::unique_ptr<engine::AudioFileReader> EngineFileReaders::open(const std::stri
 
 void EngineRuntimeFactory::attach(engine::ClipSnapshotFeed& clips, engine::ClipStreamFeed& streams,
                                   engine::LaunchHandleFeed& handles,
-                                  const engine::LiveInputFeed& liveInputs,
-                                  LiveMidiSources& sources) {
+                                  const engine::LiveInputFeed& liveInputs) {
     clips_ = &clips;
     streams_ = &streams;
     handles_ = &handles;
     liveInputs_ = &liveInputs;
-    sources_ = &sources;
-    resolveRouteTables();
 }
 
 void EngineRuntimeFactory::setModel(const std::vector<TrackInfo>& tracks, const TrackInfo& master) {
     devices_.clear();
     unbuilt_.clear();
-    refreshMidiRoutes(tracks);
 
     for (const auto& [key, device] : adapter::devicesIn(tracks, master))
         devices_.emplace(key, *device);
@@ -212,78 +169,10 @@ std::unique_ptr<engine::EngineMidiSource> EngineRuntimeFactory::createSessionMid
 }
 
 std::unique_ptr<engine::EngineMidiSource> EngineRuntimeFactory::createMidiInput(TrackId trackId) {
-    if (liveInputs_ == nullptr || sources_ == nullptr)
+    if (liveInputs_ == nullptr)
         return nullptr;
 
-    return std::make_unique<TrackMidiInput>(*liveInputs_, sources_->auditionSourceFor(trackId),
-                                            routeTableFor(trackId));
-}
-
-void EngineRuntimeFactory::MidiRouteTable::set(const std::vector<engine::LiveMidiSourceId>& ids) {
-    const auto n = std::min(static_cast<int>(ids.size()), kMaxSources);
-
-    // Only what is leaving: a source added beside the ones already routed
-    // takes nothing away, and a panic raised for it would cut a chord that is
-    // still being held down.
-    const auto was = count.load(std::memory_order_relaxed);
-    for (auto i = 0; i < was; ++i) {
-        const auto source = sources[static_cast<std::size_t>(i)].load(std::memory_order_relaxed);
-        if (std::ranges::find(ids, source) == ids.end()) {
-            dropped.store(true, std::memory_order_relaxed);
-            break;
-        }
-    }
-
-    for (auto i = 0; i < n; ++i)
-        sources[static_cast<std::size_t>(i)].store(ids[static_cast<std::size_t>(i)],
-                                                   std::memory_order_relaxed);
-    count.store(n, std::memory_order_release);
-}
-
-std::shared_ptr<EngineRuntimeFactory::MidiRouteTable> EngineRuntimeFactory::routeTableFor(
-    TrackId trackId) {
-    auto& table = routeTables_[trackId];
-    if (table == nullptr)
-        table = std::make_shared<MidiRouteTable>();
-    return table;
-}
-
-void EngineRuntimeFactory::refreshMidiRoutes(const std::vector<TrackInfo>& tracks) {
-    midiRoutes_.clear();
-
-    // monitorsInput, which is what the compiler gates a routed input on: the
-    // fork assigns a device to a track in Auto too, but TE's monitor mode
-    // still decides whether it is heard, and this table is heard directly.
-    for (const auto& track : tracks)
-        midiRoutes_.emplace(track.id, MidiRoute{track.midiInputDevice, track.monitorsInput()});
-
-    resolveRouteTables();
-}
-
-void EngineRuntimeFactory::resolveRouteTables() {
-    if (sources_ == nullptr)
-        return;
-
-    for (const auto& [trackId, route] : midiRoutes_)
-        routeTableFor(trackId)->set(routedSources(route));
-}
-
-std::vector<engine::LiveMidiSourceId> EngineRuntimeFactory::routedSources(const MidiRoute& route) {
-    // Monitoring is the fork's own gate on hearing an input, and a "track:"
-    // route is carried inside the plan rather than by a device.
-    if (!route.monitors || route.device.startsWith("track:"))
-        return {};
-
-    // An empty field is "all" on the fork too: a monitoring track that names
-    // no device is routed to every input (MidiInputRouter.cpp:747).
-    if (route.device.isEmpty() || route.device == "all")
-        return sources_->deviceSources();
-
-    const auto source = sources_->resolveRoute(route.device);
-    if (source == LiveMidiSources::kNoSource)
-        return {};
-
-    return {source};
+    return std::make_unique<engine::TrackLiveMidiInput>(*liveInputs_, trackId);
 }
 
 // Both sections through the handle-reading constructor, including the

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -119,9 +119,8 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
     std::unique_ptr<engine::EngineAudioSource> createSessionAudioSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineMidiSource> createSessionMidiSource(TrackId trackId) override;
 
-    /// What the track hears is the published routing's answer, not this
-    /// (LiveRouting.hpp). createAudioInput stays unoverridden: live audio is
-    /// #2553's.
+    /// The published routing supplies what the track hears (LiveRouting.hpp).
+    /// createAudioInput stays unoverridden; live audio is #2553's.
     std::unique_ptr<engine::EngineMidiSource> createMidiInput(TrackId trackId) override;
 
   private:

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -2,8 +2,6 @@
 
 #include <juce_audio_formats/juce_audio_formats.h>
 
-#include <array>
-#include <atomic>
 #include <map>
 #include <memory>
 #include <set>
@@ -11,7 +9,6 @@
 
 #include "EngineTrace.hpp"
 #include "ExternalPluginLoader.hpp"
-#include "LiveMidiSources.hpp"
 #include "clip/ClipSnapshotFeed.hpp"
 #include "clip/ClipStreamFeed.hpp"
 #include "core/DeviceInfo.hpp"
@@ -57,12 +54,10 @@ class EngineFileReaders final : public engine::AudioFileReaderFactory {
  */
 class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
   public:
-    /// The feeds every source it makes will read, and the registry a live
-    /// route resolves through. Once, before the first publish; all of them
-    /// outlive every source bound into any plan.
+    /// The feeds every source it makes will read. Once, before the first
+    /// publish; all of them outlive every source bound into any plan.
     void attach(engine::ClipSnapshotFeed& clips, engine::ClipStreamFeed& streams,
-                engine::LaunchHandleFeed& handles, const engine::LiveInputFeed& liveInputs,
-                LiveMidiSources& sources);
+                engine::LaunchHandleFeed& handles, const engine::LiveInputFeed& liveInputs);
 
     /**
      * @brief What the model holds now, for the publish about to happen.
@@ -124,55 +119,12 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
     std::unique_ptr<engine::EngineAudioSource> createSessionAudioSource(TrackId trackId) override;
     std::unique_ptr<engine::EngineMidiSource> createSessionMidiSource(TrackId trackId) override;
 
-    /// The track's audition, and the devices its route names. createAudioInput
-    /// is deliberately left unoverridden: live audio is #2553's.
+    /// What the track hears is the published routing's answer, not this
+    /// (LiveRouting.hpp). createAudioInput stays unoverridden: live audio is
+    /// #2553's.
     std::unique_ptr<engine::EngineMidiSource> createMidiInput(TrackId trackId) override;
 
-    /**
-     * @brief A track's routed device sources, as a table the publisher rewrites.
-     *
-     * The store builds a track's input once and keeps it across every later
-     * publish, so a monitor or route change after that has to reach the input
-     * some other way: this is written on the publishing thread and read on the
-     * audio thread, count last so a reader sees whole entries.
-     */
-    struct MidiRouteTable {
-        static constexpr int kMaxSources = 32;
-        std::array<std::atomic<engine::LiveMidiSourceId>, kMaxSources> sources{};
-        std::atomic<int> count{0};
-
-        /// A source has left the table since the last block. Read and cleared
-        /// by the input, which turns it into the panic its instrument needs to
-        /// release the notes that source will never send an off for. Mutable
-        /// because the input holds the table as const and consuming this is
-        /// the one thing it writes.
-        mutable std::atomic<bool> dropped{false};
-
-        void set(const std::vector<engine::LiveMidiSourceId>& ids);
-    };
-
-    /// Every track's routed sources from the model as it is now. setModel
-    /// calls it; the host calls it again on a values publish, which is where
-    /// a monitor change arrives.
-    void refreshMidiRoutes(const std::vector<TrackInfo>& tracks);
-
   private:
-    /// What a track's MIDI input op resolves through.
-    struct MidiRoute {
-        juce::String device;
-        bool monitors = false;
-    };
-
-    /// The device sources @p route names, resolved here rather than in
-    /// render(): this runs on the publishing thread.
-    std::vector<engine::LiveMidiSourceId> routedSources(const MidiRoute& route);
-
-    std::shared_ptr<MidiRouteTable> routeTableFor(TrackId trackId);
-
-    /// Every stored route into its table. Needs the registry, so it runs from
-    /// whichever of setModel and attach comes second.
-    void resolveRouteTables();
-
     std::unique_ptr<engine::EngineDevice> handOver(engine::DeviceKey key, const DeviceInfo& model,
                                                    std::unique_ptr<engine::EngineDevice> device);
     std::unique_ptr<engine::EngineAudioSource> audioSource(TrackId trackId,
@@ -183,14 +135,6 @@ class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
     engine::ClipStreamFeed* streams_ = nullptr;
     engine::LaunchHandleFeed* handles_ = nullptr;
     const engine::LiveInputFeed* liveInputs_ = nullptr;
-    LiveMidiSources* sources_ = nullptr;
-
-    /// The model's routes as of the last setModel or refresh.
-    std::map<TrackId, MidiRoute> midiRoutes_;
-
-    /// Shared with the input that reads it, so a table outlives the store's
-    /// eviction of that input and the factory's copy is never dangling.
-    std::map<TrackId, std::shared_ptr<MidiRouteTable>> routeTables_;
 
     std::map<engine::DeviceKey, DeviceInfo> devices_;
 

--- a/magda/daw/engine/host/EngineRuntimeFactory.hpp
+++ b/magda/daw/engine/host/EngineRuntimeFactory.hpp
@@ -54,8 +54,12 @@ class EngineFileReaders final : public engine::AudioFileReaderFactory {
  */
 class EngineRuntimeFactory final : public engine::RuntimeStateFactory {
   public:
-    /// The feeds every source it makes will read. Once, before the first
-    /// publish; all of them outlive every source bound into any plan.
+    /**
+     * @brief Store the feeds that sources created here read from.
+     *
+     * Call once, before the first publish. Each feed outlives every source
+     * bound into a plan.
+     */
     void attach(engine::ClipSnapshotFeed& clips, engine::ClipStreamFeed& streams,
                 engine::LaunchHandleFeed& handles, const engine::LiveInputFeed& liveInputs);
 

--- a/magda/daw/engine/host/LiveMidiRouting.cpp
+++ b/magda/daw/engine/host/LiveMidiRouting.cpp
@@ -1,0 +1,60 @@
+#include "LiveMidiRouting.hpp"
+
+#include <algorithm>
+
+namespace magda::daw::engine_host {
+
+std::shared_ptr<const engine::LiveRouting> LiveMidiRouting::resolve(
+    const std::vector<TrackInfo>& tracks) {
+    auto routing = std::make_shared<engine::LiveRouting>();
+    routing->tracks.reserve(tracks.size());
+
+    for (const auto& track : tracks) {
+        engine::TrackLiveMidi entry{.trackId = track.id,
+                                    .audition = sources_.auditionSourceFor(track.id),
+                                    .sources = devicesFor(track),
+                                    .sourcesLost = 0};
+
+        const auto* before = previous_ != nullptr ? previous_->find(track.id) : nullptr;
+        if (before != nullptr) {
+            const auto gone = std::ranges::any_of(before->sources, [&](auto source) {
+                return std::ranges::find(entry.sources, source) == entry.sources.end();
+            });
+            entry.sourcesLost = before->sourcesLost + (gone ? 1 : 0);
+        }
+
+        routing->tracks.push_back(std::move(entry));
+    }
+
+    // The model holds its tracks in arrangement order; find() binary-searches.
+    std::ranges::sort(routing->tracks,
+                      [](const auto& a, const auto& b) { return a.trackId < b.trackId; });
+
+    if (previous_ != nullptr && previous_->tracks == routing->tracks)
+        return nullptr;
+
+    previous_ = routing;
+    return routing;
+}
+
+std::vector<engine::LiveMidiSourceId> LiveMidiRouting::devicesFor(const TrackInfo& track) {
+    // monitorsInput, not receivesLiveMidiInput: Auto without an arm is the UI's
+    // activity light.
+    if (!track.monitorsInput() || track.midiInputDevice.startsWith("track:"))
+        return {};
+
+    // An empty field is the selector's None, not every input.
+    if (track.midiInputDevice.isEmpty())
+        return {};
+
+    if (track.midiInputDevice == "all")
+        return sources_.deviceSources();
+
+    const auto source = sources_.resolveRoute(track.midiInputDevice);
+    if (source == LiveMidiSources::kNoSource)
+        return {};
+
+    return {source};
+}
+
+}  // namespace magda::daw::engine_host

--- a/magda/daw/engine/host/LiveMidiRouting.cpp
+++ b/magda/daw/engine/host/LiveMidiRouting.cpp
@@ -26,7 +26,6 @@ std::shared_ptr<const engine::LiveRouting> LiveMidiRouting::resolve(
         routing->tracks.push_back(std::move(entry));
     }
 
-    // The model holds its tracks in arrangement order; find() binary-searches.
     std::ranges::sort(routing->tracks,
                       [](const auto& a, const auto& b) { return a.trackId < b.trackId; });
 
@@ -38,11 +37,9 @@ std::shared_ptr<const engine::LiveRouting> LiveMidiRouting::resolve(
 }
 
 std::vector<engine::LiveMidiSourceId> LiveMidiRouting::devicesFor(const TrackInfo& track) {
-    // "track:<id>" names a track, not a MIDI device.
     if (!track.monitorsInput() || track.midiInputDevice.startsWith("track:"))
         return {};
 
-    // An empty field means no device.
     if (track.midiInputDevice.isEmpty())
         return {};
 

--- a/magda/daw/engine/host/LiveMidiRouting.cpp
+++ b/magda/daw/engine/host/LiveMidiRouting.cpp
@@ -38,11 +38,11 @@ std::shared_ptr<const engine::LiveRouting> LiveMidiRouting::resolve(
 }
 
 std::vector<engine::LiveMidiSourceId> LiveMidiRouting::devicesFor(const TrackInfo& track) {
-    // A "track:" route is an edge in the plan, not a device.
+    // "track:<id>" names a track, not a MIDI device.
     if (!track.monitorsInput() || track.midiInputDevice.startsWith("track:"))
         return {};
 
-    // An empty field is the selector's None, not every input.
+    // An empty field means no device.
     if (track.midiInputDevice.isEmpty())
         return {};
 

--- a/magda/daw/engine/host/LiveMidiRouting.cpp
+++ b/magda/daw/engine/host/LiveMidiRouting.cpp
@@ -38,8 +38,7 @@ std::shared_ptr<const engine::LiveRouting> LiveMidiRouting::resolve(
 }
 
 std::vector<engine::LiveMidiSourceId> LiveMidiRouting::devicesFor(const TrackInfo& track) {
-    // monitorsInput, not receivesLiveMidiInput: Auto without an arm is the UI's
-    // activity light.
+    // A "track:" route is an edge in the plan, not a device.
     if (!track.monitorsInput() || track.midiInputDevice.startsWith("track:"))
         return {};
 

--- a/magda/daw/engine/host/LiveMidiRouting.hpp
+++ b/magda/daw/engine/host/LiveMidiRouting.hpp
@@ -11,8 +11,8 @@
  * @file LiveMidiRouting.hpp
  * @brief The model's input routing as one engine snapshot (#2592).
  *
- * Publishing thread only. Holds the snapshot it resolved last, which is what
- * lets it say when a source has left.
+ * Publishing thread only. Keeps the last snapshot so it can tell which sources
+ * a track has lost.
  */
 
 namespace magda::daw::engine_host {
@@ -26,15 +26,20 @@ class LiveMidiRouting {
      * @brief @p tracks as the routing the engine renders, or null when it
      *        matches the snapshot before.
      *
-     * Every track gets an entry: without one, a track whose monitor was
-     * switched off keeps the sources the previous snapshot gave it. Null when
-     * unchanged, because a fader drag publishes values, and this with them, on
-     * every frame.
+     * Every track gets an entry. Without one, a track whose monitor was
+     * switched off would keep the sources from the previous snapshot.
+     *
+     * Returns null when nothing changed, because a fader drag republishes this
+     * on every frame.
      */
     std::shared_ptr<const engine::LiveRouting> resolve(const std::vector<TrackInfo>& tracks);
 
-    /// Nothing resolved so far still holds: a new project (#2572), or a rebuilt
-    /// session whose feed was never published to.
+    /**
+     * @brief Forget the last snapshot, so the next resolve returns a full one.
+     *
+     * Call it for a new project (#2572) and for a rebuilt session, whose feed
+     * has never been published to.
+     */
     void reset() {
         previous_.reset();
     }

--- a/magda/daw/engine/host/LiveMidiRouting.hpp
+++ b/magda/daw/engine/host/LiveMidiRouting.hpp
@@ -48,8 +48,8 @@ class LiveMidiRouting {
     /**
      * @brief The device sources @p track names.
      *
-     * Empty for a track that is not monitoring and for a "track:" route, which
-     * the plan carries as an edge.
+     * Empty for a track that is not monitoring, and for a field that names no
+     * MIDI device.
      */
     std::vector<engine::LiveMidiSourceId> devicesFor(const TrackInfo& track);
 

--- a/magda/daw/engine/host/LiveMidiRouting.hpp
+++ b/magda/daw/engine/host/LiveMidiRouting.hpp
@@ -17,6 +17,7 @@
 
 namespace magda::daw::engine_host {
 
+/** @brief Resolves the model's MIDI input routing into engine snapshots. */
 class LiveMidiRouting {
   public:
     explicit LiveMidiRouting(LiveMidiSources& sources) : sources_(sources) {}
@@ -25,9 +26,10 @@ class LiveMidiRouting {
      * @brief @p tracks as the routing the engine renders, or null when it
      *        matches the snapshot before.
      *
-     * Every track gets an entry, since an entry naming no devices is what makes
-     * a monitor switched off silence. Null for an unchanged reading because a
-     * fader drag publishes values, and this, on every frame.
+     * Every track gets an entry: without one, a track whose monitor was
+     * switched off keeps the sources the previous snapshot gave it. Null when
+     * unchanged, because a fader drag publishes values, and this with them, on
+     * every frame.
      */
     std::shared_ptr<const engine::LiveRouting> resolve(const std::vector<TrackInfo>& tracks);
 
@@ -38,8 +40,12 @@ class LiveMidiRouting {
     }
 
   private:
-    /// The device sources @p track names. Empty for a track that is not
-    /// monitoring and for a "track:" route, which the plan carries as an edge.
+    /**
+     * @brief The device sources @p track names.
+     *
+     * Empty for a track that is not monitoring and for a "track:" route, which
+     * the plan carries as an edge.
+     */
     std::vector<engine::LiveMidiSourceId> devicesFor(const TrackInfo& track);
 
     LiveMidiSources& sources_;

--- a/magda/daw/engine/host/LiveMidiRouting.hpp
+++ b/magda/daw/engine/host/LiveMidiRouting.hpp
@@ -23,7 +23,7 @@ class LiveMidiRouting {
     explicit LiveMidiRouting(LiveMidiSources& sources) : sources_(sources) {}
 
     /**
-     * @brief @p tracks as the routing the engine renders.
+     * @brief Resolve @p tracks into the routing the engine renders.
      *
      * Every track gets an entry, so each one carries its own sources. Returns
      * null when the result equals the last snapshot.

--- a/magda/daw/engine/host/LiveMidiRouting.hpp
+++ b/magda/daw/engine/host/LiveMidiRouting.hpp
@@ -11,8 +11,8 @@
  * @file LiveMidiRouting.hpp
  * @brief The model's input routing as one engine snapshot (#2592).
  *
- * Publishing thread only. Keeps the last snapshot so it can tell which sources
- * a track has lost.
+ * Publishing thread only. Keeps the last snapshot to detect a source a track
+ * has lost.
  */
 
 namespace magda::daw::engine_host {
@@ -23,34 +23,24 @@ class LiveMidiRouting {
     explicit LiveMidiRouting(LiveMidiSources& sources) : sources_(sources) {}
 
     /**
-     * @brief @p tracks as the routing the engine renders, or null when it
-     *        matches the snapshot before.
+     * @brief @p tracks as the routing the engine renders.
      *
-     * Every track gets an entry. Without one, a track whose monitor was
-     * switched off would keep the sources from the previous snapshot.
-     *
-     * Returns null when nothing changed, because a fader drag republishes this
-     * on every frame.
+     * Every track gets an entry, so each one carries its own sources. Returns
+     * null when the result equals the last snapshot.
      */
     std::shared_ptr<const engine::LiveRouting> resolve(const std::vector<TrackInfo>& tracks);
 
     /**
      * @brief Forget the last snapshot, so the next resolve returns a full one.
      *
-     * Call it for a new project (#2572) and for a rebuilt session, whose feed
-     * has never been published to.
+     * Call it for a new project (#2572) and for a rebuilt session.
      */
     void reset() {
         previous_.reset();
     }
 
   private:
-    /**
-     * @brief The device sources @p track names.
-     *
-     * Empty for a track that is not monitoring, and for a field that names no
-     * MIDI device.
-     */
+    /** @brief The device sources @p track names. */
     std::vector<engine::LiveMidiSourceId> devicesFor(const TrackInfo& track);
 
     LiveMidiSources& sources_;

--- a/magda/daw/engine/host/LiveMidiRouting.hpp
+++ b/magda/daw/engine/host/LiveMidiRouting.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "LiveMidiSources.hpp"
+#include "core/TrackInfo.hpp"
+#include "io/LiveRouting.hpp"
+
+/**
+ * @file LiveMidiRouting.hpp
+ * @brief The model's input routing as one engine snapshot (#2592).
+ *
+ * Publishing thread only. Holds the snapshot it resolved last, which is what
+ * lets it say when a source has left.
+ */
+
+namespace magda::daw::engine_host {
+
+class LiveMidiRouting {
+  public:
+    explicit LiveMidiRouting(LiveMidiSources& sources) : sources_(sources) {}
+
+    /**
+     * @brief @p tracks as the routing the engine renders, or null when it
+     *        matches the snapshot before.
+     *
+     * Every track gets an entry, since an entry naming no devices is what makes
+     * a monitor switched off silence. Null for an unchanged reading because a
+     * fader drag publishes values, and this, on every frame.
+     */
+    std::shared_ptr<const engine::LiveRouting> resolve(const std::vector<TrackInfo>& tracks);
+
+    /// Nothing resolved so far still holds: a new project (#2572), or a rebuilt
+    /// session whose feed was never published to.
+    void reset() {
+        previous_.reset();
+    }
+
+  private:
+    /// The device sources @p track names. Empty for a track that is not
+    /// monitoring and for a "track:" route, which the plan carries as an edge.
+    std::vector<engine::LiveMidiSourceId> devicesFor(const TrackInfo& track);
+
+    LiveMidiSources& sources_;
+    std::shared_ptr<const engine::LiveRouting> previous_;
+};
+
+}  // namespace magda::daw::engine_host

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -137,6 +137,7 @@ add_library(magda_engine STATIC
     io/AudioFileSink.hpp
     io/LiveInput.cpp
     io/LiveInput.hpp
+    io/LiveRouting.hpp
     io/PcmQuantiser.cpp
     io/PcmQuantiser.hpp
     io/SourceLoopInfo.cpp

--- a/magda/engine/io/LiveInput.cpp
+++ b/magda/engine/io/LiveInput.cpp
@@ -190,8 +190,8 @@ void TrackLiveMidiInput::render(const BlockInfo& /*block*/, juce::MidiBuffer& ou
     if (dropped > 0)
         dropped_.fetch_add(static_cast<std::uint32_t>(dropped), std::memory_order_relaxed);
 
-    // Only a loss panics: a source arriving takes nothing away, and a panic for
-    // it would cut a chord still being held down.
+    // Only a loss raises all-notes-off. A source arriving removes nothing, and
+    // a panic would cut notes that are still held.
     panicked_ = started_ && routing->sourcesLost != lost_;
     lost_ = routing->sourcesLost;
     started_ = true;

--- a/magda/engine/io/LiveInput.cpp
+++ b/magda/engine/io/LiveInput.cpp
@@ -12,6 +12,11 @@ constexpr int kEventOverheadBytes = 6;
 
 }  // namespace
 
+LiveInputFeed::~LiveInputFeed() {
+    if (holdsRouting_)
+        published_.realtimeRelease();
+}
+
 void LiveInputFeed::prepare(int maxChannels, int maxBlockSize) {
     const auto channels = std::max(scratch_.getNumChannels(), std::max(0, maxChannels));
     const auto samples = std::max(scratch_.getNumSamples(), std::max(0, maxBlockSize));
@@ -21,6 +26,13 @@ void LiveInputFeed::prepare(int maxChannels, int maxBlockSize) {
 }
 
 void LiveInputFeed::beginCallback(const LiveInputBlock& input, int numSamples) {
+    // One acquisition for the whole callback (#2592). Guarded because the
+    // acquire and its release have to pair exactly.
+    if (!holdsRouting_) {
+        routing_ = published_.realtimeAcquire().get();
+        holdsRouting_ = true;
+    }
+
     midi_ = input.midi;
 
     const auto delivered = static_cast<int>(input.audio.getNumSamples());
@@ -70,12 +82,22 @@ void LiveInputFeed::beginSegment(int startSample, int numSamples) {
 }
 
 void LiveInputFeed::endCallback() {
+    if (holdsRouting_) {
+        routing_ = nullptr;
+        holdsRouting_ = false;
+        published_.realtimeRelease();
+    }
+
     audio_ = {};
     midi_ = {};
     callbackChannels_ = 0;
     callbackSamples_ = 0;
     segmentStart_ = 0;
     segmentSamples_ = 0;
+}
+
+void LiveInputFeed::publishRouting(std::shared_ptr<const LiveRouting> routing) {
+    published_.nonRealtimeReplace(std::move(routing));
 }
 
 int LiveInputFeed::appendEvents(LiveMidiSourceId source, juce::MidiBuffer& out,
@@ -152,6 +174,27 @@ LiveMidiInput::LiveMidiInput(const LiveInputFeed& feed, LiveMidiSourceId source,
 void LiveMidiInput::render(const BlockInfo& /*block*/, juce::MidiBuffer& out) {
     if (const auto dropped = feed_.appendEvents(source_, out, kMaxMidiBytesPerPort); dropped > 0)
         dropped_.fetch_add(static_cast<std::uint32_t>(dropped), std::memory_order_relaxed);
+}
+
+void TrackLiveMidiInput::render(const BlockInfo& /*block*/, juce::MidiBuffer& out) {
+    const auto* routing = feed_.routingFor(trackId_);
+    if (routing == nullptr) {
+        panicked_ = false;
+        return;
+    }
+
+    auto dropped = feed_.appendEvents(routing->audition, out, kMaxMidiBytesPerPort);
+    for (const auto source : routing->sources)
+        dropped += feed_.appendEvents(source, out, kMaxMidiBytesPerPort);
+
+    if (dropped > 0)
+        dropped_.fetch_add(static_cast<std::uint32_t>(dropped), std::memory_order_relaxed);
+
+    // Only a loss panics: a source arriving takes nothing away, and a panic for
+    // it would cut a chord still being held down.
+    panicked_ = started_ && routing->sourcesLost != lost_;
+    lost_ = routing->sourcesLost;
+    started_ = true;
 }
 
 }  // namespace magda::engine

--- a/magda/engine/io/LiveInput.cpp
+++ b/magda/engine/io/LiveInput.cpp
@@ -190,8 +190,8 @@ void TrackLiveMidiInput::render(const BlockInfo& /*block*/, juce::MidiBuffer& ou
     if (dropped > 0)
         dropped_.fetch_add(static_cast<std::uint32_t>(dropped), std::memory_order_relaxed);
 
-    // Only a loss raises all-notes-off. A source arriving removes nothing, and
-    // a panic would cut notes that are still held.
+    // Only a loss raises all-notes-off, which keeps held notes sounding when a
+    // source arrives.
     panicked_ = started_ && routing->sourcesLost != lost_;
     lost_ = routing->sourcesLost;
     started_ = true;

--- a/magda/engine/io/LiveInput.cpp
+++ b/magda/engine/io/LiveInput.cpp
@@ -26,8 +26,8 @@ void LiveInputFeed::prepare(int maxChannels, int maxBlockSize) {
 }
 
 void LiveInputFeed::beginCallback(const LiveInputBlock& input, int numSamples) {
-    // One acquisition for the whole callback (#2592). Guarded because the
-    // acquire and its release have to pair exactly.
+    // One acquisition for the whole callback (#2592). The guard keeps acquire
+    // and release paired.
     if (!holdsRouting_) {
         routing_ = published_.realtimeAcquire().get();
         holdsRouting_ = true;

--- a/magda/engine/io/LiveInput.hpp
+++ b/magda/engine/io/LiveInput.hpp
@@ -5,11 +5,14 @@
 
 #include <atomic>
 #include <cstdint>
+#include <farbot/RealtimeObject.hpp>
+#include <memory>
 #include <span>
 #include <vector>
 
 #include "exec/EngineDevice.hpp"
 #include "exec/RenderContext.hpp"
+#include "io/LiveRouting.hpp"
 
 /**
  * @file LiveInput.hpp
@@ -27,17 +30,6 @@
  */
 
 namespace magda::engine {
-
-/**
- * @brief Which MIDI input a stream came from.
- *
- * Opaque to the engine. The host assigns one per enabled device and resolves
- * a track's model string to it; kAnyLiveMidiSource is the "all" that string
- * also accepts, and merges every stream in the callback.
- */
-using LiveMidiSourceId = int;
-
-constexpr LiveMidiSourceId kAnyLiveMidiSource = -1;
 
 /** @brief One MIDI input's events for a callback, stamped from its first sample. */
 struct LiveMidiStream {
@@ -77,9 +69,17 @@ struct LiveInputBlock {
  *
  * The room for the copy is taken by @ref prepare, so the copy itself cannot
  * allocate. Written and read on the audio thread only, within one callback.
+ *
+ * The routing every live MIDI input reads travels with it (#2592): a callback
+ * pins one snapshot in @ref beginCallback and reads it throughout, so two
+ * tracks cannot render against two readings of the model.
  */
 class LiveInputFeed {
   public:
+    /// Gives back a routing snapshot still pinned, so a feed destroyed inside a
+    /// callback leaves nothing acquired.
+    ~LiveInputFeed();
+
     /**
      * @brief Room for what a callback may deliver. Off the audio thread.
      *
@@ -103,6 +103,16 @@ class LiveInputFeed {
     /// Audio thread, after the last block. A source reaching the feed outside
     /// a callback reads nothing rather than the previous callback's samples.
     void endCallback();
+
+    /// Which live MIDI each track hears, replaced whole (#2592). On the
+    /// publishing thread; the snapshot it replaces is destroyed there.
+    void publishRouting(std::shared_ptr<const LiveRouting> routing);
+
+    /// @p trackId's routing for this callback. Null before the first publish
+    /// and outside a callback, which is a track hearing nothing.
+    const TrackLiveMidi* routingFor(TrackId trackId) const {
+        return routing_ != nullptr ? routing_->find(trackId) : nullptr;
+    }
 
     /// The current block's input audio, empty when the host supplied none.
     juce::dsp::AudioBlock<const float> audio() const {
@@ -135,6 +145,16 @@ class LiveInputFeed {
     }
 
   private:
+    using PublishedRouting =
+        farbot::RealtimeObject<std::shared_ptr<const LiveRouting>,
+                               farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
+
+    PublishedRouting published_;
+
+    /// What beginCallback pinned, released by endCallback.
+    const LiveRouting* routing_ = nullptr;
+    bool holdsRouting_ = false;
+
     juce::AudioBuffer<float> scratch_;
     juce::dsp::AudioBlock<const float> audio_;
     std::span<const LiveMidiStream> midi_;
@@ -226,6 +246,42 @@ class LiveMidiInput final : public EngineMidiSource {
     const LiveInputFeed& feed_;
     LiveMidiSourceId source_ = kAnyLiveMidiSource;
     int latencySamples_ = 0;
+    std::atomic<std::uint32_t> dropped_{0};
+};
+
+/**
+ * @brief A track's live MIDI: its own audition, and the devices routed to it.
+ *
+ * Which ids those are is the published routing's (LiveRouting.hpp), read fresh
+ * each block, so a route change reaches an input built for an earlier plan.
+ */
+class TrackLiveMidiInput final : public EngineMidiSource {
+  public:
+    TrackLiveMidiInput(const LiveInputFeed& feed, TrackId trackId)
+        : feed_(feed), trackId_(trackId) {}
+
+    void render(const BlockInfo& /*block*/, juce::MidiBuffer& out) override;
+
+    bool raisedAllNotesOff() const override {
+        return panicked_;
+    }
+
+    /// Events dropped for want of room in the port's byte budget
+    /// (kMaxMidiBytesPerPort). Read from any thread.
+    std::uint32_t droppedEvents() const {
+        return dropped_.load(std::memory_order_relaxed);
+    }
+
+  private:
+    const LiveInputFeed& feed_;
+    TrackId trackId_ = INVALID_TRACK_ID;
+
+    /// The routing identity last rendered against. An input starts from what it
+    /// finds, so a recompile does not panic for a source it never heard.
+    std::uint32_t lost_ = 0;
+    bool started_ = false;
+
+    bool panicked_ = false;
     std::atomic<std::uint32_t> dropped_{0};
 };
 

--- a/magda/engine/io/LiveInput.hpp
+++ b/magda/engine/io/LiveInput.hpp
@@ -104,9 +104,10 @@ class LiveInputFeed {
     void endCallback();
 
     /**
-     * @brief Which live MIDI each track hears, replaced whole (#2592).
+     * @brief Replace the routing every track's MIDI input reads (#2592).
      *
-     * On the publishing thread; the snapshot it replaces is destroyed there.
+     * On the publishing thread, which is also where the old snapshot is
+     * destroyed.
      */
     void publishRouting(std::shared_ptr<const LiveRouting> routing);
 

--- a/magda/engine/io/LiveInput.hpp
+++ b/magda/engine/io/LiveInput.hpp
@@ -76,8 +76,11 @@ struct LiveInputBlock {
  */
 class LiveInputFeed {
   public:
-    /// Gives back a routing snapshot still pinned, so a feed destroyed inside a
-    /// callback leaves nothing acquired.
+    /**
+     * @brief Gives back a routing snapshot still pinned.
+     *
+     * So a feed destroyed inside a callback leaves nothing acquired.
+     */
     ~LiveInputFeed();
 
     /**
@@ -104,12 +107,19 @@ class LiveInputFeed {
     /// a callback reads nothing rather than the previous callback's samples.
     void endCallback();
 
-    /// Which live MIDI each track hears, replaced whole (#2592). On the
-    /// publishing thread; the snapshot it replaces is destroyed there.
+    /**
+     * @brief Which live MIDI each track hears, replaced whole (#2592).
+     *
+     * On the publishing thread; the snapshot it replaces is destroyed there.
+     */
     void publishRouting(std::shared_ptr<const LiveRouting> routing);
 
-    /// @p trackId's routing for this callback. Null before the first publish
-    /// and outside a callback, which is a track hearing nothing.
+    /**
+     * @brief @p trackId's routing for this callback.
+     *
+     * Null before the first publish and outside a callback, which is a track
+     * hearing nothing.
+     */
     const TrackLiveMidi* routingFor(TrackId trackId) const {
         return routing_ != nullptr ? routing_->find(trackId) : nullptr;
     }
@@ -262,12 +272,15 @@ class TrackLiveMidiInput final : public EngineMidiSource {
 
     void render(const BlockInfo& /*block*/, juce::MidiBuffer& out) override;
 
+    /** @brief Whether a source left the routing since the block before. */
     bool raisedAllNotesOff() const override {
         return panicked_;
     }
 
-    /// Events dropped for want of room in the port's byte budget
-    /// (kMaxMidiBytesPerPort). Read from any thread.
+    /**
+     * @brief Events dropped for want of room in the port's byte budget
+     *        (kMaxMidiBytesPerPort). Read from any thread.
+     */
     std::uint32_t droppedEvents() const {
         return dropped_.load(std::memory_order_relaxed);
     }

--- a/magda/engine/io/LiveInput.hpp
+++ b/magda/engine/io/LiveInput.hpp
@@ -70,17 +70,13 @@ struct LiveInputBlock {
  * The room for the copy is taken by @ref prepare, so the copy itself cannot
  * allocate. Written and read on the audio thread only, within one callback.
  *
- * The routing every live MIDI input reads travels with it (#2592): a callback
- * pins one snapshot in @ref beginCallback and reads it throughout, so two
- * tracks cannot render against two readings of the model.
+ * The routing every live MIDI input reads travels with it (#2592). A callback
+ * pins one snapshot in @ref beginCallback and reads it throughout, so every
+ * track renders against one reading of the model.
  */
 class LiveInputFeed {
   public:
-    /**
-     * @brief Gives back a routing snapshot still pinned.
-     *
-     * So a feed destroyed inside a callback leaves nothing acquired.
-     */
+    /** @brief Releases a routing snapshot this still holds pinned. */
     ~LiveInputFeed();
 
     /**
@@ -117,8 +113,7 @@ class LiveInputFeed {
     /**
      * @brief @p trackId's routing for this callback.
      *
-     * Null before the first publish and outside a callback, which is a track
-     * hearing nothing.
+     * Null until the first publish, and null outside a callback.
      */
     const TrackLiveMidi* routingFor(TrackId trackId) const {
         return routing_ != nullptr ? routing_->find(trackId) : nullptr;
@@ -262,8 +257,8 @@ class LiveMidiInput final : public EngineMidiSource {
 /**
  * @brief A track's live MIDI: its own audition, and the devices routed to it.
  *
- * Which ids those are is the published routing's (LiveRouting.hpp), read fresh
- * each block, so a route change reaches an input built for an earlier plan.
+ * The published routing supplies those ids (LiveRouting.hpp), read fresh each
+ * block, so a route change reaches an input built for an earlier plan.
  */
 class TrackLiveMidiInput final : public EngineMidiSource {
   public:
@@ -289,8 +284,8 @@ class TrackLiveMidiInput final : public EngineMidiSource {
     const LiveInputFeed& feed_;
     TrackId trackId_ = INVALID_TRACK_ID;
 
-    /// The routing identity last rendered against. An input starts from what it
-    /// finds, so a recompile does not panic for a source it never heard.
+    /// The routing identity last rendered against. A new input adopts whatever
+    /// it first reads, so it panics only for a source it has heard.
     std::uint32_t lost_ = 0;
     bool started_ = false;
 

--- a/magda/engine/io/LiveRouting.hpp
+++ b/magda/engine/io/LiveRouting.hpp
@@ -22,14 +22,14 @@ using LiveMidiSourceId = int;
 /// The "all" a route also accepts: every stream in the callback.
 constexpr LiveMidiSourceId kAnyLiveMidiSource = -1;
 
-/// No source. Never an id a stream arrives under, so it matches nothing.
+/// No source. Host ids start at 1, so this matches no stream.
 constexpr LiveMidiSourceId kNoLiveMidiSource = 0;
 
 /**
  * @brief What one track hears of the live MIDI.
  *
- * Monitor mode, arm, the device the route names and whether it is still
- * connected are all already answered.
+ * The host has already applied the track's monitor mode, its arm, the device
+ * its route names, and whether that device is connected.
  */
 struct TrackLiveMidi {
     TrackId trackId = INVALID_TRACK_ID;

--- a/magda/engine/io/LiveRouting.hpp
+++ b/magda/engine/io/LiveRouting.hpp
@@ -19,17 +19,17 @@ namespace magda::engine {
 /** @brief Which MIDI input a stream came from, assigned by the host. */
 using LiveMidiSourceId = int;
 
-/// The "all" a route also accepts: every stream in the callback.
+/// Matches every stream in the callback.
 constexpr LiveMidiSourceId kAnyLiveMidiSource = -1;
 
-/// No source. Host ids start at 1, so this matches no stream.
+/// Sentinel below the host's ids, which start at 1.
 constexpr LiveMidiSourceId kNoLiveMidiSource = 0;
 
 /**
  * @brief What one track hears of the live MIDI.
  *
- * The host has already applied the track's monitor mode, its arm, the device
- * its route names, and whether that device is connected.
+ * The host resolves it from the track's monitor mode, its arm, the device its
+ * route names, and that device's connection state.
  */
 struct TrackLiveMidi {
     TrackId trackId = INVALID_TRACK_ID;
@@ -39,9 +39,8 @@ struct TrackLiveMidi {
 
     std::vector<LiveMidiSourceId> sources;
 
-    /// Bumped when a source has left since the snapshot before. That source
-    /// sends no note-off for the notes it held, so the input raises
-    /// all-notes-off (#2418).
+    /// Counts the sources this track has lost. A change raises all-notes-off,
+    /// which releases the notes the departed source held (#2418).
     std::uint32_t sourcesLost = 0;
 
     bool operator==(const TrackLiveMidi&) const = default;
@@ -50,13 +49,13 @@ struct TrackLiveMidi {
 /**
  * @brief Every track's routing for one reading of the model.
  *
- * Immutable once published: a route change makes a new one.
+ * Immutable once published. A route change produces a new one.
  */
 struct LiveRouting {
     /// Sorted by trackId, which @ref find binary-searches.
     std::vector<TrackLiveMidi> tracks;
 
-    /** @brief @p trackId's entry, or null for a track the snapshot omits. */
+    /** @brief @p trackId's entry, or null. */
     const TrackLiveMidi* find(TrackId trackId) const {
         const auto byId = [](const TrackLiveMidi& entry, TrackId id) { return entry.trackId < id; };
         const auto found = std::lower_bound(tracks.begin(), tracks.end(), trackId, byId);

--- a/magda/engine/io/LiveRouting.hpp
+++ b/magda/engine/io/LiveRouting.hpp
@@ -16,38 +16,47 @@
 
 namespace magda::engine {
 
-/// Which MIDI input a stream came from, assigned by the host.
+/** @brief Which MIDI input a stream came from, assigned by the host. */
 using LiveMidiSourceId = int;
 
 /// The "all" a route also accepts: every stream in the callback.
 constexpr LiveMidiSourceId kAnyLiveMidiSource = -1;
 
-/// No source. Never an id a stream arrives under, so reading it is silence.
+/// No source. Never an id a stream arrives under, so it matches nothing.
 constexpr LiveMidiSourceId kNoLiveMidiSource = 0;
 
-/// What one track hears. Monitor mode, arm, the device the route names and
-/// whether it is still connected are all already answered.
+/**
+ * @brief What one track hears of the live MIDI.
+ *
+ * Monitor mode, arm, the device the route names and whether it is still
+ * connected are all already answered.
+ */
 struct TrackLiveMidi {
     TrackId trackId = INVALID_TRACK_ID;
 
-    /// Its own preview, heard whatever the input routing is.
+    /// The track's piano-roll preview, independent of the input routing.
     LiveMidiSourceId audition = kNoLiveMidiSource;
 
     std::vector<LiveMidiSourceId> sources;
 
-    /// Bumped when a source has left since the snapshot before: the note-off it
-    /// was holding is never coming, so the input panics for it (#2418).
+    /// Bumped when a source has left since the snapshot before. That source
+    /// sends no note-off for the notes it held, so the input raises
+    /// all-notes-off (#2418).
     std::uint32_t sourcesLost = 0;
 
     bool operator==(const TrackLiveMidi&) const = default;
 };
 
-/// Every track's routing for one reading of the model, immutable once
-/// published.
+/**
+ * @brief Every track's routing for one reading of the model.
+ *
+ * Immutable once published: a route change makes a new one.
+ */
 struct LiveRouting {
     /// Sorted by trackId, which @ref find binary-searches.
     std::vector<TrackLiveMidi> tracks;
 
+    /** @brief @p trackId's entry, or null for a track the snapshot omits. */
     const TrackLiveMidi* find(TrackId trackId) const {
         const auto byId = [](const TrackLiveMidi& entry, TrackId id) { return entry.trackId < id; };
         const auto found = std::lower_bound(tracks.begin(), tracks.end(), trackId, byId);

--- a/magda/engine/io/LiveRouting.hpp
+++ b/magda/engine/io/LiveRouting.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "core/TypeIds.hpp"
+
+/**
+ * @file LiveRouting.hpp
+ * @brief Which live MIDI a track hears, as one published snapshot (#2592).
+ *
+ * The engine knows opaque source ids. Turning a device name, a monitor mode and
+ * an arm into these is the host's (LiveMidiRouting.hpp).
+ */
+
+namespace magda::engine {
+
+/// Which MIDI input a stream came from, assigned by the host.
+using LiveMidiSourceId = int;
+
+/// The "all" a route also accepts: every stream in the callback.
+constexpr LiveMidiSourceId kAnyLiveMidiSource = -1;
+
+/// No source. Never an id a stream arrives under, so reading it is silence.
+constexpr LiveMidiSourceId kNoLiveMidiSource = 0;
+
+/// What one track hears. Monitor mode, arm, the device the route names and
+/// whether it is still connected are all already answered.
+struct TrackLiveMidi {
+    TrackId trackId = INVALID_TRACK_ID;
+
+    /// Its own preview, heard whatever the input routing is.
+    LiveMidiSourceId audition = kNoLiveMidiSource;
+
+    std::vector<LiveMidiSourceId> sources;
+
+    /// Bumped when a source has left since the snapshot before: the note-off it
+    /// was holding is never coming, so the input panics for it (#2418).
+    std::uint32_t sourcesLost = 0;
+
+    bool operator==(const TrackLiveMidi&) const = default;
+};
+
+/// Every track's routing for one reading of the model, immutable once
+/// published.
+struct LiveRouting {
+    /// Sorted by trackId, which @ref find binary-searches.
+    std::vector<TrackLiveMidi> tracks;
+
+    const TrackLiveMidi* find(TrackId trackId) const {
+        const auto byId = [](const TrackLiveMidi& entry, TrackId id) { return entry.trackId < id; };
+        const auto found = std::lower_bound(tracks.begin(), tracks.end(), trackId, byId);
+        return found != tracks.end() && found->trackId == trackId ? &*found : nullptr;
+    }
+};
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -378,6 +378,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES PlanEditHarness.cpp)
     list(APPEND TEST_SOURCES engine/test_plan_edit_properties.cpp)
     list(APPEND TEST_SOURCES engine/test_engine_session.cpp)
+    list(APPEND TEST_SOURCES engine/test_live_midi_routing.cpp)
     # The parameter lane (#2116). The lanes are fed by hand, so the precedence
     # rules are testable before anything writes them.
     list(APPEND TEST_SOURCES engine/test_param_lane.cpp)

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -20,6 +20,7 @@
 #include "magda/daw/engine/host/EngineProject.hpp"
 #include "magda/daw/engine/host/EngineRuntimeFactory.hpp"
 #include "magda/daw/engine/host/EngineTrace.hpp"
+#include "magda/daw/engine/host/LiveMidiRouting.hpp"
 #include "magda/daw/engine/host/LiveMidiSources.hpp"
 #include "plan/PlanCompiler.hpp"
 
@@ -117,9 +118,8 @@ class NoteCapture final : public engine::EngineDevice {
 class CapturingFactory final : public engine::RuntimeStateFactory {
   public:
     void attach(engine::ClipSnapshotFeed& clips, engine::ClipStreamFeed& streams,
-                engine::LaunchHandleFeed& handles, const engine::LiveInputFeed& liveInputs,
-                host::LiveMidiSources& sources) {
-        inner_.attach(clips, streams, handles, liveInputs, sources);
+                engine::LaunchHandleFeed& handles, const engine::LiveInputFeed& liveInputs) {
+        inner_.attach(clips, streams, handles, liveInputs);
     }
 
     void setModel(const std::vector<magda::TrackInfo>& tracks, const magda::TrackInfo& master) {
@@ -246,7 +246,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::engine::ClipVoicePool voices(files, reader, context);
         magda::engine::EngineSession session(factory, nullptr, &voices);
         factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed(),
-                       session.liveInputs(), sources);
+                       session.liveInputs());
 
         const auto plan = std::make_shared<const magda::engine::RenderPlan>(
             magda::engine::compileRenderPlan(tracks, *master));
@@ -318,7 +318,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         engine::ClipVoicePool voices(files, reader, context);
         engine::EngineSession session(factory, nullptr, &voices);
         factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed(),
-                       session.liveInputs(), sources);
+                       session.liveInputs());
 
         const auto plan =
             std::make_shared<const engine::RenderPlan>(engine::compileRenderPlan(tracks, *master));
@@ -561,7 +561,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::engine::ClipVoicePool voices(files, reader, context);
         magda::engine::EngineSession session(factory, nullptr, &voices);
         factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed(),
-                       session.liveInputs(), sources);
+                       session.liveInputs());
 
         const auto plan = std::make_shared<const magda::engine::RenderPlan>(
             magda::engine::compileRenderPlan(tracks, *master));
@@ -646,8 +646,13 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::engine::ClipVoicePool voices(files, reader, context);
         magda::engine::EngineSession session(factory, nullptr, &voices);
         factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed(),
-                       session.liveInputs(), sources);
+                       session.liveInputs());
         session.liveInputs().prepare(0, context.maxBlockSize);
+
+        // The audition id is the routing's answer too, so a session published
+        // to with none hears nothing (#2592).
+        host::LiveMidiRouting routing(sources);
+        session.liveInputs().publishRouting(routing.resolve(tracks));
 
         // Without the option the track is neither armed nor monitoring, so
         // there is no input op for the preview to reach (#2579).
@@ -686,9 +691,9 @@ class EngineHostPublishTest final : public juce::UnitTest {
 
         auto& trackManager = magda::TrackManager::getInstance();
         const auto routed = synthTrack("Monitoring", 1, magda::InputMonitorMode::In, "all");
-        const auto idle = synthTrack("Idle", 2, magda::InputMonitorMode::Off, {});
-        // Monitoring with no device named, which the fork routes to every
-        // input (MidiInputRouter::updateMidiInputRouting) and so must this.
+        const auto idle = synthTrack("Idle", 2, magda::InputMonitorMode::Off, "all");
+        // Monitoring with the input selector on None, which is an empty field.
+        // Read as "all", it played every keyboard attached.
         const auto unnamed = synthTrack("Unnamed", 3, magda::InputMonitorMode::In, {});
         // Auto and unarmed: routed on the fork, where TE's monitor mode still
         // decides what is heard, and audible here the moment it is in a route
@@ -723,8 +728,11 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::engine::ClipVoicePool voices(files, reader, context);
         magda::engine::EngineSession session(factory, nullptr, &voices);
         factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed(),
-                       session.liveInputs(), sources);
+                       session.liveInputs());
         session.liveInputs().prepare(0, context.maxBlockSize);
+
+        host::LiveMidiRouting routing(sources);
+        session.liveInputs().publishRouting(routing.resolve(tracks));
 
         const auto plan = std::make_shared<const magda::engine::RenderPlan>(
             magda::engine::compileRenderPlan(tracks, *master, {.auditionMidi = true}));
@@ -758,22 +766,23 @@ class EngineHostPublishTest final : public juce::UnitTest {
             return;
 
         expect(routedTap->read().loudest() > 0.0f, "The track routed to the device heard it");
-        expect(unnamedTap->read().loudest() > 0.0f,
-               "So did the track monitoring with no device named");
+        expect(unnamedTap->read().loudest() == 0.0f,
+               "The track whose input is None did not, though it is monitoring");
 
         // The audition op every track now carries reads its own source alone;
         // kAnyLiveMidiSource here would have merged the two.
-        expect(idleTap->read().loudest() == 0.0f, "The track monitoring nothing did not");
+        expect(idleTap->read().loudest() == 0.0f,
+               "Nor did the track routed to it but monitoring nothing");
 
         // What monitorsInput() gates and receivesLiveMidiInput() does not: Auto
         // without an arm is the UI's activity light, not an audible input.
         expect(autoTap->read().loudest() == 0.0f, "Nor did the unarmed Auto track");
 
-        // The store keeps the input it built, so a monitor switched on after
-        // the publish reaches it through the route table, not a new source.
+        // The store keeps the input it built, so a monitor switched on after the
+        // publish reaches it through a republished routing.
         if (auto* track = trackManager.getTrack(idle))
             track->inputMonitor = magda::InputMonitorMode::In;
-        factory.refreshMidiRoutes(trackManager.getTracks());
+        session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));
 
         session.process(context.maxBlockSize, output, {{}, streams});
         for (auto block = 0; block < 43; ++block)
@@ -784,7 +793,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
     }
 
     void testRouteRemovalPanicsTheInput() {
-        beginTest("A source leaving a route table panics the input that read it");
+        beginTest("A source leaving a track's routing panics the input that read it");
 
         auto& trackManager = magda::TrackManager::getInstance();
         const auto trackId = synthTrack("Monitoring", 1, magda::InputMonitorMode::In, "all");
@@ -807,11 +816,12 @@ class EngineHostPublishTest final : public juce::UnitTest {
         magda::engine::ClipVoicePool voices(files, reader, context);
         magda::engine::EngineSession session(factory, nullptr, &voices);
         factory.attach(session.clipFeed(), voices.feed(), session.launchHandleFeed(),
-                       session.liveInputs(), sources);
+                       session.liveInputs());
         session.liveInputs().prepare(0, context.maxBlockSize);
 
-        // The input the store would bind, over the same route table the
-        // publisher rewrites.
+        host::LiveMidiRouting routing(sources);
+        session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));
+
         auto input = factory.createMidiInput(trackId);
         expect(input != nullptr, "The track has a live MIDI input");
         if (input == nullptr)
@@ -820,33 +830,55 @@ class EngineHostPublishTest final : public juce::UnitTest {
         const magda::engine::BlockInfo block{};
         juce::MidiBuffer events;
 
-        input->render(block, events);
-        expect(!input->raisedAllNotesOff(), "A block with the route unchanged raises nothing");
+        // A callback around each render, since that is what pins the routing.
+        const auto renderBlock = [&] {
+            events.clear();
+            session.liveInputs().beginCallback({}, 0);
+            input->render(block, events);
+            session.liveInputs().endCallback();
+        };
+
+        renderBlock();
+        expect(!input->raisedAllNotesOff(), "A block with the routing unchanged raises nothing");
 
         // A note-off for whatever the device is holding will never arrive
-        // through a route that has gone, and the mutation publishes no
-        // topology, so nothing else can panic the instrument.
+        // through a route that has gone, and the change publishes no topology,
+        // so nothing else can panic the instrument.
         if (auto* track = trackManager.getTrack(trackId))
             track->inputMonitor = magda::InputMonitorMode::Off;
-        factory.refreshMidiRoutes(trackManager.getTracks());
+        session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));
 
-        events.clear();
-        input->render(block, events);
+        renderBlock();
         expect(input->raisedAllNotesOff(), "Losing the route panics the block that follows it");
 
-        events.clear();
-        input->render(block, events);
+        renderBlock();
         expect(!input->raisedAllNotesOff(), "Once, and not on every block after it");
 
         // Adding one back takes nothing away, so a chord held on another
         // source keeps sounding.
         if (auto* track = trackManager.getTrack(trackId))
             track->inputMonitor = magda::InputMonitorMode::In;
-        factory.refreshMidiRoutes(trackManager.getTracks());
+        session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));
+
+        renderBlock();
+        expect(!input->raisedAllNotesOff(), "A source arriving raises no panic");
+
+        // An input bound after the loss reads the routing it finds, not the
+        // history behind it.
+        if (auto* track = trackManager.getTrack(trackId))
+            track->inputMonitor = magda::InputMonitorMode::Off;
+        session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));
+
+        auto rebuilt = factory.createMidiInput(trackId);
+        expect(rebuilt != nullptr, "The input is rebuilt");
+        if (rebuilt == nullptr)
+            return;
 
         events.clear();
-        input->render(block, events);
-        expect(!input->raisedAllNotesOff(), "A source arriving raises no panic");
+        session.liveInputs().beginCallback({}, 0);
+        rebuilt->render(block, events);
+        session.liveInputs().endCallback();
+        expect(!rebuilt->raisedAllNotesOff(), "A freshly bound input raises no panic of its own");
     }
 
     void testDeviceConnectedAfterAPublishResolves() {

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -649,8 +649,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
                        session.liveInputs());
         session.liveInputs().prepare(0, context.maxBlockSize);
 
-        // The audition id is the routing's answer too, so a session published
-        // to with none hears nothing (#2592).
+        // The routing carries the audition id as well (#2592).
         host::LiveMidiRouting routing(sources);
         session.liveInputs().publishRouting(routing.resolve(tracks));
 
@@ -830,7 +829,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         const magda::engine::BlockInfo block{};
         juce::MidiBuffer events;
 
-        // A callback around each render, since that is what pins the routing.
+        // A callback around each render pins the routing.
         const auto renderBlock = [&] {
             events.clear();
             session.liveInputs().beginCallback({}, 0);
@@ -841,9 +840,6 @@ class EngineHostPublishTest final : public juce::UnitTest {
         renderBlock();
         expect(!input->raisedAllNotesOff(), "A block with the routing unchanged raises nothing");
 
-        // A note-off for whatever the device is holding will never arrive
-        // through a route that has gone, and the change publishes no topology,
-        // so nothing else can panic the instrument.
         if (auto* track = trackManager.getTrack(trackId))
             track->inputMonitor = magda::InputMonitorMode::Off;
         session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));
@@ -854,8 +850,6 @@ class EngineHostPublishTest final : public juce::UnitTest {
         renderBlock();
         expect(!input->raisedAllNotesOff(), "Once, and not on every block after it");
 
-        // Adding one back takes nothing away, so a chord held on another
-        // source keeps sounding.
         if (auto* track = trackManager.getTrack(trackId))
             track->inputMonitor = magda::InputMonitorMode::In;
         session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));
@@ -863,8 +857,7 @@ class EngineHostPublishTest final : public juce::UnitTest {
         renderBlock();
         expect(!input->raisedAllNotesOff(), "A source arriving raises no panic");
 
-        // An input bound after the loss reads the routing it finds, not the
-        // history behind it.
+        // A fresh input adopts the routing identity it first reads.
         if (auto* track = trackManager.getTrack(trackId))
             track->inputMonitor = magda::InputMonitorMode::Off;
         session.liveInputs().publishRouting(routing.resolve(trackManager.getTracks()));

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -33,7 +33,9 @@ using magda::engine::kMaxMidiBytesPerPort;
 using magda::engine::LiveAudioInput;
 using magda::engine::LiveInputFeed;
 using magda::engine::LiveMidiInput;
+using magda::engine::LiveMidiSourceId;
 using magda::engine::LiveMidiStream;
+using magda::engine::LiveRouting;
 using magda::engine::OpKey;
 using magda::engine::OpKind;
 using magda::engine::OpRole;
@@ -41,6 +43,7 @@ using magda::engine::PlanValues;
 using magda::engine::RenderContext;
 using magda::engine::RenderPlan;
 using magda::engine::RuntimeStateFactory;
+using magda::engine::TrackLiveMidiInput;
 
 namespace {
 
@@ -361,6 +364,107 @@ TEST_CASE("A live MIDI input keeps the offsets the host stamped", "[engine][live
         for (const auto metadata : out)
             CHECK(metadata.samplePosition == 1);
     }
+}
+
+TEST_CASE("A track's live MIDI is what the published routing says it is", "[engine][live-input]") {
+    juce::MidiBuffer keyboard;
+    keyboard.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    juce::MidiBuffer pads;
+    pads.addEvent(juce::MidiMessage::noteOn(1, 36, 1.0f), 8);
+    juce::MidiBuffer preview;
+    preview.addEvent(juce::MidiMessage::noteOn(1, 72, 1.0f), 16);
+
+    const std::array<LiveMidiStream, 3> streams{
+        LiveMidiStream{1, &keyboard}, LiveMidiStream{2, &pads}, LiveMidiStream{9, &preview}};
+
+    LiveInputFeed feed;
+    feed.prepare(2, kBlockSize);
+
+    const auto routing = [](std::vector<LiveMidiSourceId> sources, std::uint32_t lost = 0) {
+        auto snapshot = std::make_shared<LiveRouting>();
+        snapshot->tracks.push_back(
+            {.trackId = 1, .audition = 9, .sources = std::move(sources), .sourcesLost = lost});
+        return snapshot;
+    };
+
+    TrackLiveMidiInput input(feed, 1);
+    juce::MidiBuffer out;
+
+    const auto renderBlock = [&] {
+        out.clear();
+        feed.beginCallback({{}, streams}, kBlockSize);
+        feed.beginSegment(0, kBlockSize);
+        input.render(blockInfo(kBlockSize), out);
+        feed.endCallback();
+    };
+
+    SECTION("Its own preview reaches it whatever its input routing is") {
+        feed.publishRouting(routing({}));
+        renderBlock();
+
+        REQUIRE(out.getNumEvents() == 1);
+        for (const auto metadata : out)
+            CHECK(metadata.getMessage().getNoteNumber() == 72);
+    }
+
+    SECTION("Beside the devices routed to it") {
+        feed.publishRouting(routing({1, 2}));
+        renderBlock();
+
+        CHECK(out.getNumEvents() == 3);
+    }
+
+    SECTION("A session published to with no routing hears nothing") {
+        renderBlock();
+
+        CHECK(out.getNumEvents() == 0);
+    }
+
+    SECTION("A route change reaches an input the store built for an earlier plan") {
+        feed.publishRouting(routing({}));
+        renderBlock();
+        CHECK(out.getNumEvents() == 1);
+
+        feed.publishRouting(routing({1}));
+        renderBlock();
+        CHECK(out.getNumEvents() == 2);
+    }
+}
+
+TEST_CASE("A source a track has lost panics the block that follows it", "[engine][live-input]") {
+    LiveInputFeed feed;
+    feed.prepare(2, kBlockSize);
+
+    const auto routing = [](std::uint32_t lost) {
+        auto snapshot = std::make_shared<LiveRouting>();
+        snapshot->tracks.push_back(
+            {.trackId = 1, .audition = 9, .sources = {}, .sourcesLost = lost});
+        return snapshot;
+    };
+
+    TrackLiveMidiInput input(feed, 1);
+    juce::MidiBuffer out;
+
+    const auto renderBlock = [&] {
+        out.clear();
+        feed.beginCallback({}, kBlockSize);
+        feed.beginSegment(0, kBlockSize);
+        input.render(blockInfo(kBlockSize), out);
+        feed.endCallback();
+    };
+
+    // An input bound after a loss reads the identity it finds.
+    feed.publishRouting(routing(4));
+    renderBlock();
+    CHECK(!input.raisedAllNotesOff());
+
+    // A route change publishes no topology, so this is the only panic (#2418).
+    feed.publishRouting(routing(5));
+    renderBlock();
+    CHECK(input.raisedAllNotesOff());
+
+    renderBlock();
+    CHECK(!input.raisedAllNotesOff());
 }
 
 TEST_CASE("A live MIDI burst past the port's budget is dropped and counted",

--- a/tests/engine/test_live_midi_routing.cpp
+++ b/tests/engine/test_live_midi_routing.cpp
@@ -1,0 +1,181 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/engine/host/LiveMidiRouting.hpp"
+
+/// @file The model's input routing as one snapshot (#2592).
+
+namespace {
+
+namespace host = magda::daw::engine_host;
+
+const juce::MidiDeviceInfo kKeystep{"Keystep", "keystep-identifier"};
+const juce::MidiDeviceInfo kPush{"Push", "push-identifier"};
+
+magda::TrackInfo monitoring(magda::TrackId id, const juce::String& device) {
+    magda::TrackInfo track;
+    track.id = id;
+    track.inputMonitor = magda::InputMonitorMode::In;
+    track.midiInputDevice = device;
+    return track;
+}
+
+const magda::engine::TrackLiveMidi& entryFor(const magda::engine::LiveRouting& routing,
+                                             magda::TrackId id) {
+    const auto* found = routing.find(id);
+    REQUIRE(found != nullptr);
+    return *found;
+}
+
+}  // namespace
+
+TEST_CASE("A monitoring track's route resolves to the devices it names", "[live-routing]") {
+    host::LiveMidiSources sources;
+    sources.registerAvailableDevices({kKeystep, kPush});
+    host::LiveMidiRouting routing(sources);
+
+    SECTION("An all route is every connected device") {
+        const auto snapshot = routing.resolve({monitoring(1, "all")});
+        REQUIRE(snapshot != nullptr);
+
+        CHECK(entryFor(*snapshot, 1).sources.size() == 2);
+    }
+
+    SECTION("An empty field is None, not every input") {
+        const auto snapshot = routing.resolve({monitoring(1, "")});
+        REQUIRE(snapshot != nullptr);
+
+        // Read as "all", a track switched to None played every keyboard.
+        CHECK(entryFor(*snapshot, 1).sources.empty());
+    }
+
+    SECTION("A named device is that device alone") {
+        const auto snapshot = routing.resolve({monitoring(1, kKeystep.identifier)});
+        REQUIRE(snapshot != nullptr);
+
+        const auto& entry = entryFor(*snapshot, 1);
+        REQUIRE(entry.sources.size() == 1);
+        CHECK(entry.sources.front() == sources.sourceFor(kKeystep.identifier));
+    }
+
+    SECTION("A track route names no device: the plan carries it as an edge") {
+        const auto snapshot = routing.resolve({monitoring(1, "track:7")});
+        REQUIRE(snapshot != nullptr);
+
+        CHECK(entryFor(*snapshot, 1).sources.empty());
+    }
+
+    SECTION("A track that is not monitoring hears none of them") {
+        auto track = monitoring(1, "all");
+        track.inputMonitor = magda::InputMonitorMode::Off;
+
+        const auto snapshot = routing.resolve({track});
+        REQUIRE(snapshot != nullptr);
+
+        CHECK(entryFor(*snapshot, 1).sources.empty());
+        CHECK(entryFor(*snapshot, 1).audition == sources.auditionSourceFor(1));
+    }
+
+    SECTION("An unarmed Auto track is the UI's activity light, not an audible input") {
+        auto track = monitoring(1, "all");
+        track.inputMonitor = magda::InputMonitorMode::Auto;
+
+        const auto snapshot = routing.resolve({track});
+        REQUIRE(snapshot != nullptr);
+
+        CHECK(track.receivesLiveMidiInput());
+        CHECK(entryFor(*snapshot, 1).sources.empty());
+    }
+}
+
+TEST_CASE("Every track's audition is its own", "[live-routing]") {
+    host::LiveMidiSources sources;
+    host::LiveMidiRouting routing(sources);
+
+    const auto snapshot = routing.resolve({monitoring(1, ""), monitoring(2, "")});
+    REQUIRE(snapshot != nullptr);
+
+    CHECK(entryFor(*snapshot, 1).audition != entryFor(*snapshot, 2).audition);
+}
+
+TEST_CASE("A snapshot is addressed by track id whatever order the model is in", "[live-routing]") {
+    host::LiveMidiSources sources;
+    host::LiveMidiRouting routing(sources);
+
+    // Arrangement order, which find()'s binary search would read as missing.
+    const auto snapshot =
+        routing.resolve({monitoring(9, ""), monitoring(3, ""), monitoring(6, "")});
+    REQUIRE(snapshot != nullptr);
+
+    CHECK(snapshot->find(3) != nullptr);
+    CHECK(snapshot->find(6) != nullptr);
+    CHECK(snapshot->find(9) != nullptr);
+    CHECK(snapshot->find(4) == nullptr);
+}
+
+TEST_CASE("A routing that has not moved is not republished", "[live-routing]") {
+    host::LiveMidiSources sources;
+    sources.registerAvailableDevices({kKeystep});
+    host::LiveMidiRouting routing(sources);
+
+    const std::vector<magda::TrackInfo> tracks{monitoring(1, "all")};
+
+    REQUIRE(routing.resolve(tracks) != nullptr);
+
+    CHECK(routing.resolve(tracks) == nullptr);
+
+    auto muted = tracks;
+    muted.front().inputMonitor = magda::InputMonitorMode::Off;
+    CHECK(routing.resolve(muted) != nullptr);
+}
+
+TEST_CASE("A source a track loses is counted, so the input can panic for it", "[live-routing]") {
+    host::LiveMidiSources sources;
+    sources.registerAvailableDevices({kKeystep});
+    host::LiveMidiRouting routing(sources);
+
+    const std::vector<magda::TrackInfo> tracks{monitoring(1, "all")};
+
+    const auto first = routing.resolve(tracks);
+    REQUIRE(first != nullptr);
+    const auto before = entryFor(*first, 1).sourcesLost;
+
+    SECTION("A device unplugged leaves every all route") {
+        sources.registerAvailableDevices({});
+
+        const auto after = routing.resolve(tracks);
+        REQUIRE(after != nullptr);
+
+        CHECK(entryFor(*after, 1).sources.empty());
+        CHECK(entryFor(*after, 1).sourcesLost != before);
+    }
+
+    SECTION("Monitoring switched off takes the route with it") {
+        auto idle = tracks;
+        idle.front().inputMonitor = magda::InputMonitorMode::Off;
+
+        const auto after = routing.resolve(idle);
+        REQUIRE(after != nullptr);
+
+        CHECK(entryFor(*after, 1).sourcesLost != before);
+    }
+
+    SECTION("A device arriving takes nothing away, so a held chord keeps sounding") {
+        sources.registerAvailableDevices({kKeystep, kPush});
+
+        const auto after = routing.resolve(tracks);
+        REQUIRE(after != nullptr);
+
+        CHECK(entryFor(*after, 1).sources.size() == 2);
+        CHECK(entryFor(*after, 1).sourcesLost == before);
+    }
+
+    SECTION("A new project starts over: track 1 there never heard this one's device") {
+        routing.reset();
+        sources.registerAvailableDevices({});
+
+        const auto after = routing.resolve(tracks);
+        REQUIRE(after != nullptr);
+
+        CHECK(entryFor(*after, 1).sourcesLost == 0);
+    }
+}

--- a/tests/midi/test_midi_bridge_note_events_juce.cpp
+++ b/tests/midi/test_midi_bridge_note_events_juce.cpp
@@ -51,8 +51,7 @@ class MidiBridgeNoteEventsTest final : public juce::UnitTest {
         };
     }
 
-    /// A sink that records nothing: installing one is what tells MidiBridge the
-    /// native engine is the one rendering.
+    /// Installing a sink tells MidiBridge the native engine is rendering.
     struct NullSink final : magda::LiveMidiSink {
         void pushMidi(const juce::String&, const juce::MidiMessage&) override {}
         void audition(magda::TrackId, const juce::MidiMessage&) override {}
@@ -64,8 +63,6 @@ class MidiBridgeNoteEventsTest final : public juce::UnitTest {
         auto& engine = *magda::test::getSharedEngine().getEngine();
         auto& devices = engine.getDeviceManager();
 
-        // The fork's own merge of every input, which is what the selector
-        // offered and what nothing feeds here.
         const juce::String merged("All MIDI Ins");
         const auto created = devices.createVirtualMidiDevice(merged);
         expect(created.wasOk(), "The virtual device is created");

--- a/tests/midi/test_midi_bridge_note_events_juce.cpp
+++ b/tests/midi/test_midi_bridge_note_events_juce.cpp
@@ -1,10 +1,6 @@
 #include <juce_core/juce_core.h>
 #include <tracktion_engine/tracktion_engine.h>
 
-#include <algorithm>
-#include <ranges>
-#include <vector>
-
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/MidiBridge.hpp"
 #include "magda/daw/core/MidiTypes.hpp"
@@ -25,7 +21,6 @@ class MidiBridgeNoteEventsTest final : public juce::UnitTest {
         testSynthesizedNoteSilentWhenNotMonitored();
         testSynthesizedNoteSilentForUnroutedDevice();
         testAllRoutingMatchesSynthesizedNote();
-        testForkVirtualInputsAreNotOfferedOnTheNativeEngine();
     }
 
   private:
@@ -49,65 +44,6 @@ class MidiBridgeNoteEventsTest final : public juce::UnitTest {
             else
                 ++capture.noteOffCount;
         };
-    }
-
-    /// Installing a sink tells MidiBridge the native engine is rendering.
-    struct NullSink final : magda::LiveMidiSink {
-        void pushMidi(const juce::String&, const juce::MidiMessage&) override {}
-        void audition(magda::TrackId, const juce::MidiMessage&) override {}
-    };
-
-    void testForkVirtualInputsAreNotOfferedOnTheNativeEngine() {
-        beginTest("The fork's virtual MIDI inputs are not offered under the native engine");
-
-        auto& engine = *magda::test::getSharedEngine().getEngine();
-        auto& devices = engine.getDeviceManager();
-
-        const juce::String merged("All MIDI Ins");
-        const auto created = devices.createVirtualMidiDevice(merged);
-        expect(created.wasOk(), "The virtual device is created");
-        if (!created.wasOk())
-            return;
-
-        // By value, so the vector has to outlive the search.
-        const auto midiIns = devices.getMidiInDevices();
-        const auto byName = [&merged](const auto& dev) { return dev->getName() == merged; };
-        const auto found = std::ranges::find_if(midiIns, byName);
-
-        auto virtualDevice = found != midiIns.end() ? *found : nullptr;
-        expect(virtualDevice != nullptr, "And enumerated by the engine");
-        if (virtualDevice == nullptr)
-            return;
-        virtualDevice->setEnabled(true);
-
-        magda::MidiBridge bridge(engine);
-        bridge.setQwertyEnabled(true);
-
-        const auto names = [](const std::vector<magda::MidiDeviceInfo>& list) {
-            return list | std::views::transform([](const auto& d) { return d.name; }) |
-                   std::ranges::to<std::vector>();
-        };
-
-        expect(std::ranges::contains(names(bridge.getAvailableMidiInputs()), merged),
-               "The fork offers it while the fork renders");
-
-        NullSink sink;
-        bridge.setLiveSink(&sink);
-
-        const auto listed = bridge.getAvailableMidiInputs();
-        bridge.setLiveSink(nullptr);
-
-        expect(!std::ranges::contains(names(listed), merged),
-               "The native engine does not, since a route to it is silence");
-
-        const auto isKeyboard = [](const magda::MidiDeviceInfo& device) {
-            return device.id == magda::qwertyMidiDeviceId();
-        };
-        expect(std::ranges::any_of(listed, isKeyboard),
-               "The keyboard is still there, under the id it pushes under");
-
-        if (auto* toDelete = dynamic_cast<te::VirtualMidiInputDevice*>(virtualDevice.get()))
-            devices.deleteVirtualMidiDevice(*toDelete);
     }
 
     void testSynthesizedNoteFiresForMonitoredTrack() {

--- a/tests/midi/test_midi_bridge_note_events_juce.cpp
+++ b/tests/midi/test_midi_bridge_note_events_juce.cpp
@@ -1,6 +1,10 @@
 #include <juce_core/juce_core.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <algorithm>
+#include <ranges>
+#include <vector>
+
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/MidiBridge.hpp"
 #include "magda/daw/core/MidiTypes.hpp"
@@ -21,6 +25,7 @@ class MidiBridgeNoteEventsTest final : public juce::UnitTest {
         testSynthesizedNoteSilentWhenNotMonitored();
         testSynthesizedNoteSilentForUnroutedDevice();
         testAllRoutingMatchesSynthesizedNote();
+        testForkVirtualInputsAreNotOfferedOnTheNativeEngine();
     }
 
   private:
@@ -44,6 +49,68 @@ class MidiBridgeNoteEventsTest final : public juce::UnitTest {
             else
                 ++capture.noteOffCount;
         };
+    }
+
+    /// A sink that records nothing: installing one is what tells MidiBridge the
+    /// native engine is the one rendering.
+    struct NullSink final : magda::LiveMidiSink {
+        void pushMidi(const juce::String&, const juce::MidiMessage&) override {}
+        void audition(magda::TrackId, const juce::MidiMessage&) override {}
+    };
+
+    void testForkVirtualInputsAreNotOfferedOnTheNativeEngine() {
+        beginTest("The fork's virtual MIDI inputs are not offered under the native engine");
+
+        auto& engine = *magda::test::getSharedEngine().getEngine();
+        auto& devices = engine.getDeviceManager();
+
+        // The fork's own merge of every input, which is what the selector
+        // offered and what nothing feeds here.
+        const juce::String merged("All MIDI Ins");
+        const auto created = devices.createVirtualMidiDevice(merged);
+        expect(created.wasOk(), "The virtual device is created");
+        if (!created.wasOk())
+            return;
+
+        // By value, so the vector has to outlive the search.
+        const auto midiIns = devices.getMidiInDevices();
+        const auto byName = [&merged](const auto& dev) { return dev->getName() == merged; };
+        const auto found = std::ranges::find_if(midiIns, byName);
+
+        auto virtualDevice = found != midiIns.end() ? *found : nullptr;
+        expect(virtualDevice != nullptr, "And enumerated by the engine");
+        if (virtualDevice == nullptr)
+            return;
+        virtualDevice->setEnabled(true);
+
+        magda::MidiBridge bridge(engine);
+        bridge.setQwertyEnabled(true);
+
+        const auto names = [](const std::vector<magda::MidiDeviceInfo>& list) {
+            return list | std::views::transform([](const auto& d) { return d.name; }) |
+                   std::ranges::to<std::vector>();
+        };
+
+        expect(std::ranges::contains(names(bridge.getAvailableMidiInputs()), merged),
+               "The fork offers it while the fork renders");
+
+        NullSink sink;
+        bridge.setLiveSink(&sink);
+
+        const auto listed = bridge.getAvailableMidiInputs();
+        bridge.setLiveSink(nullptr);
+
+        expect(!std::ranges::contains(names(listed), merged),
+               "The native engine does not, since a route to it is silence");
+
+        const auto isKeyboard = [](const magda::MidiDeviceInfo& device) {
+            return device.id == magda::qwertyMidiDeviceId();
+        };
+        expect(std::ranges::any_of(listed, isKeyboard),
+               "The keyboard is still there, under the id it pushes under");
+
+        if (auto* toDelete = dynamic_cast<te::VirtualMidiInputDevice*>(virtualDevice.get()))
+            devices.deleteVirtualMidiDevice(*toDelete);
     }
 
     void testSynthesizedNoteFiresForMonitoredTrack() {


### PR DESCRIPTION
First slice of #2592, and two routing bugs found smoke-testing it.

## One snapshot instead of a mutated table

Routing was answered in two places that published independently: the compiler decided whether a
track's input op existed, and a table the publisher rewrote per track decided what that op read.
Both gated on `monitorsInput()`, read at different moments.

`LiveRouting` is the single answer -- one entry per track carrying its audition, its routed device
sources, and a count of the sources it has lost. `LiveInputFeed` publishes it the way the clip feed
publishes a snapshot: swapped whole, pinned once per callback, so two tracks cannot render against
two readings of the model.

`LiveMidiRouting` on the host side is the one place eligibility is decided. It answers null for a
reading that has not moved, since a fader drag publishes values, and this, on every frame.

`TrackLiveMidiInput` turns a change in `sourcesLost` into the all-notes-off an instrument needs for
a source that will never send its note-offs. An input bound after a loss starts from the identity
it finds, so a recompile does not panic a track that never heard the source that went.

`EngineRuntimeFactory` loses `MidiRouteTable`, the per-track route map and the source registry.

## Two routes that did not work

**None played everything.** An empty `midiInputDevice` is what the selector writes for None. The
resolver read it as "all", so a track switched to None went on playing every keyboard attached.

**"All MIDI Ins" played nothing.** It is the fork's own virtual merge of every input, which the
fork skips by name wherever it routes, and nothing feeds it when the native engine renders. The
device list no longer offers any fork virtual input while a live sink is installed.

## Tests

Five cases over the resolver and two over the reader, plus the JUCE panic case rewritten against
the snapshot and a MidiBridge case that creates a real virtual device. Mutation-checked: never
counting a loss, panicking on the first block, and listing the fork's virtuals each fail a case.

`make test` (4007 passed, 13 skipped) and `make test-juce` green. `make lint-changed` reports
nothing on the new files.

## Left on #2592

A monitor switch is still a topology change for an external audio input, both `track:` edges and a
MIDI device on a chain that consumes no MIDI. Filed as #2612.

Closes nothing; refs #2592.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF
