### PR TITLE
Revert the parameter-config rebuild handling (#2608, #2611)

### DIFF
--- a/magda/daw/audio/processors/base/DeviceProcessor.cpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.cpp
@@ -2,8 +2,6 @@
 
 #include <utility>
 
-#include "core/PluginParameterConfigStore.hpp"
-
 namespace magda {
 
 DeviceProcessor::DeviceProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
@@ -99,35 +97,30 @@ bool DeviceProcessor::isDeltaSolo() const {
 void DeviceProcessor::populateParameters(DeviceInfo& info, ValueSource source) const {
     if (source == ValueSource::Engine || info.format != PluginFormat::Internal) {
         populateParametersFromEngine(info);
-    } else {
-        const auto model = std::move(info.parameters);
-        populateParametersFromEngine(info);
-
-        auto sameParameter = [](const ParameterInfo& kept, const ParameterInfo& fresh) {
-            if (kept.paramIndex != fresh.paramIndex)
-                return false;
-            // A minimal hydrated entry (value and saved id only, named after
-            // that id) has no metadata to compare; its frozen index is all it
-            // has.
-            if (kept.name == kept.stableId)
-                return true;
-            if (kept.stableId.isNotEmpty() && fresh.stableId.isNotEmpty())
-                return kept.stableId == fresh.stableId;
-            return kept.name == fresh.name;
-        };
-
-        for (auto& fresh : info.parameters)
-            for (const auto& kept : model)
-                if (sameParameter(kept, fresh)) {
-                    fresh.currentValue = kept.currentValue;
-                    break;
-                }
+        return;
     }
 
-    // What the plugin's parameters were detected to mean, over the bare records
-    // the engine reports. The array is rebuilt on every load, so this has to be
-    // here; EngineHost::applyLoadedDevice is the native engine's match (#2601).
-    PluginParameterConfigStore::applyToDevice(info);
+    const auto model = std::move(info.parameters);
+    populateParametersFromEngine(info);
+
+    auto sameParameter = [](const ParameterInfo& kept, const ParameterInfo& fresh) {
+        if (kept.paramIndex != fresh.paramIndex)
+            return false;
+        // A minimal hydrated entry (value and saved id only, named after that
+        // id) has no metadata to compare; its frozen index is all it has.
+        if (kept.name == kept.stableId)
+            return true;
+        if (kept.stableId.isNotEmpty() && fresh.stableId.isNotEmpty())
+            return kept.stableId == fresh.stableId;
+        return kept.name == fresh.name;
+    };
+
+    for (auto& fresh : info.parameters)
+        for (const auto& kept : model)
+            if (sameParameter(kept, fresh)) {
+                fresh.currentValue = kept.currentValue;
+                break;
+            }
 }
 
 void DeviceProcessor::syncFromDeviceInfo(const DeviceInfo& info) {

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -4,7 +4,6 @@
 #include <unordered_map>
 
 #include "AppPaths.hpp"
-#include "ChainWalk.hpp"
 #include "DeviceInfo.hpp"
 #include "RackInfo.hpp"
 #include "TrackManager.hpp"
@@ -27,15 +26,14 @@ bool applyConfigToMatchingDevice(const juce::String& uniqueId, DeviceInfo& devic
 bool refreshElementParameterConfig(const juce::String& uniqueId,
                                    std::vector<ChainElement>& elements) {
     bool changed = false;
-    // Pads entered: a device on a Drum Grid pad is configured from the same
-    // dialog as any other, and the walk is shared so that adding a container to
-    // the model does not leave this one behind (#2204).
-    chain_walk::forEachDevice(elements, {}, chain_walk::Pads::Enter,
-                              [&changed, &uniqueId](DeviceInfo& device, const ChainNodePath&) {
-                                  changed =
-                                      applyConfigToMatchingDevice(uniqueId, device) || changed;
-                                  return true;
-                              });
+    for (auto& element : elements) {
+        if (isDevice(element)) {
+            changed = applyConfigToMatchingDevice(uniqueId, getDevice(element)) || changed;
+        } else if (isRack(element)) {
+            for (auto& chain : getRack(element).chains)
+                changed = refreshElementParameterConfig(uniqueId, chain.elements) || changed;
+        }
+    }
     return changed;
 }
 

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -535,6 +535,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     }
 
     updateParameterPagination();
+    applySavedParameterConfig();
+    updateParameterPagination();
 
     // Load parameters for current page
     updateParameterSlots();
@@ -762,6 +764,10 @@ void DeviceSlotComponent::setNodePath(const magda::ChainNodePath& path) {
     customUI_.setDevicePath(path);
     updateDeviceSlotInlineUi(device_, compiledPanel_.get(), customUI_);
 
+    if (applySavedParameterConfig()) {
+        updateParameterPagination();
+        updateParameterSlots();
+    }
     refreshDeviceTraits(device_);
 
     // Hide power / preset / delete for post-FX analysis devices (the getters
@@ -941,6 +947,8 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     // Update multi-out button visibility
     if (multiOutButton_)
         multiOutButton_->setVisible(device_.multiOut.isMultiOut);
+
+    applySavedParameterConfig();
 
     // Update pagination based on visible parameter count, then clamp current page
     updateParameterPagination();
@@ -1519,6 +1527,10 @@ void DeviceSlotComponent::refreshFaustMeterPanel() {
 
 void DeviceSlotComponent::updateParameterValues() {
     updateDeviceSlotParameterValues(device_, *paramGrid_);
+}
+
+bool DeviceSlotComponent::applySavedParameterConfig() {
+    return applyDeviceSlotSavedParameterConfig(device_, nodePath_, paramGrid_.get());
 }
 
 void DeviceSlotComponent::updateParameterPagination() {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -320,6 +320,7 @@ class DeviceSlotComponent : public NodeComponent,
 
     void updateParameterSlots();   // Reload parameter data for current page
     void updateParameterValues();  // Update only parameter values (for polling)
+    bool applySavedParameterConfig();
     void updateParameterPagination();
     void goToPrevPage();
     void goToNextPage();

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "compiled/CompiledPluginPresentation.hpp"
+#include "core/PluginParameterConfigStore.hpp"
 #include "core/TrackManager.hpp"
 #include "params/ParamHostComponent.hpp"
 #include "slot/DeviceParameterChangeHandler.hpp"
@@ -65,6 +66,42 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
 void updateDeviceSlotParameterValues(const magda::DeviceInfo& device,
                                      ParamHostComponent& paramGrid) {
     paramGrid.updateParameterValues(device, paramGrid.getCurrentPage());
+}
+
+bool applyDeviceSlotSavedParameterConfig(magda::DeviceInfo& device,
+                                         const magda::ChainNodePath& nodePath,
+                                         ParamHostComponent* paramGrid) {
+    if (paramGrid == nullptr || device.uniqueId.isEmpty() || device.parameters.empty())
+        return false;
+
+    magda::DeviceInfo tempDevice = device;
+    if (!magda::PluginParameterConfigStore::applyToDevice(tempDevice.uniqueId, tempDevice))
+        return false;
+
+    if (!tempDevice.visibleParameters.empty()) {
+        if (nodePath.isValid())
+            magda::TrackManager::getInstance().setDeviceVisibleParameters(
+                nodePath, tempDevice.visibleParameters);
+        device.visibleParameters = tempDevice.visibleParameters;
+    }
+
+    if (nodePath.isValid())
+        magda::TrackManager::getInstance().setDeviceMiniMixerParameters(
+            nodePath, tempDevice.miniMixerParameters);
+    device.miniMixerParameters = tempDevice.miniMixerParameters;
+
+    if (nodePath.isValid())
+        magda::TrackManager::getInstance().setDeviceAiSoundDesignerParameters(
+            nodePath, tempDevice.aiSoundDesignerParameters);
+    device.aiSoundDesignerParameters = tempDevice.aiSoundDesignerParameters;
+
+    if (nodePath.isValid())
+        magda::TrackManager::getInstance().setDeviceAiSoundDesignerPrompt(
+            nodePath, tempDevice.aiSoundDesignerPrompt);
+    device.aiSoundDesignerPrompt = tempDevice.aiSoundDesignerPrompt;
+
+    device.parameters = tempDevice.parameters;
+    return true;
 }
 
 void updateDeviceSlotParameterPagination(const magda::DeviceInfo& device,

--- a/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotParameterPaging.hpp
@@ -26,6 +26,10 @@ void updateDeviceSlotParameterSlots(magda::DeviceInfo& device, const magda::Chai
 void updateDeviceSlotParameterValues(const magda::DeviceInfo& device,
                                      ParamHostComponent& paramGrid);
 
+bool applyDeviceSlotSavedParameterConfig(magda::DeviceInfo& device,
+                                         const magda::ChainNodePath& nodePath,
+                                         ParamHostComponent* paramGrid);
+
 void updateDeviceSlotParameterPagination(const magda::DeviceInfo& device,
                                          ParamHostComponent* paramGrid);
 

--- a/magda/daw/ui/components/mixer/MiniChainRow.cpp
+++ b/magda/daw/ui/components/mixer/MiniChainRow.cpp
@@ -10,6 +10,7 @@
 #include "../common/SvgButton.hpp"
 #include "../common/TextSlider.hpp"
 #include "core/ChainNodePath.hpp"
+#include "core/PluginParameterConfigStore.hpp"
 #include "core/TrackManager.hpp"
 #include "core/UndoManager.hpp"
 
@@ -136,6 +137,8 @@ void MiniChainRow::resolveParams() {
     auto* devInfo = TrackManager::getInstance().getDeviceInChainByPath(devicePath_);
     if (devInfo == nullptr)
         return;
+    if (devInfo->uniqueId.isNotEmpty())
+        magda::PluginParameterConfigStore::applyToDevice(devInfo->uniqueId, *devInfo);
     const auto path = devicePath_;
 
     auto addParamSlider = [&](const ParameterInfo& paramInfo) {

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -3,7 +3,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 
-#include "magda/daw/audio/processors/base/DeviceProcessor.hpp"
 #include "magda/daw/core/AppPaths.hpp"
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/PluginParameterConfigStore.hpp"
@@ -73,25 +72,6 @@ magda::DeviceInfo makeExternalDevice() {
     device.parameters[2].stableId = "mode";
     return device;
 }
-
-/// A processor whose engine read is a fixed list, standing in for whatever the
-/// fork rebuilds a device's parameter array from.
-class StubProcessor : public magda::DeviceProcessor {
-  public:
-    explicit StubProcessor(std::vector<magda::ParameterInfo> parameters)
-        : magda::DeviceProcessor(1, nullptr), parameters_(std::move(parameters)) {}
-
-    int getParameterCount() const override {
-        return static_cast<int>(parameters_.size());
-    }
-
-    magda::ParameterInfo getParameterInfo(int index) const override {
-        return parameters_[static_cast<std::size_t>(index)];
-    }
-
-  private:
-    std::vector<magda::ParameterInfo> parameters_;
-};
 
 }  // namespace
 
@@ -320,56 +300,4 @@ TEST_CASE("hasAiSoundDesignerParameters reflects the saved AI selection", "[para
     config.entries[1].aiAgent = true;
     REQUIRE(store::save(device.uniqueId, config));
     REQUIRE(store::hasAiSoundDesignerParameters(device.uniqueId));
-}
-
-TEST_CASE("A rebuilt parameter array carries the plugin's stored config",
-          "[param-config-store][2601]") {
-    // Both engines rebuild an external plugin's array wholesale on load, so a
-    // detected unit that is not re-applied there lasts until the next rebuild
-    // and no longer.
-    TempDataDir temp;
-    const auto configured = makeExternalDevice();
-
-    auto config = store::fromDevice(configured);
-    config.entries[0].visible = true;
-    config.entries[0].unit = "kHz";
-    config.entries[0].rangeMax = 20.0f;
-    REQUIRE(store::save(configured.uniqueId, config));
-
-    const StubProcessor processor(configured.parameters);
-
-    magda::DeviceInfo device;
-    device.uniqueId = configured.uniqueId;
-    device.format = magda::PluginFormat::VST3;
-    processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Engine);
-
-    REQUIRE(device.parameters.size() == 3);
-    CHECK(device.parameters[0].unit == "kHz");
-    CHECK(device.parameters[0].maxValue == 20.0f);
-    CHECK(device.visibleParameters == std::vector<int>{0});
-}
-
-TEST_CASE("A model-first refresh keeps its values and still gains the config",
-          "[param-config-store][2601]") {
-    // An internal device takes the other branch of populateParameters: values
-    // stay the model's, metadata is re-read, and the overlay goes over both.
-    TempDataDir temp;
-    const auto configured = makeExternalDevice();
-
-    auto config = store::fromDevice(configured);
-    config.entries[1].unit = "Q";
-    REQUIRE(store::save("magda_stub_device", config));
-
-    const StubProcessor processor(configured.parameters);
-
-    magda::DeviceInfo device;
-    device.pluginId = "magda_stub_device";
-    device.format = magda::PluginFormat::Internal;
-    device.parameters = configured.parameters;
-    device.parameters[1].currentValue = 42.0f;
-    processor.populateParameters(device, magda::DeviceProcessor::ValueSource::Model);
-
-    REQUIRE(device.parameters.size() == 3);
-    CHECK(device.parameters[1].currentValue == 42.0f);
-    CHECK(device.parameters[1].unit == "Q");
 }

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -5,11 +5,8 @@
 
 #include "magda/daw/audio/processors/base/DeviceProcessor.hpp"
 #include "magda/daw/core/AppPaths.hpp"
-#include "magda/daw/core/ChainWalk.hpp"
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/PluginParameterConfigStore.hpp"
-#include "magda/daw/core/RackInfo.hpp"
-#include "magda/daw/core/TrackManager.hpp"
 
 namespace store = magda::PluginParameterConfigStore;
 
@@ -375,83 +372,4 @@ TEST_CASE("A model-first refresh keeps its values and still gains the config",
     REQUIRE(device.parameters.size() == 3);
     CHECK(device.parameters[1].currentValue == 42.0f);
     CHECK(device.parameters[1].unit == "Q");
-}
-
-TEST_CASE("A saved config reaches a live device without a rebuild", "[param-config-store][2601]") {
-    // What Configure Parameters leans on. The device is already built, so
-    // nothing repopulates its array on save, and since the device slot stopped
-    // applying the config itself this is the only thing that puts a new one on
-    // a device already on screen.
-    TempDataDir temp;
-    auto& tm = magda::TrackManager::getInstance();
-    tm.clearAllTracks();
-
-    const auto trackId = tm.createTrack("Track");
-    tm.addDeviceToTrack(trackId, makeExternalDevice());
-
-    auto config = store::fromDevice(makeExternalDevice());
-    config.entries[0].visible = true;
-    config.entries[0].unit = "kHz";
-    config.entries[1].miniMixer = true;
-    REQUIRE(store::save("VST3-Surge-XT-1a2b3c4d", config));
-
-    store::refreshLiveDevices("VST3-Surge-XT-1a2b3c4d");
-
-    const auto* track = tm.getTrack(trackId);
-    REQUIRE(track != nullptr);
-    REQUIRE(track->chain.fxChainElements.size() == 1);
-
-    const auto& device = magda::getDevice(track->chain.fxChainElements[0]);
-    CHECK(device.parameters[0].unit == "kHz");
-    CHECK(device.visibleParameters == std::vector<int>{0});
-    CHECK(device.miniMixerParameters == std::vector<int>{1});
-
-    tm.clearAllTracks();
-}
-
-TEST_CASE("A saved config reaches a device on a Drum Grid pad", "[param-config-store][2601]") {
-    // A pad device is configured from the same dialog as any other, and a
-    // device is not a leaf when it owns pads (#2204).
-    TempDataDir temp;
-    auto& tm = magda::TrackManager::getInstance();
-    tm.clearAllTracks();
-
-    const auto trackId = tm.createTrack("Track");
-
-    magda::DeviceInfo grid;
-    grid.name = "Grid";
-    grid.pluginId = "drumgrid";
-    grid.format = magda::PluginFormat::Internal;
-    grid.isInstrument = true;
-    grid.deviceType = magda::DeviceType::Instrument;
-    const auto gridId = tm.addDeviceToTrack(trackId, grid);
-
-    const auto gridPath = magda::ChainNodePath::topLevelDevice(trackId, gridId);
-    const auto padChainId = tm.ensurePad(gridPath, 0);
-    REQUIRE(padChainId != magda::INVALID_CHAIN_ID);
-    REQUIRE(tm.addDeviceToPad(gridPath, padChainId, makeExternalDevice()) !=
-            magda::INVALID_DEVICE_ID);
-
-    auto config = store::fromDevice(makeExternalDevice());
-    config.entries[0].visible = true;
-    config.entries[0].unit = "kHz";
-    REQUIRE(store::save("VST3-Surge-XT-1a2b3c4d", config));
-
-    store::refreshLiveDevices("VST3-Surge-XT-1a2b3c4d");
-
-    const auto* track = tm.getTrack(trackId);
-    REQUIRE(track != nullptr);
-
-    const magda::DeviceInfo* onPad = magda::chain_walk::findDevice(
-        track->chain.fxChainElements, magda::ChainNodePath::trackLevel(trackId),
-        magda::chain_walk::Pads::Enter,
-        [](const magda::DeviceInfo& device, const magda::ChainNodePath&) {
-            return device.uniqueId == "VST3-Surge-XT-1a2b3c4d";
-        });
-    REQUIRE(onPad != nullptr);
-
-    CHECK(onPad->parameters[0].unit == "kHz");
-    CHECK(onPad->visibleParameters == std::vector<int>{0});
-
-    tm.clearAllTracks();
 }


### PR DESCRIPTION
Reverts #2608 and #2611. A device slot comes up with no parameter controls.

#2608 applied a plugin's saved parameter config wherever the parameter array is rebuilt. `applyToDevice` clears `visibleParameters` and rebuilds it from the entries ticked visible — and a config with none ticked therefore wipes the list. The only config file on the machine I tested against has 774 parameters and zero ticked, so every rebuild wiped that device's saved selection.

The UI path #2611 then removed had guarded against exactly that:

```cpp
if (!tempDevice.visibleParameters.empty()) { ...write back... }
```

I argued in #2608 that the guard was unnecessary because `setDeviceVisibleParameters` has a single caller fed from the config store. That was wrong: `TrackSerializer` deserialises `visibleParameters` straight from the project file, so a project's own saved selection was being overwritten.

#2611 is reverted with it — it only removed the redundancy #2608 introduced, and removing it also took the slot rebuild out of `DeviceSlotComponent::setNodePath`, where the call was wrapped around `updateParameterPagination()` / `updateParameterSlots()`.

What the pair was worth on real data: of the 774 entries in that config, one carries a unit. That is what surviving a rebuild was buying.

To re-land: keep the selection when the config has nothing to say about it, and cover the device slot, which no test drives.

`make test` (4007 passed, 13 skipped) green on the reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN