### PR TITLE
Build a parameter config from the device's own selections

### DIFF
--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -47,6 +47,34 @@ bool refreshFlatParameterConfig(const juce::String& uniqueId,
     return changed;
 }
 
+/// The entry describing `device`'s parameter at `index` as it stands now.
+PluginParameterConfigEntry entryFor(const DeviceInfo& device, size_t index) {
+    const auto& info = device.parameters[index];
+    const auto selected = [index](const std::vector<int>& indices) {
+        return std::find(indices.begin(), indices.end(), static_cast<int>(index)) != indices.end();
+    };
+
+    PluginParameterConfigEntry entry;
+    entry.index = static_cast<int>(index);
+    entry.id = info.stableId;
+    entry.name = info.name;
+    // Off the device, like the prompt: a caller with no saved file to overlay
+    // then starts from the truth (#2620).
+    entry.visible = selected(device.visibleParameters);
+    entry.miniMixer = selected(device.miniMixerParameters);
+    entry.aiAgent = selected(device.aiSoundDesignerParameters);
+    entry.unit = info.unit;
+    entry.scale = info.scale;
+    entry.rangeMin = info.minValue;
+    entry.rangeMax = info.maxValue;
+    entry.rangeCenter = (info.minValue + info.maxValue) * 0.5f;
+    if (!info.choices.empty())
+        entry.choices = info.choices;
+    if (!info.valueTable.empty())
+        entry.valueTable = info.valueTable;
+    return entry;
+}
+
 }  // namespace
 
 juce::String scaleToString(ParameterScale scale) {
@@ -237,23 +265,8 @@ PluginParameterConfig fromDevice(const DeviceInfo& device) {
     config.pluginId = configIdFor(device);
     config.aiPrompt = device.aiSoundDesignerPrompt;
     config.entries.reserve(device.parameters.size());
-    for (size_t i = 0; i < device.parameters.size(); ++i) {
-        const auto& info = device.parameters[i];
-        PluginParameterConfigEntry entry;
-        entry.index = static_cast<int>(i);
-        entry.id = info.stableId;
-        entry.name = info.name;
-        entry.unit = info.unit;
-        entry.scale = info.scale;
-        entry.rangeMin = info.minValue;
-        entry.rangeMax = info.maxValue;
-        entry.rangeCenter = (info.minValue + info.maxValue) * 0.5f;
-        if (!info.choices.empty())
-            entry.choices = info.choices;
-        if (!info.valueTable.empty())
-            entry.valueTable = info.valueTable;
-        config.entries.push_back(std::move(entry));
-    }
+    for (size_t i = 0; i < device.parameters.size(); ++i)
+        config.entries.push_back(entryFor(device, i));
     return config;
 }
 

--- a/magda/daw/core/PluginParameterConfigStore.hpp
+++ b/magda/daw/core/PluginParameterConfigStore.hpp
@@ -95,8 +95,9 @@ std::optional<PluginParameterConfig> load(const juce::String& uniqueId);
 
 bool save(const juce::String& uniqueId, const PluginParameterConfig& config);
 
-/// A fresh, everything-off config describing `device`'s parameters — the
-/// starting point when a plugin has never been configured.
+/// A config describing `device` as it stands: its parameters, its visible /
+/// mini-mixer / AI selections and its prompt. The starting point when a plugin
+/// has no config file yet.
 PluginParameterConfig fromDevice(const DeviceInfo& device);
 
 /// Load `uniqueId`'s config onto `device`: rebuilds the visible / mini-mixer /

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 
+#include "magda/daw/api/device_api_live.hpp"
 #include "magda/daw/audio/processors/base/DeviceProcessor.hpp"
 #include "magda/daw/core/AppPaths.hpp"
 #include "magda/daw/core/ChainWalk.hpp"
@@ -133,7 +134,8 @@ TEST_CASE("parameter config save and load round-trip", "[param-config-store]") {
     REQUIRE(*loaded->entries[2].choices == std::vector<juce::String>{"LP", "BP", "HP"});
 }
 
-TEST_CASE("fromDevice describes every parameter with everything off", "[param-config-store]") {
+TEST_CASE("fromDevice describes every parameter, unselected device ticks nothing",
+          "[param-config-store]") {
     const auto device = makeExternalDevice();
     const auto config = store::fromDevice(device);
 
@@ -146,6 +148,26 @@ TEST_CASE("fromDevice describes every parameter with everything off", "[param-co
         REQUIRE_FALSE(config.entries[i].miniMixer);
         REQUIRE_FALSE(config.entries[i].aiAgent);
     }
+}
+
+TEST_CASE("fromDevice takes the flags off the device's own selections", "[param-config-store]") {
+    auto device = makeExternalDevice();
+    device.visibleParameters = {0, 2};
+    device.miniMixerParameters = {1};
+    device.aiSoundDesignerParameters = {0};
+    device.aiSoundDesignerPrompt = "Warm analog pads";
+
+    const auto config = store::fromDevice(device);
+
+    REQUIRE(config.aiPrompt == "Warm analog pads");
+    REQUIRE(config.entries[0].visible);
+    REQUIRE_FALSE(config.entries[1].visible);
+    REQUIRE(config.entries[2].visible);
+    REQUIRE_FALSE(config.entries[0].miniMixer);
+    REQUIRE(config.entries[1].miniMixer);
+    REQUIRE(config.entries[0].aiAgent);
+    REQUIRE_FALSE(config.entries[1].aiAgent);
+    REQUIRE_FALSE(config.entries[2].aiAgent);
 }
 
 TEST_CASE("applyToDevice rebuilds selections and applies overrides", "[param-config-store]") {
@@ -452,6 +474,47 @@ TEST_CASE("A saved config reaches a device on a Drum Grid pad", "[param-config-s
 
     CHECK(onPad->parameters[0].unit == "kHz");
     CHECK(onPad->visibleParameters == std::vector<int>{0});
+
+    tm.clearAllTracks();
+}
+
+TEST_CASE("A partial config update keeps the selections of a device with no config file",
+          "[param-config-store][2620]") {
+    // devices.setParameterConfig with a prompt and nothing else: it starts
+    // from fromDevice, and there is no file to overlay.
+    TempDataDir temp;
+    auto& tm = magda::TrackManager::getInstance();
+    tm.clearAllTracks();
+
+    const auto trackId = tm.createTrack("Track");
+    auto device = makeExternalDevice();
+    device.visibleParameters = {0, 1};
+    device.miniMixerParameters = {2};
+    device.aiSoundDesignerParameters = {0};
+    const auto deviceId = tm.addDeviceToTrack(trackId, device);
+    const auto path = tm.findDevicePath(deviceId);
+
+    magda::DeviceApiLive devices;
+    magda::DeviceParameterConfigUpdate update;
+    update.aiPrompt = "Warm analog pads";
+    REQUIRE(devices.setDeviceParameterConfig(path, update));
+
+    const auto saved = store::load(device.uniqueId);
+    REQUIRE(saved.has_value());
+    CHECK(saved->aiPrompt == "Warm analog pads");
+    CHECK(saved->entries[0].visible);
+    CHECK(saved->entries[1].visible);
+    CHECK(saved->entries[2].miniMixer);
+    CHECK(saved->entries[0].aiAgent);
+
+    // And the config that reaches the live device leaves it as it was.
+    const auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->chain.fxChainElements.size() == 1);
+    const auto& live = magda::getDevice(track->chain.fxChainElements[0]);
+    CHECK(live.visibleParameters == std::vector<int>{0, 1});
+    CHECK(live.miniMixerParameters == std::vector<int>{2});
+    CHECK(live.aiSoundDesignerParameters == std::vector<int>{0});
 
     tm.clearAllTracks();
 }


### PR DESCRIPTION
Closes #2620.

`PluginParameterConfigStore::fromDevice` built every entry with `visible`,
`miniMixer` and `aiAgent` at their `false` defaults, though it took
`aiSoundDesignerPrompt` off the same device. `devices.setParameterConfig`
starts from it and overlays the saved file, so for a device with **no** file
under `PluginConfigs` there was nothing to overlay: a request carrying only
`aiPrompt` was saved as a config that ticks nothing, and `refreshLiveDevices`
then cleared the device's visible / mini-mixer / AI selections.

## Change

- `fromDevice` seeds the three flags from `DeviceInfo::visibleParameters`,
  `miniMixerParameters` and `aiSoundDesignerParameters`.
- The per-parameter build moves into an `entryFor` helper, leaving `fromDevice`
  four lines.

The other caller, `ParameterConfigDialog`, builds its config from its own rows
and never goes through `fromDevice`, so it is unaffected. Where a saved entry
matches, the MCP path's field-by-field overlay still wins.

Not the same as the unconditional clear in `applyToDevice` (#2618), which is
correct: a config that ticks nothing legitimately means "show all".

## Tests

- `fromDevice takes the flags off the device's own selections`.
- `[2620]`: an end-to-end case driving `DeviceApiLive::setDeviceParameterConfig`
  with only `aiPrompt`, against a device with curated selections and no config
  file — asserts both the written config and the live device.
- Renamed the everything-off case to say it is about an unselected device.

Verified negatively: with the three assignments removed both new cases fail and
the live device's selection lists come back empty, exactly the issue's repro.
`make test` green — 4033 cases, 1,835,928 assertions, 0 failures, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN