### PR TITLE
Pin that a detected range does not re-scale the plugin's own number

### DIFF
--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -2105,6 +2105,44 @@ TEST_CASE("The answer does not depend on a provider no project carries",
     CHECK(model.parameters[1].currentValue == Catch::Approx(0.7f));
 }
 
+TEST_CASE("A detected display range does not re-scale what the table already holds",
+          "[engine][external][2601]") {
+    // The two ends of one trip: ParamTableCompiler fills a slot through
+    // modelToNormalizedValue, and writeParameters reads it back out. They agree
+    // because the device the renderer holds carries describeHostParameters'
+    // records, which are normalised whatever the model was configured with, so
+    // the conversion out is the identity. Pinned here because the failure is
+    // silent and total -- a 20 Hz-20 kHz parameter would take the bottom of its
+    // range for every position the user ever set.
+    // Seated somewhere else, so the value below is one the plugin does not
+    // already hold and the check cannot pass on the seat alone.
+    auto model = externalDeviceWithDetectedRange(0.2f);
+
+    auto plugin = std::make_unique<StubPlugin>(2, 2, 0);
+    auto* raw = plugin.get();
+
+    auto result = adapter::adaptExternalPluginInstance(std::move(plugin), model);
+    REQUIRE(result.device != nullptr);
+    REQUIRE(raw->tone->getValue() == Catch::Approx(0.2f));
+
+    const auto context = contextFor();
+    result.device->prepare(context);
+
+    // Dry, wet, Gain, Tone -- the slots in the order the table allocates them.
+    ParamArena arena({0.0f, 1.0f, 0.3f, 0.7f});
+    Block block(context, 2);
+    block.fill(0.0f);
+
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    result.device->process(deviceBlock);
+
+    CHECK(raw->tone->getValue() == Catch::Approx(0.7f));
+
+    // The parameter with no configured range comes through either way, which is
+    // why this went unnoticed: the conversion is the identity for all of them.
+    CHECK(raw->gain->getValue() == Catch::Approx(0.3f));
+}
+
 TEST_CASE("A parameter's id is the one its format declares", "[engine][external][2601]") {
     // What a saved parameter config is matched by, so a plugin that renumbers
     // its parameters in an update does not hand every override to whatever


### PR DESCRIPTION
The last of #2601, and the end of it.

The issue asked for `EngineExternalDevice::writeParameters` to go through
`modelToNormalizedValue()` rather than `realToNormalized()`, the way
`ParamTableCompiler::allocateDevice` does at the other end of the same trip. I
went to fix that and it turned out not to need fixing — but the reason was
nowhere in the code, and nothing tested it.

## Why it does not need fixing

`createEngineExternalDevice` hands the renderer a `resolvedDevice` whose
`parameters` come from `describeHostParameters()`, and those are normalised
records — `normalisedParameter()`, no unit, 0..1 — whatever the model was
configured with. The detected range lives on the *model*, applied by
`EngineHost::applyLoadedDevice` (#2606), and the model is what the compiler
reads. So the compiler converts a configured value down to the plugin's own
number on the way in, and the conversion on the way out is the identity on a
bare record. The two ends agree.

They agree by holding different `ParameterInfo`s, which is not obvious and is
exactly the kind of thing that stops being true quietly — if
`describeHostParameters` ever carried the config forward, `writeParameters`
would start squashing every configured parameter with nothing to catch it.

## The test

The existing `[2601]` cases stop at the seat and the read back
(`applySavedPluginState` / `applyRestoredParameters`). None drove a render
block, so the compiler-to-plugin leg was uncovered.

This one seats the plugin at 0.2, drives a block with 0.7 in the table against
a 20 Hz–20 kHz logarithmic model range, and checks the plugin receives 0.7. The
seat value differs from the table value on purpose: with both at 0.7 the case
passes without `writeParameters` running at all, which is how I first wrote it
and why it proved nothing.

The failure it guards against is silent and total — every configured parameter
pinned to the bottom of its range.

## #2601, closed

| Item | Where |
| --- | --- |
| One meaning for a hosted parameter's stored value | #2606 |
| `applyRestoredParameters` stops converting through the display range | #2606 |
| `allocateDevice` through `modelToNormalizedValue` | already so |
| `writeParameters` through `modelToNormalizedValue` | not needed — this PR |
| Overlay applied where the array is built | #2606 native, #2608 fork |
| Overlay addressed by the parameter's own id | #2607 |
| Draw-time appliers removed | #2611 |
| Detection off the device rather than an Edit | #2609 |
| MCP reports the unit and the real range | `remote_api_projection.cpp:398` |

The `displayText` gate stayed deliberately; #2606 commented on the issue
explaining why dropping it would have moved internal devices too.

`make test` (4012 passed, 13 skipped) and `make test-juce` green.

Closes #2601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN
