### PR TITLE
Refresh the chain when a plugin finishes loading on the native engine

### DIFF
--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -808,8 +808,18 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         // would find the wrong device (#2600).
         attachParameterTextProviders(*device, path);
 
-        if (path.isValid())
+        if (path.isValid()) {
             TrackManager::getInstance().notifyDevicePropertyChanged(path);
+
+            // And the chain, because a device slot is built before its plugin
+            // has finished loading and holds its own copy of the model: nothing
+            // in the chain UI listens for a property change, so without this it
+            // keeps the empty parameter array it was made with (#2617). This is
+            // the notification the fork's load path announces for the same
+            // reason; the rebuild behind it reuses the slot and pushes the
+            // device into it rather than building a new one.
+            TrackManager::getInstance().notifyTrackDevicesChanged(path.trackId);
+        }
 
         // Last, so the plan that binds the loader's instance is compiled from
         // the model as corrected above.

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -811,9 +811,9 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         if (path.isValid()) {
             TrackManager::getInstance().notifyDevicePropertyChanged(path);
 
-            // The chain UI listens for this and not for the property change,
-            // and a slot built before its plugin loaded holds an empty
-            // parameter array until something tells it to rebuild (#2617).
+            // The chain rebuilds its slots on this one, and a slot built
+            // before its plugin loaded holds an empty array until it does
+            // (#2617).
             TrackManager::getInstance().notifyTrackDevicesChanged(path.trackId);
         }
 

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -811,8 +811,9 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         if (path.isValid()) {
             TrackManager::getInstance().notifyDevicePropertyChanged(path);
 
-            // And the chain, which listens for this one and not the above: a
-            // slot built before its plugin loaded keeps an empty array (#2617).
+            // The chain UI listens for this and not for the property change,
+            // and a slot built before its plugin loaded holds an empty
+            // parameter array until something tells it to rebuild (#2617).
             TrackManager::getInstance().notifyTrackDevicesChanged(path.trackId);
         }
 

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -811,13 +811,8 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         if (path.isValid()) {
             TrackManager::getInstance().notifyDevicePropertyChanged(path);
 
-            // And the chain, because a device slot is built before its plugin
-            // has finished loading and holds its own copy of the model: nothing
-            // in the chain UI listens for a property change, so without this it
-            // keeps the empty parameter array it was made with (#2617). This is
-            // the notification the fork's load path announces for the same
-            // reason; the rebuild behind it reuses the slot and pushes the
-            // device into it rather than building a new one.
+            // And the chain, which listens for this one and not the above: a
+            // slot built before its plugin loaded keeps an empty array (#2617).
             TrackManager::getInstance().notifyTrackDevicesChanged(path.trackId);
         }
 


### PR DESCRIPTION
Closes #2617. Diagnosed by Luca.

A hosted plugin came up with no parameter controls at all under the native engine. The device slot is built before the plugin has finished loading and holds its own copy of the model, whose `parameters` is still empty. `EngineHost::applyLoadedDevice` announced only `devicePropertyChanged`, and nothing in the chain UI listens for it — `TrackChainContent` implements `trackDevicesChanged`, `DeviceSlotComponent` implements neither — so the slot kept the empty array it was made with. The fork's load path announces `trackDevicesChanged`, which is why it never showed there.

## What changed

```cpp
if (path.isValid()) {
    TrackManager::getInstance().notifyDevicePropertyChanged(path);
    TrackManager::getInstance().notifyTrackDevicesChanged(path.trackId);
}
```

Both, because the property notification is what `TrackInspector`, `TrackHeadersPanel` and `MixerView` are on.

The rebuild behind `trackDevicesChanged` is not a teardown: since #2214 `rebuildNodeComponents()` reuses the component standing for an element by its device id and calls `updateFromDevice()` on it, so the slot survives and takes the populated array. The element count does not change on a load completing, so it does not scroll to end either.

## Verification

Verified by Luca on this branch: a hosted plugin's controls appear, with configured units.

**No test.** `applyLoadedDevice` is a private method of `EngineHost::Impl`, defined in the .cpp and reached only through `ExternalPluginLoader`'s completion callback, so covering the notification needs either a real plugin load or a seam that does not exist yet. `make test` (4011 passed, 13 skipped) and `make test-juce` are green, but neither says anything about this.

Related: #2570 is the same shape for per-slot meters on the native engine, and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN