### PR TITLE
Make a hardware input's monitor switch a value, not a plan change

### DIFF
--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -69,7 +69,7 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // resolved from one model against one plan.
     auto messages = prepared->executor.prepare(*prepared->plan, bindings, context,
                                                live_ == nullptr ? nullptr : &live_->executor,
-                                               prepared->values.params.get());
+                                               &prepared->values);
     if (!prepared->executor.isPrepared())
         return {false, std::move(messages)};
 

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -204,8 +204,12 @@ EngineSession::Result EngineSession::publishValues(PlanValues values) {
                  "published: the plan they belong to has to be published with them"}};
 
     if (live_->executor.fitsParameters(values)) {
+        // Asked before the swap and of the values themselves: a switch that
+        // makes an input audible arrives here, with no prepare to notice that
+        // nothing is bound to it (#2612).
+        auto messages = live_->executor.reportUnboundInputs(&values);
         values_.nonRealtimeReplace(std::move(values));
-        return {true, {}};
+        return {true, std::move(messages)};
     }
 
     // The parameter set changed without the plan changing. See the header: this

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -49,7 +49,7 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
                                                        const PlanBindings& bindings,
                                                        const RenderContext& context,
                                                        const ParallelPlanExecutor* previous,
-                                                       const ParamTable* params) {
+                                                       const PlanValues* values) {
     // Everything below reallocates what a worker still finishing the last block
     // would read, so this comes first, the same as at destruction.
     letGoOfPool();
@@ -59,7 +59,7 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
     modSourceOps_.clear();
 
     auto messages = core_.prepare(plan, bindings, context,
-                                  previous != nullptr ? &previous->core_ : nullptr, params);
+                                  previous != nullptr ? &previous->core_ : nullptr, values);
     if (!core_.isPrepared())
         return messages;
 

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -69,7 +69,7 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
     std::vector<std::string> prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                      const RenderContext& context,
                                      const ParallelPlanExecutor* previous = nullptr,
-                                     const ParamTable* params = nullptr);
+                                     const PlanValues* values = nullptr);
 
     /**
      * @brief Render one block into @p output. On the audio thread.

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -71,6 +71,11 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
                                      const ParallelPlanExecutor* previous = nullptr,
                                      const PlanValues* values = nullptr);
 
+    /// @copydoc PlanExecutor::reportUnboundInputs
+    std::vector<std::string> reportUnboundInputs(const PlanValues* values) {
+        return core_.reportUnboundInputs(values);
+    }
+
     /**
      * @brief Render one block into @p output. On the audio thread.
      *

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -271,6 +271,7 @@ int PlanExecutor::activeCrossfades() const {
 void PlanExecutor::reset() {
     plan_ = nullptr;
     planFingerprint_ = 0;
+    reportedUnboundInputs_.clear();
     latencySamples_ = 0;
     carriedDelayLines_ = 0;
     carriedCrossfades_ = 0;
@@ -325,6 +326,11 @@ bool hearsLiveInput(const RenderPlan& plan, const PlanValues* values, TrackId tr
             return i < values->ops.size() ? !values->ops[i].silent : true;
     }
     return true;
+}
+
+std::string describeOp(const RenderPlan& plan, std::size_t index) {
+    return "op " + std::to_string(index) + " (" + toString(plan.ops[index].kind) + " " +
+           toString(plan.ops[index].key) + "): ";
 }
 
 }  // namespace
@@ -565,10 +571,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
 
     detectMono_.assign(static_cast<std::size_t>(std::max(context.maxBlockSize, 0)), 0.0f);
 
-    const auto describe = [&plan](std::size_t index) {
-        return "op " + std::to_string(index) + " (" + toString(plan.ops[index].kind) + " " +
-               toString(plan.ops[index].key) + "): ";
-    };
+    const auto describe = [&plan](std::size_t index) { return describeOp(plan, index); };
 
     const auto findAudioSource = [](const auto& map, TrackId trackId) -> EngineAudioSource* {
         const auto found = map.find(trackId);
@@ -591,15 +594,13 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                                        std::to_string(trackId) + ", it renders silence");
                 break;
 
-            // Reported only where the track is asking to hear the input. Its op
-            // is compiled whether or not the track is monitoring, so that the
-            // meter on it keeps reading (#2612); an input nobody is listening
-            // to is not a binding the host failed to make.
+            // Not reported here: an input op is compiled whether or not the
+            // track is monitoring, so what makes an unbound one worth saying is
+            // the values, and those arrive again without a prepare (#2612).
+            // reportUnboundInputs below answers for the values this plan is
+            // published with, and publishValues asks again for every set after.
             case OpKind::AudioInput:
                 audioSourceForOp_[i] = findAudioSource(bindings.audioInputs, trackId);
-                if (audioSourceForOp_[i] == nullptr && hearsLiveInput(plan, values, trackId))
-                    messages.push_back(describe(i) + "no live audio input bound for track " +
-                                       std::to_string(trackId) + ", it renders silence");
                 break;
 
             // Reported only by a host that has a launcher at all, which is what
@@ -1016,6 +1017,30 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
 
     planFingerprint_ = magda::engine::planFingerprint(plan);
     plan_ = &plan;
+
+    for (auto& report : reportUnboundInputs(values))
+        messages.push_back(std::move(report));
+
+    return messages;
+}
+
+std::vector<std::string> PlanExecutor::reportUnboundInputs(const PlanValues* values) {
+    std::vector<std::string> messages;
+    if (plan_ == nullptr)
+        return messages;
+
+    for (std::size_t i = 0; i < plan_->ops.size(); ++i) {
+        const auto& op = plan_->ops[i];
+        if (op.kind != OpKind::AudioInput || audioSourceForOp_[i] != nullptr)
+            continue;
+        if (!hearsLiveInput(*plan_, values, op.key.trackId))
+            continue;
+        if (!reportedUnboundInputs_.insert(static_cast<OpId>(i)).second)
+            continue;
+
+        messages.push_back(describeOp(*plan_, i) + "no live audio input bound for track " +
+                           std::to_string(op.key.trackId) + ", it renders silence");
+    }
     return messages;
 }
 

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -569,15 +569,9 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                                        std::to_string(trackId) + ", it renders silence");
                 break;
 
-            // Reported only by a host that binds live inputs at all, the way a
-            // session op is below. An input op is emitted for every track that
-            // names an input device whether or not the track is monitoring
-            // (#2612), so an offline render binds none of them and says
-            // nothing. Binding some and not others is a track that lost its
-            // input.
             case OpKind::AudioInput:
                 audioSourceForOp_[i] = findAudioSource(bindings.audioInputs, trackId);
-                if (audioSourceForOp_[i] == nullptr && !bindings.audioInputs.empty())
+                if (audioSourceForOp_[i] == nullptr)
                     messages.push_back(describe(i) + "no live audio input bound for track " +
                                        std::to_string(trackId) + ", it renders silence");
                 break;
@@ -610,7 +604,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
 
             case OpKind::MidiInput:
                 midiSourceForOp_[i] = findMidiSource(bindings.midiInputs, trackId);
-                if (midiSourceForOp_[i] == nullptr && !bindings.midiInputs.empty())
+                if (midiSourceForOp_[i] == nullptr)
                     messages.push_back(describe(i) + "no live MIDI input bound for track " +
                                        std::to_string(trackId) + ", it renders nothing");
                 break;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -569,9 +569,15 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                                        std::to_string(trackId) + ", it renders silence");
                 break;
 
+            // Reported only by a host that binds live inputs at all, the way a
+            // session op is below. An input op is emitted for every track that
+            // names an input device whether or not the track is monitoring
+            // (#2612), so an offline render binds none of them and says
+            // nothing. Binding some and not others is a track that lost its
+            // input.
             case OpKind::AudioInput:
                 audioSourceForOp_[i] = findAudioSource(bindings.audioInputs, trackId);
-                if (audioSourceForOp_[i] == nullptr)
+                if (audioSourceForOp_[i] == nullptr && !bindings.audioInputs.empty())
                     messages.push_back(describe(i) + "no live audio input bound for track " +
                                        std::to_string(trackId) + ", it renders silence");
                 break;
@@ -604,7 +610,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
 
             case OpKind::MidiInput:
                 midiSourceForOp_[i] = findMidiSource(bindings.midiInputs, trackId);
-                if (midiSourceForOp_[i] == nullptr)
+                if (midiSourceForOp_[i] == nullptr && !bindings.midiInputs.empty())
                     messages.push_back(describe(i) + "no live MIDI input bound for track " +
                                        std::to_string(trackId) + ", it renders nothing");
                 break;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -309,11 +309,33 @@ void PlanExecutor::reset() {
     paramLayout_ = 0;
 }
 
+namespace {
+
+/// Whether @p trackId is listening to its live audio input, which is the value
+/// on the gate the input reaches its chain through (#2612). True where the
+/// caller published no values, and where the plan has no gate: an input nobody
+/// can silence is one the track hears.
+bool hearsLiveInput(const RenderPlan& plan, const PlanValues* values, TrackId trackId) {
+    if (values == nullptr)
+        return true;
+
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& key = plan.ops[i].key;
+        if (key.role == OpRole::LiveInputGate && key.trackId == trackId)
+            return i < values->ops.size() ? !values->ops[i].silent : true;
+    }
+    return true;
+}
+
+}  // namespace
+
 std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                                const RenderContext& context,
                                                const PlanExecutor* previous,
-                                               const ParamTable* params) {
+                                               const PlanValues* values) {
     reset();
+
+    const auto* params = values == nullptr ? nullptr : values->params.get();
 
     std::vector<std::string> messages;
 
@@ -569,9 +591,13 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                                        std::to_string(trackId) + ", it renders silence");
                 break;
 
+            // Reported only where the track is asking to hear the input. Its op
+            // is compiled whether or not the track is monitoring, so that the
+            // meter on it keeps reading (#2612); an input nobody is listening
+            // to is not a binding the host failed to make.
             case OpKind::AudioInput:
                 audioSourceForOp_[i] = findAudioSource(bindings.audioInputs, trackId);
-                if (audioSourceForOp_[i] == nullptr)
+                if (audioSourceForOp_[i] == nullptr && hearsLiveInput(plan, values, trackId))
                     messages.push_back(describe(i) + "no live audio input bound for track " +
                                        std::to_string(trackId) + ", it renders silence");
                 break;

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -192,10 +192,14 @@ class PlanExecutor {
      * which is why the session holds its own handle on the rendering epoch
      * rather than reaching for whatever is currently published.
      */
+    /// @p values is what the plan will render with. The parameter table inside
+    /// it sizes the per-op windows, and the op values say which inputs the
+    /// model is asking to hear, which is what makes an unbound one worth
+    /// reporting (#2612). Null where a caller has neither.
     std::vector<std::string> prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                      const RenderContext& context,
                                      const PlanExecutor* previous = nullptr,
-                                     const ParamTable* params = nullptr);
+                                     const PlanValues* values = nullptr);
 
     /**
      * @brief Publish the panics this plan owes devices it rerouted (#2418).

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -202,6 +202,20 @@ class PlanExecutor {
                                      const PlanValues* values = nullptr);
 
     /**
+     * @brief What @p values make audible with nothing bound to it.
+     *
+     * An input op is compiled whether or not the track is monitoring, so an
+     * unbound one is only worth reporting once the model asks to hear it --
+     * and that can arrive as values, long after the prepare that bound
+     * nothing (#2612). So the session asks again for every set it publishes.
+     *
+     * Each op is reported once per prepared plan: the switch is flipped once,
+     * while values arrive for every fader move. On the publishing thread,
+     * like prepare; the audio thread reads none of this.
+     */
+    std::vector<std::string> reportUnboundInputs(const PlanValues* values);
+
+    /**
      * @brief Publish the panics this plan owes devices it rerouted (#2418).
      *
      * At the swap and nowhere earlier: a plan can still be refused after it
@@ -560,6 +574,10 @@ class PlanExecutor {
     const std::shared_ptr<CrossfadeRamp>& crossfadeFor(OpId op) const;
 
     const RenderPlan* plan_ = nullptr;
+
+    /// The unbound inputs reportUnboundInputs has already answered for, so a
+    /// fader move does not say it again. Publishing thread only.
+    std::set<OpId> reportedUnboundInputs_;
     RenderContext context_;
 
     /// The arena. Ports share these where no schedule can want both at

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -484,11 +484,10 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
             break;
         }
 
-        // Silent while the track is not listening to the input routed to it.
-        // The route is compiled either way, so this flag is the whole of what
-        // the monitor switch moves (#2612).
-        case OpRole::AudioInputGate:
-        case OpRole::MidiInputGate:
+        // Silent while the track is not listening to its live audio input. The
+        // input op and its meter are compiled either way, so this flag is the
+        // whole of what the monitor switch moves (#2612).
+        case OpRole::LiveInputGate:
             if (!track->monitorsInput())
                 value.silent = true;
             break;

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -484,6 +484,15 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
             break;
         }
 
+        // Silent while the track is not listening to the input routed to it.
+        // The route is compiled either way, so this flag is the whole of what
+        // the monitor switch moves (#2612).
+        case OpRole::AudioInputGate:
+        case OpRole::MidiInputGate:
+            if (!track->monitorsInput())
+                value.silent = true;
+            break;
+
         // Sources, sums, merges, differences, meters and the output carry no
         // value of their own: what they render comes from their bindings, and
         // what they pass on is whatever reached them.

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -189,24 +189,26 @@ class Compiler {
     bool carriesClips(const TrackInfo& track) const;
 
     /**
-     * @brief What each input field routes to, whether or not the track listens.
+     * @brief The routing each input field resolves to.
      *
-     * Ordering discovery and emission both go through these, so a route can
-     * never be a dependency without also being a connection: an edge that is
-     * not a connection can invent a cycle, and breaking that cycle costs a real
-     * connection elsewhere. Monitoring is a value on the gate below (#2612).
+     * A hardware input resolves whether or not the track is monitoring: the
+     * switch is a value on the gate it arrives through (#2612). A route from
+     * another track still comes and goes with the switch, because it is an
+     * ordering dependency as well as a connection -- ordering discovery and
+     * emission both go through here, so a route can never be a dependency
+     * without also being a connection, and a dormant one that closed a cycle
+     * would cost a real connection elsewhere.
      */
     TrackRoute activeAudioInputRoute(const TrackInfo& track) const;
     TrackRoute activeMidiInputRoute(const TrackInfo& track) const;
 
     /**
-     * @brief The op @p source reaches @p trackId's input through.
+     * @brief The op the live audio input reaches @p trackId's chain through.
      *
-     * Where the monitor switch lands: the gate is silent while the track is not
-     * listening, so flipping it publishes values and rebuilds nothing (#2612).
+     * Where the monitor switch lands: silent while the track is not listening,
+     * so flipping it publishes values and rebuilds nothing (#2612).
      */
-    PortRef emitAudioInputGate(TrackId trackId, PortRef source);
-    PortRef emitMidiInputGate(TrackId trackId, PortRef source);
+    PortRef emitLiveInputGate(TrackId trackId, PortRef source);
 
     /// The track this track's audio output feeds; the master by default.
     static TrackId resolveAudioDestination(const TrackInfo& track);
@@ -393,11 +395,15 @@ bool Compiler::carriesClips(const TrackInfo& track) const {
 TrackRoute Compiler::activeAudioInputRoute(const TrackInfo& track) const {
     if (!carriesClips(track) || track.audioInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
-    return parseTrackRoute(track.audioInputDevice);
+
+    const auto route = parseTrackRoute(track.audioInputDevice);
+    if (route.namesTrack() && !track.monitorsInput())
+        return {RouteKind::None, INVALID_TRACK_ID};
+    return route;
 }
 
 TrackRoute Compiler::activeMidiInputRoute(const TrackInfo& track) const {
-    if (!carriesClips(track) || track.midiInputDevice.isEmpty())
+    if (!carriesClips(track) || !track.monitorsInput() || track.midiInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
     return parseTrackRoute(track.midiInputDevice);
 }
@@ -550,18 +556,10 @@ PortRef Compiler::emitMix(const OpKey& key, const std::vector<PortRef>& sources)
                    0};
 }
 
-PortRef Compiler::emitAudioInputGate(TrackId trackId, PortRef source) {
-    const OpKey key{trackId,           INVALID_RACK_ID,        INVALID_CHAIN_ID,
-                    INVALID_DEVICE_ID, OpRole::AudioInputGate, 0};
-    return PortRef{addOp(OpKind::Gain, key, {source}, {SignalKind::Audio}), 0};
-}
-
-PortRef Compiler::emitMidiInputGate(TrackId trackId, PortRef source) {
-    // A merge of one. There is no gain on a MIDI stream, so silence is the only
-    // thing a value can say about it, and a merge is what already reads that.
+PortRef Compiler::emitLiveInputGate(TrackId trackId, PortRef source) {
     const OpKey key{trackId,           INVALID_RACK_ID,       INVALID_CHAIN_ID,
-                    INVALID_DEVICE_ID, OpRole::MidiInputGate, 0};
-    return PortRef{addOp(OpKind::MergeMidi, key, {source}, {SignalKind::Midi}), 0};
+                    INVALID_DEVICE_ID, OpRole::LiveInputGate, 0};
+    return PortRef{addOp(OpKind::Gain, key, {source}, {SignalKind::Audio}), 0};
 }
 
 PortRef Compiler::emitDelta(const OpKey& key, PortRef wet, PortRef dry) {
@@ -1326,10 +1324,11 @@ void Compiler::emitTrack(const TrackInfo& track) {
             PortRef{addOp(OpKind::SessionAudio, sessionKey, {}, {SignalKind::Audio}), 0});
     }
 
-    // Input reaches a track whenever the track names one, from hardware or from
-    // another track. Whether the track is listening is the monitor switch, and
-    // that is a value on the gate each route arrives through rather than a
-    // shape: a switch flip publishes values and rebuilds nothing (#2612).
+    // A hardware input is compiled for every track that names one, and the
+    // monitor switch is a value on the gate below rather than a shape: flipping
+    // it publishes values and rebuilds nothing (#2612). A route from another
+    // track is still gated in activeAudioInputRoute, so ordering agrees with
+    // what is connected.
     switch (const auto route = activeAudioInputRoute(track); route.kind) {
         case RouteKind::Track: {
             // An internal route carries the source track's post-mute output.
@@ -1337,7 +1336,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
             // the source rather than asserted here.
             if (const auto source = trackRoutedOutput_.find(route.trackId);
                 source != trackRoutedOutput_.end())
-                audioSources.push_back(emitAudioInputGate(track.id, source->second));
+                audioSources.push_back(source->second);
             else
                 diagnose("track " + std::to_string(track.id) + ": audio input track " +
                          std::to_string(route.trackId) + " is not compiled, input not connected");
@@ -1364,7 +1363,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
                 addOp(OpKind::Meter, meterKey, {PortRef{op, 0}}, {SignalKind::Audio});
             plan_.ops[static_cast<std::size_t>(meter)].liveness = LivenessDomain::Live;
 
-            audioSources.push_back(emitAudioInputGate(track.id, PortRef{meter, 0}));
+            audioSources.push_back(emitLiveInputGate(track.id, PortRef{meter, 0}));
             break;
         }
         case RouteKind::None:
@@ -1404,9 +1403,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
     // One live input op per track, whatever else is routed to it: a preview is
     // queued under the track's own audition source, and the store keys live
     // inputs by TrackId, so a second op here would be a second binding to one
-    // object (CompileOptions::auditionMidi, #2579). No monitor gate on it and
-    // none wanted: the published routing decides which sources it hears, and
-    // the audition is not one of them (#2592).
+    // object (CompileOptions::auditionMidi, #2579).
     const auto route = activeMidiInputRoute(track);
     if (route.kind == RouteKind::External || (options_.auditionMidi && readsMidi))
         midiSources.push_back(emitLiveMidiInput(track.id));
@@ -1417,7 +1414,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
             // not what its own chain made of it.
             if (const auto source = trackMidiInput_.find(route.trackId);
                 source != trackMidiInput_.end())
-                midiSources.push_back(emitMidiInputGate(track.id, source->second));
+                midiSources.push_back(source->second);
             else
                 diagnose("track " + std::to_string(track.id) + ": MIDI input track " +
                          std::to_string(route.trackId) + " produces no MIDI, input not connected");
@@ -1627,9 +1624,9 @@ RenderPlan Compiler::run() {
     // nothing in its own chain consumes it, so this is collected up front.
     for (const auto& track : tracks_) {
         collectSidechainSources(track, SidechainConfig::Type::MIDI, midiSourceTracks_);
-        // Whether the destination is listening this second does not come into
-        // it: one track's monitor button would otherwise decide another track's
-        // op set (#2612). The same rule a MIDI sidechain already follows.
+        // Gated the same way the route itself is: an unmonitored route reads
+        // nothing, so making its source compile MIDI ops would leave ops in the
+        // plan that no one reads.
         if (const auto route = activeMidiInputRoute(track); route.namesTrack())
             midiSourceTracks_.insert(route.trackId);
     }

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -188,13 +188,25 @@ class Compiler {
     /// and Master tracks only pass on what reaches them from elsewhere.
     bool carriesClips(const TrackInfo& track) const;
 
-    /// The routing each input field resolves to, already gated on whether the
-    /// track will actually read it. Ordering discovery and emission both go
-    /// through these, so a route can never be a dependency without also being
-    /// a connection: an ungated edge can invent a cycle, and breaking that
-    /// cycle costs a real connection elsewhere.
+    /**
+     * @brief What each input field routes to, whether or not the track listens.
+     *
+     * Ordering discovery and emission both go through these, so a route can
+     * never be a dependency without also being a connection: an edge that is
+     * not a connection can invent a cycle, and breaking that cycle costs a real
+     * connection elsewhere. Monitoring is a value on the gate below (#2612).
+     */
     TrackRoute activeAudioInputRoute(const TrackInfo& track) const;
     TrackRoute activeMidiInputRoute(const TrackInfo& track) const;
+
+    /**
+     * @brief The op @p source reaches @p trackId's input through.
+     *
+     * Where the monitor switch lands: the gate is silent while the track is not
+     * listening, so flipping it publishes values and rebuilds nothing (#2612).
+     */
+    PortRef emitAudioInputGate(TrackId trackId, PortRef source);
+    PortRef emitMidiInputGate(TrackId trackId, PortRef source);
 
     /// The track this track's audio output feeds; the master by default.
     static TrackId resolveAudioDestination(const TrackInfo& track);
@@ -379,13 +391,13 @@ bool Compiler::carriesClips(const TrackInfo& track) const {
 }
 
 TrackRoute Compiler::activeAudioInputRoute(const TrackInfo& track) const {
-    if (!carriesClips(track) || !track.monitorsInput() || track.audioInputDevice.isEmpty())
+    if (!carriesClips(track) || track.audioInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
     return parseTrackRoute(track.audioInputDevice);
 }
 
 TrackRoute Compiler::activeMidiInputRoute(const TrackInfo& track) const {
-    if (!carriesClips(track) || !track.monitorsInput() || track.midiInputDevice.isEmpty())
+    if (!carriesClips(track) || track.midiInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
     return parseTrackRoute(track.midiInputDevice);
 }
@@ -536,6 +548,20 @@ PortRef Compiler::emitMix(const OpKey& key, const std::vector<PortRef>& sources)
     return PortRef{addOp(OpKind::MixAudio, key, alignInputs(key, OpKind::MixAudio, sources),
                          {SignalKind::Audio}),
                    0};
+}
+
+PortRef Compiler::emitAudioInputGate(TrackId trackId, PortRef source) {
+    const OpKey key{trackId,           INVALID_RACK_ID,        INVALID_CHAIN_ID,
+                    INVALID_DEVICE_ID, OpRole::AudioInputGate, 0};
+    return PortRef{addOp(OpKind::Gain, key, {source}, {SignalKind::Audio}), 0};
+}
+
+PortRef Compiler::emitMidiInputGate(TrackId trackId, PortRef source) {
+    // A merge of one. There is no gain on a MIDI stream, so silence is the only
+    // thing a value can say about it, and a merge is what already reads that.
+    const OpKey key{trackId,           INVALID_RACK_ID,       INVALID_CHAIN_ID,
+                    INVALID_DEVICE_ID, OpRole::MidiInputGate, 0};
+    return PortRef{addOp(OpKind::MergeMidi, key, {source}, {SignalKind::Midi}), 0};
 }
 
 PortRef Compiler::emitDelta(const OpKey& key, PortRef wet, PortRef dry) {
@@ -1300,10 +1326,10 @@ void Compiler::emitTrack(const TrackInfo& track) {
             PortRef{addOp(OpKind::SessionAudio, sessionKey, {}, {SignalKind::Audio}), 0});
     }
 
-    // Input reaches a track only while it is monitoring or armed, whether it
-    // comes from hardware or from another track. Both forms go through the
-    // input path in the current engine, so both are gated the same way, and
-    // the gate lives in activeAudioInputRoute so ordering agrees with this.
+    // Input reaches a track whenever the track names one, from hardware or from
+    // another track. Whether the track is listening is the monitor switch, and
+    // that is a value on the gate each route arrives through rather than a
+    // shape: a switch flip publishes values and rebuilds nothing (#2612).
     switch (const auto route = activeAudioInputRoute(track); route.kind) {
         case RouteKind::Track: {
             // An internal route carries the source track's post-mute output.
@@ -1311,7 +1337,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
             // the source rather than asserted here.
             if (const auto source = trackRoutedOutput_.find(route.trackId);
                 source != trackRoutedOutput_.end())
-                audioSources.push_back(source->second);
+                audioSources.push_back(emitAudioInputGate(track.id, source->second));
             else
                 diagnose("track " + std::to_string(track.id) + ": audio input track " +
                          std::to_string(route.trackId) + " is not compiled, input not connected");
@@ -1328,17 +1354,17 @@ void Compiler::emitTrack(const TrackInfo& track) {
             const auto op = addOp(OpKind::AudioInput, key, {}, {SignalKind::Audio});
             plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
 
-            // What a monitoring track is hearing, which the incumbent reads off
-            // the input device rather than off the signal (#2463). Here it is
-            // the input op's own output, so an armed track that is not
-            // monitoring still meters what it is recording.
+            // What the track is hearing, which the incumbent reads off the
+            // input device rather than off the signal (#2463). Here it is the
+            // input op's own output, ahead of the gate, so a track that is
+            // recording without monitoring still meters what it records.
             const OpKey meterKey{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
                                  INVALID_DEVICE_ID, OpRole::LiveInputMeter, 0};
             const auto meter =
                 addOp(OpKind::Meter, meterKey, {PortRef{op, 0}}, {SignalKind::Audio});
             plan_.ops[static_cast<std::size_t>(meter)].liveness = LivenessDomain::Live;
 
-            audioSources.push_back(PortRef{meter, 0});
+            audioSources.push_back(emitAudioInputGate(track.id, PortRef{meter, 0}));
             break;
         }
         case RouteKind::None:
@@ -1378,7 +1404,9 @@ void Compiler::emitTrack(const TrackInfo& track) {
     // One live input op per track, whatever else is routed to it: a preview is
     // queued under the track's own audition source, and the store keys live
     // inputs by TrackId, so a second op here would be a second binding to one
-    // object (CompileOptions::auditionMidi, #2579).
+    // object (CompileOptions::auditionMidi, #2579). No monitor gate on it and
+    // none wanted: the published routing decides which sources it hears, and
+    // the audition is not one of them (#2592).
     const auto route = activeMidiInputRoute(track);
     if (route.kind == RouteKind::External || (options_.auditionMidi && readsMidi))
         midiSources.push_back(emitLiveMidiInput(track.id));
@@ -1389,7 +1417,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
             // not what its own chain made of it.
             if (const auto source = trackMidiInput_.find(route.trackId);
                 source != trackMidiInput_.end())
-                midiSources.push_back(source->second);
+                midiSources.push_back(emitMidiInputGate(track.id, source->second));
             else
                 diagnose("track " + std::to_string(track.id) + ": MIDI input track " +
                          std::to_string(route.trackId) + " produces no MIDI, input not connected");
@@ -1599,9 +1627,9 @@ RenderPlan Compiler::run() {
     // nothing in its own chain consumes it, so this is collected up front.
     for (const auto& track : tracks_) {
         collectSidechainSources(track, SidechainConfig::Type::MIDI, midiSourceTracks_);
-        // Gated the same way the route itself is: an unmonitored route reads
-        // nothing, so making its source compile MIDI ops would leave ops in the
-        // plan that no one reads.
+        // Whether the destination is listening this second does not come into
+        // it: one track's monitor button would otherwise decide another track's
+        // op set (#2612). The same rule a MIDI sidechain already follows.
         if (const auto route = activeMidiInputRoute(track); route.namesTrack())
             midiSourceTracks_.insert(route.trackId);
     }

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -109,6 +109,10 @@ const char* toString(OpRole role) {
             return "liveInputMeter";
         case OpRole::LiveMidiInput:
             return "liveMidiInput";
+        case OpRole::AudioInputGate:
+            return "audioInputGate";
+        case OpRole::MidiInputGate:
+            return "midiInputGate";
         case OpRole::SessionAudio:
             return "sessionAudio";
         case OpRole::SessionMidi:

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -109,10 +109,8 @@ const char* toString(OpRole role) {
             return "liveInputMeter";
         case OpRole::LiveMidiInput:
             return "liveMidiInput";
-        case OpRole::AudioInputGate:
-            return "audioInputGate";
-        case OpRole::MidiInputGate:
-            return "midiInputGate";
+        case OpRole::LiveInputGate:
+            return "liveInputGate";
         case OpRole::SessionAudio:
             return "sessionAudio";
         case OpRole::SessionMidi:

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -152,8 +152,7 @@ enum class OpRole : std::uint8_t {
     LiveAudioInput,       ///< the track's live audio input
     LiveInputMeter,       ///< the live audio input's level tap, ahead of the monitor gate
     LiveMidiInput,        ///< the track's live MIDI input
-    AudioInputGate,       ///< whether the track hears the audio input it is routed
-    MidiInputGate,        ///< whether the track hears the MIDI routed to it from another track
+    LiveInputGate,        ///< whether the track hears its live audio input
     SessionAudio,         ///< the track's session audio, whichever slot is playing
     SessionMidi,          ///< the track's session MIDI
     TrackAudioInput,      ///< sum of everything feeding the track's chain head

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -150,8 +150,10 @@ enum class OpRole : std::uint8_t {
     ClipAudio,            ///< the track's audio clip source
     ClipMidi,             ///< the track's MIDI clip source
     LiveAudioInput,       ///< the track's live audio input
-    LiveInputMeter,       ///< the live audio input's level tap, read while monitoring
+    LiveInputMeter,       ///< the live audio input's level tap, ahead of the monitor gate
     LiveMidiInput,        ///< the track's live MIDI input
+    AudioInputGate,       ///< whether the track hears the audio input it is routed
+    MidiInputGate,        ///< whether the track hears the MIDI routed to it from another track
     SessionAudio,         ///< the track's session audio, whichever slot is playing
     SessionMidi,          ///< the track's session MIDI
     TrackAudioInput,      ///< sum of everything feeding the track's chain head

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -335,8 +335,9 @@ std::vector<MgdFixture> build() {
 
     {
         // A Faust device on an audio track, and a Poly Synth on a track whose
-        // input monitoring is on: a device whose DSP was compiled from a .dsp
-        // file, which no code-built case has.
+        // input monitoring is on. Two things no code-built case has: a device
+        // whose DSP was compiled from a .dsp file, and a track that is listening
+        // to an input nothing is bound to.
         //
         // The clip is warped, and its markers are what a real transient pass
         // produced rather than what somebody would write down: one of them
@@ -358,6 +359,7 @@ std::vector<MgdFixture> build() {
 
         fixture.declaration.expectedDiagnostics = {
             "warp marker(s) that do not run forwards",
+            "no live MIDI input bound for track 2",
         };
 
         fixture.sources = {

--- a/tests/MgdFixtures.cpp
+++ b/tests/MgdFixtures.cpp
@@ -335,9 +335,8 @@ std::vector<MgdFixture> build() {
 
     {
         // A Faust device on an audio track, and a Poly Synth on a track whose
-        // input monitoring is on. Two things no code-built case has: a device
-        // whose DSP was compiled from a .dsp file, and a track that is listening
-        // to an input nothing is bound to.
+        // input monitoring is on: a device whose DSP was compiled from a .dsp
+        // file, which no code-built case has.
         //
         // The clip is warped, and its markers are what a real transient pass
         // produced rather than what somebody would write down: one of them
@@ -359,7 +358,6 @@ std::vector<MgdFixture> build() {
 
         fixture.declaration.expectedDiagnostics = {
             "warp marker(s) that do not run forwards",
-            "no live MIDI input bound for track 2",
         };
 
         fixture.sources = {

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -720,8 +720,7 @@ NativeRender renderNative(const Case& value, const InstalledPlugins& installed) 
     // device is handed an empty window, and the gain device reads that as
     // unity, so the project would sound plausible and assert nothing.
     PlanExecutor executor;
-    for (const auto& diagnostic :
-         executor.prepare(plan, bindings, context, nullptr, values.params.get()))
+    for (const auto& diagnostic : executor.prepare(plan, bindings, context, nullptr, &values))
         result.diagnostics.push_back("prepare: " + diagnostic);
 
     if (!executor.isPrepared()) {

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -943,15 +943,20 @@ class EngineHostPublishTest final : public juce::UnitTest {
         expect(shapeNow() != compiledFrom, "Bypassing a device is");
         device.bypassed = false;
 
-        // Monitoring is what the compiler gates an input route on, so the
-        // switch and the route are one edit here.
-        track->inputMonitor = magda::InputMonitorMode::In;
+        // A route is an op and an edge the plan holds whatever the monitor
+        // switch says.
         track->midiInputDevice = "track:" + juce::String(sourceId);
         expect(shapeNow() != compiledFrom, "So is taking MIDI from another track");
         track->midiInputDevice = "";
 
         track->audioInputDevice = "Input 1";
-        expect(shapeNow() != compiledFrom, "So is a monitored audio input");
+        const auto withInput = shapeNow();
+        expect(withInput != compiledFrom, "So is naming an audio input");
+
+        // The switch itself is not: it lands on the gate the route arrives
+        // through, which a values publish carries (#2612).
+        track->inputMonitor = magda::InputMonitorMode::In;
+        expect(shapeNow() == withInput, "Monitoring that input is not a shape change");
     }
 
     void testOnlyTrackMetersAreTapped() {

--- a/tests/engine/test_engine_host_publish_juce.cpp
+++ b/tests/engine/test_engine_host_publish_juce.cpp
@@ -943,8 +943,9 @@ class EngineHostPublishTest final : public juce::UnitTest {
         expect(shapeNow() != compiledFrom, "Bypassing a device is");
         device.bypassed = false;
 
-        // A route is an op and an edge the plan holds whatever the monitor
-        // switch says.
+        // Monitoring is what the compiler gates an input route on, so the
+        // switch and the route are one edit here.
+        track->inputMonitor = magda::InputMonitorMode::In;
         track->midiInputDevice = "track:" + juce::String(sourceId);
         expect(shapeNow() != compiledFrom, "So is taking MIDI from another track");
         track->midiInputDevice = "";
@@ -953,9 +954,9 @@ class EngineHostPublishTest final : public juce::UnitTest {
         const auto withInput = shapeNow();
         expect(withInput != compiledFrom, "So is naming an audio input");
 
-        // The switch itself is not: it lands on the gate the route arrives
-        // through, which a values publish carries (#2612).
-        track->inputMonitor = magda::InputMonitorMode::In;
+        // But not the switch over it: that lands on the input's gate, which a
+        // values publish carries (#2612).
+        track->inputMonitor = magda::InputMonitorMode::Off;
         expect(shapeNow() == withInput, "Monitoring that input is not a shape change");
     }
 

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -208,31 +208,31 @@ magda::engine::TransportSnapshot rolling(double fromBeat) {
 
 }  // namespace
 
-TEST_CASE("An input op is compiled for every track that names an input",
+TEST_CASE("A hardware audio input is compiled for every track that names one",
           "[engine][live-input][2612]") {
-    // Whether the track is listening is monitorsInput(): armed, or monitoring
-    // set to In. That is a value on the input gate, so the ops it decides
-    // nothing about are compiled for every switch position.
+    // monitorsInput(): armed, or monitoring set to In. Auto lights the activity
+    // indicator (receivesLiveMidiInput) but is not audible until the track is
+    // armed, which is what ships. For the audio input that decides the gate's
+    // value rather than whether the op exists, so the op is there either way.
     CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::AudioInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::AudioInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::In, false, OpKind::AudioInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Off, true, OpKind::AudioInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Auto, true, OpKind::AudioInput) == 1);
 
-    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::MidiInput) == 1);
-    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::MidiInput) == 1);
+    // Live MIDI still comes and goes with the switch. #2612 is the audio half.
+    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::MidiInput) == 0);
+    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::MidiInput) == 0);
     CHECK(inputOpsFor(InputMonitorMode::In, false, OpKind::MidiInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Off, true, OpKind::MidiInput) == 1);
 }
 
-TEST_CASE("What the monitor switch moves is the gate's silence", "[engine][live-input][2612]") {
-    // The switch reaches the engine as values now, which is a publish that
-    // prepares nothing: the plan a monitoring track compiles is the plan an
-    // idle one compiles.
-    const auto silenceOf = [](InputMonitorMode monitor, OpRole role) {
-        const std::vector<TrackInfo> tracks{monitoringTrack(monitor, false)};
+TEST_CASE("What the monitor switch moves is the input gate's silence",
+          "[engine][live-input][2612]") {
+    const auto gateSilence = [](InputMonitorMode monitor, bool armed) {
+        const std::vector<TrackInfo> tracks{monitoringTrack(monitor, armed)};
         const auto plan = compile(tracks);
-        const auto gate = findRole(*plan, tracks.front().id, role);
+        const auto gate = findRole(*plan, tracks.front().id, OpRole::LiveInputGate);
         REQUIRE(gate >= 0);
 
         magda::engine::PlanValues values;
@@ -240,17 +240,21 @@ TEST_CASE("What the monitor switch moves is the gate's silence", "[engine][live-
         return values.ops[static_cast<std::size_t>(gate)].silent;
     };
 
-    CHECK(silenceOf(InputMonitorMode::Off, OpRole::AudioInputGate));
-    CHECK_FALSE(silenceOf(InputMonitorMode::In, OpRole::AudioInputGate));
+    CHECK(gateSilence(InputMonitorMode::Off, false));
+    CHECK(gateSilence(InputMonitorMode::Auto, false));
+    CHECK_FALSE(gateSilence(InputMonitorMode::In, false));
+    CHECK_FALSE(gateSilence(InputMonitorMode::Off, true));
+    CHECK_FALSE(gateSilence(InputMonitorMode::Auto, true));
 
-    // The hardware MIDI route has no gate: what a track hears of the live MIDI
-    // is the published routing, and the audition shares the op (#2592).
-    const std::vector<TrackInfo> idle{monitoringTrack(InputMonitorMode::Off, false)};
-    CHECK(findRole(*compile(idle), idle.front().id, OpRole::MidiInputGate) < 0);
-
-    const auto monitoring = std::vector<TrackInfo>{monitoringTrack(InputMonitorMode::In, false)};
-    CHECK(magda::engine::planFingerprint(*compile(idle)) ==
-          magda::engine::planFingerprint(*compile(monitoring)));
+    // The input reaches the chain through the gate and nowhere else, so a
+    // silent gate is the whole of what an unmonitored track hears of it.
+    const std::vector<TrackInfo> tracks{monitoringTrack(InputMonitorMode::Off, false)};
+    const auto plan = compile(tracks);
+    const auto meter = findRole(*plan, tracks.front().id, OpRole::LiveInputMeter);
+    const auto gate = findRole(*plan, tracks.front().id, OpRole::LiveInputGate);
+    REQUIRE(meter >= 0);
+    REQUIRE(gate >= 0);
+    CHECK(consumersOf(*plan, meter) == std::vector<int>{gate});
 }
 
 TEST_CASE("A live audio input reads the callback's own samples", "[engine][live-input]") {
@@ -579,8 +583,8 @@ TEST_CASE("An input meter reads the input a monitoring track is hearing",
     // The incumbent reads this off the input device (WaveInputDevice's level
     // measurer); here it is a meter on the input op, so it exists exactly while
     // the op does and sits in the signal rather than beside it. Ahead of the
-    // gate, so a track recording without monitoring still meters what it
-    // records (#2612).
+    // monitor gate, so a track that is not listening still meters its input
+    // (#2612).
     CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::Meter) ==
           inputOpsFor(InputMonitorMode::In, false, OpKind::Meter));
 

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -264,6 +264,31 @@ TEST_CASE("An input nobody is listening to is not a missing binding",
     // Still said where the track is asking for it, which is what the report is
     // for: the host meant to bind one and did not.
     CHECK(reportsUnboundAudio(messagesFor(InputMonitorMode::In)));
+
+    // And said when the switch arrives as values, which is the publish this
+    // change makes possible: the plan does not move, so nothing re-prepares and
+    // nothing would otherwise look at the bindings again.
+    UnboundInputFactory factory;
+    EngineSession session(factory);
+    session.liveInputs().prepare(2, kBlockSize);
+
+    const std::vector<TrackInfo> idle{monitoringTrack(InputMonitorMode::Off, false)};
+    const auto plan = compile(idle);
+    REQUIRE(publish(session, plan, idle).published);
+
+    const std::vector<TrackInfo> listening{monitoringTrack(InputMonitorMode::In, false)};
+    const auto valuesFor = [&plan](const std::vector<TrackInfo>& tracks) {
+        PlanValues values;
+        magda::engine::resolvePlanValues(*plan, tracks, makeMaster(), values);
+        return values;
+    };
+
+    const auto switched = session.publishValues(valuesFor(listening));
+    REQUIRE(switched.published);
+    CHECK(reportsUnboundAudio(switched.messages));
+
+    // Once per plan, not once per fader move.
+    CHECK_FALSE(reportsUnboundAudio(session.publishValues(valuesFor(listening)).messages));
 }
 
 TEST_CASE("What the monitor switch moves is the input gate's silence",

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -208,21 +208,49 @@ magda::engine::TransportSnapshot rolling(double fromBeat) {
 
 }  // namespace
 
-TEST_CASE("An input op is compiled for a track that is armed or monitoring in",
-          "[engine][live-input]") {
-    // monitorsInput(): armed, or monitoring set to In. Auto lights the activity
-    // indicator (receivesLiveMidiInput) but is not audible until the track is
-    // armed, which is what ships and what the compiler gates on.
-    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::AudioInput) == 0);
-    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::AudioInput) == 0);
+TEST_CASE("An input op is compiled for every track that names an input",
+          "[engine][live-input][2612]") {
+    // Whether the track is listening is monitorsInput(): armed, or monitoring
+    // set to In. That is a value on the input gate, so the ops it decides
+    // nothing about are compiled for every switch position.
+    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::AudioInput) == 1);
+    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::AudioInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::In, false, OpKind::AudioInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Off, true, OpKind::AudioInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Auto, true, OpKind::AudioInput) == 1);
 
-    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::MidiInput) == 0);
-    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::MidiInput) == 0);
+    CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::MidiInput) == 1);
+    CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::MidiInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::In, false, OpKind::MidiInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Off, true, OpKind::MidiInput) == 1);
+}
+
+TEST_CASE("What the monitor switch moves is the gate's silence", "[engine][live-input][2612]") {
+    // The switch reaches the engine as values now, which is a publish that
+    // prepares nothing: the plan a monitoring track compiles is the plan an
+    // idle one compiles.
+    const auto silenceOf = [](InputMonitorMode monitor, OpRole role) {
+        const std::vector<TrackInfo> tracks{monitoringTrack(monitor, false)};
+        const auto plan = compile(tracks);
+        const auto gate = findRole(*plan, tracks.front().id, role);
+        REQUIRE(gate >= 0);
+
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(*plan, tracks, makeMaster(), values);
+        return values.ops[static_cast<std::size_t>(gate)].silent;
+    };
+
+    CHECK(silenceOf(InputMonitorMode::Off, OpRole::AudioInputGate));
+    CHECK_FALSE(silenceOf(InputMonitorMode::In, OpRole::AudioInputGate));
+
+    // The hardware MIDI route has no gate: what a track hears of the live MIDI
+    // is the published routing, and the audition shares the op (#2592).
+    const std::vector<TrackInfo> idle{monitoringTrack(InputMonitorMode::Off, false)};
+    CHECK(findRole(*compile(idle), idle.front().id, OpRole::MidiInputGate) < 0);
+
+    const auto monitoring = std::vector<TrackInfo>{monitoringTrack(InputMonitorMode::In, false)};
+    CHECK(magda::engine::planFingerprint(*compile(idle)) ==
+          magda::engine::planFingerprint(*compile(monitoring)));
 }
 
 TEST_CASE("A live audio input reads the callback's own samples", "[engine][live-input]") {
@@ -550,9 +578,11 @@ TEST_CASE("An input meter reads the input a monitoring track is hearing",
           "[engine][live-input][2463]") {
     // The incumbent reads this off the input device (WaveInputDevice's level
     // measurer); here it is a meter on the input op, so it exists exactly while
-    // the op does and sits in the signal rather than beside it.
+    // the op does and sits in the signal rather than beside it. Ahead of the
+    // gate, so a track recording without monitoring still meters what it
+    // records (#2612).
     CHECK(inputOpsFor(InputMonitorMode::Off, false, OpKind::Meter) ==
-          inputOpsFor(InputMonitorMode::In, false, OpKind::Meter) - 1);
+          inputOpsFor(InputMonitorMode::In, false, OpKind::Meter));
 
     {
         const std::vector<TrackInfo> monitoring{monitoringTrack(InputMonitorMode::In, false)};

--- a/tests/engine/test_live_input.cpp
+++ b/tests/engine/test_live_input.cpp
@@ -1,7 +1,9 @@
+#include <algorithm>
 #include <array>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -185,6 +187,11 @@ class LiveInputFactory final : public RuntimeStateFactory {
     magda::engine::LevelTap* inputMeter = nullptr;
 };
 
+/// Binds nothing at all, which is what the app's factory does for live audio
+/// today: EngineRuntimeFactory leaves createAudioInput unoverridden, because
+/// live audio input is #2553's.
+class UnboundInputFactory final : public RuntimeStateFactory {};
+
 RenderContext context() {
     return RenderContext{44100.0, kBlockSize, 2};
 }
@@ -225,6 +232,38 @@ TEST_CASE("A hardware audio input is compiled for every track that names one",
     CHECK(inputOpsFor(InputMonitorMode::Auto, false, OpKind::MidiInput) == 0);
     CHECK(inputOpsFor(InputMonitorMode::In, false, OpKind::MidiInput) == 1);
     CHECK(inputOpsFor(InputMonitorMode::Off, true, OpKind::MidiInput) == 1);
+}
+
+TEST_CASE("An input nobody is listening to is not a missing binding",
+          "[engine][live-input][2612]") {
+    // The host path, not a test factory: with the input op compiled for every
+    // track that names a device, a report per unmonitored track would be a line
+    // about an input the user is not asking to hear -- and in the app, which
+    // binds no live audio at all yet, one per configured track on every
+    // structural publish.
+    const auto messagesFor = [](InputMonitorMode monitor) {
+        UnboundInputFactory factory;
+        EngineSession session(factory);
+        session.liveInputs().prepare(2, kBlockSize);
+
+        const std::vector<TrackInfo> tracks{monitoringTrack(monitor, false)};
+        const auto result = publish(session, compile(tracks), tracks);
+        REQUIRE(result.published);
+        return result.messages;
+    };
+
+    const auto reportsUnboundAudio = [](const std::vector<std::string>& messages) {
+        return std::ranges::any_of(messages, [](const std::string& message) {
+            return message.find("no live audio input bound") != std::string::npos;
+        });
+    };
+
+    CHECK_FALSE(reportsUnboundAudio(messagesFor(InputMonitorMode::Off)));
+    CHECK_FALSE(reportsUnboundAudio(messagesFor(InputMonitorMode::Auto)));
+
+    // Still said where the track is asking for it, which is what the report is
+    // for: the host meant to bind one and did not.
+    CHECK(reportsUnboundAudio(messagesFor(InputMonitorMode::In)));
 }
 
 TEST_CASE("What the monitor switch moves is the input gate's silence",

--- a/tests/engine/test_mod_feeds.cpp
+++ b/tests/engine/test_mod_feeds.cpp
@@ -394,13 +394,13 @@ TEST_CASE("A track's two taps never share a detector", "[engine][mod][feeds]") {
     magda::engine::PlanBindings bindings;
 
     magda::engine::PlanExecutor first;
-    first.prepare(plan, bindings, context, nullptr, values.params.get());
+    first.prepare(plan, bindings, context, nullptr, &values);
     REQUIRE(first.distinctTriggerDetectors() == 2);
 
     // And still two after taking the previous epoch's over, which is where a
     // carry keyed by the track alone would collapse them onto one.
     magda::engine::PlanExecutor second;
-    second.prepare(plan, bindings, context, &first, values.params.get());
+    second.prepare(plan, bindings, context, &first, &values);
     CHECK(second.carriedTriggerDetectors() == 2);
     CHECK(second.distinctTriggerDetectors() == 2);
 }
@@ -425,11 +425,11 @@ TEST_CASE("A modulation tap keeps its detector across a prepare", "[engine][mod]
     magda::engine::PlanBindings bindings;
 
     magda::engine::PlanExecutor first;
-    first.prepare(plan, bindings, context, nullptr, values.params.get());
+    first.prepare(plan, bindings, context, nullptr, &values);
     CHECK(first.carriedTriggerDetectors() == 0);
 
     magda::engine::PlanExecutor second;
-    second.prepare(plan, bindings, context, &first, values.params.get());
+    second.prepare(plan, bindings, context, &first, &values);
     CHECK(second.carriedTriggerDetectors() == 1);
 }
 

--- a/tests/engine/test_mod_lfo.cpp
+++ b/tests/engine/test_mod_lfo.cpp
@@ -1122,19 +1122,22 @@ TEST_CASE("An executor takes over the modifiers of the one it replaces",
     // The device op has no binding here, which prepare reports and carries on
     // from: what is being pinned is the carry, not the render.
     magda::engine::PlanExecutor first;
-    first.prepare(plan, bindings, context, nullptr, values.params.get());
+    first.prepare(plan, bindings, context, nullptr, &values);
     CHECK(first.carriedModifiers() == 0);
 
     magda::engine::PlanExecutor second;
-    second.prepare(plan, bindings, context, &first, values.params.get());
+    second.prepare(plan, bindings, context, &first, &values);
     CHECK(second.carriedModifiers() == 1);
 
     SECTION("but not one that has become something else") {
-        auto changed = *values.params;
-        changed.modifiers[0].kind = ModKind::Random;
+        auto changed = std::make_shared<magda::engine::ParamTable>(*values.params);
+        changed->modifiers[0].kind = ModKind::Random;
+
+        auto edited = values;
+        edited.params = std::move(changed);
 
         magda::engine::PlanExecutor third;
-        third.prepare(plan, bindings, context, &first, &changed);
+        third.prepare(plan, bindings, context, &first, &edited);
         CHECK(third.carriedModifiers() == 0);
     }
 }

--- a/tests/engine/test_render_plan_compiler.cpp
+++ b/tests/engine/test_render_plan_compiler.cpp
@@ -1,11 +1,14 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <optional>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
+#include "exec/PlanValues.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/PlanDump.hpp"
 #include "plan/RenderPlan.hpp"
@@ -1021,9 +1024,12 @@ TEST_CASE("An internal MIDI route reads the source track's MIDI", "[engine][plan
     REQUIRE(destMidi != magda::engine::INVALID_OP_ID);
 
     // Own clips first, arrangement then session, and the routed source behind
-    // them.
+    // them, through the gate the monitor switch lands on (#2612).
     REQUIRE(plan.ops[static_cast<std::size_t>(destMidi)].inputs.size() == 3);
-    CHECK(inputOp(plan, destMidi, 2) == sourceMidi);
+    const auto midiGate = inputOp(plan, destMidi, 2);
+    REQUIRE(midiGate != magda::engine::INVALID_OP_ID);
+    CHECK(plan.ops[static_cast<std::size_t>(midiGate)].key.role == OpRole::MidiInputGate);
+    CHECK(inputOp(plan, midiGate, 0) == sourceMidi);
 }
 
 TEST_CASE("An internal audio route reads the source track's post-mute output",
@@ -1050,7 +1056,10 @@ TEST_CASE("An internal audio route reads the source track's post-mute output",
     REQUIRE(destInput != magda::engine::INVALID_OP_ID);
 
     REQUIRE(plan.ops[static_cast<std::size_t>(destInput)].inputs.size() == 3);
-    CHECK(inputOp(plan, destInput, 2) == sourceMute);
+    const auto audioGate = inputOp(plan, destInput, 2);
+    REQUIRE(audioGate != magda::engine::INVALID_OP_ID);
+    CHECK(plan.ops[static_cast<std::size_t>(audioGate)].key.role == OpRole::AudioInputGate);
+    CHECK(inputOp(plan, audioGate, 0) == sourceMute);
 }
 
 TEST_CASE("Mute is applied after the meter and the sidechain tap", "[engine][plan][compiler]") {
@@ -1179,48 +1188,53 @@ TEST_CASE("A malformed track route is reported, not reinterpreted", "[engine][pl
     }
 }
 
-TEST_CASE("An inactive internal route is not an ordering dependency", "[engine][plan][compiler]") {
-    // Track 2 has an input from track 1 but is neither armed nor monitoring, so
-    // it reads nothing. Track 1 sidechains from track 2. Counting the dead
-    // route as a dependency would close a cycle and cost the live sidechain.
-    auto compressor = makeEffect(7);
-    compressor.sidechainPort = magda::monoAudioSidechain;
-    compressor.sidechain.type = SidechainConfig::Type::Audio;
-    compressor.sidechain.sourceTrackId = 2;
+TEST_CASE("An internal route is an ordering dependency however the track monitors",
+          "[engine][plan][compiler][2612]") {
+    // Track 2 takes its input from track 1, and track 1 sidechains from track
+    // 2: a cycle, which the breaker resolves by dropping a connection. The
+    // monitor switch decides whether track 2 hears the route, not whether the
+    // route is there, so both switch positions compile the same plan.
+    const auto planFor = [](InputMonitorMode monitor) {
+        auto compressor = makeEffect(7);
+        compressor.sidechainPort = magda::monoAudioSidechain;
+        compressor.sidechain.type = SidechainConfig::Type::Audio;
+        compressor.sidechain.sourceTrackId = 2;
 
-    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
-    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
-    tracks[1].audioInputDevice = "track:1";
-    tracks[1].recordArmed = false;
-    tracks[1].inputMonitor = InputMonitorMode::Off;
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+        tracks[1].audioInputDevice = "track:1";
+        tracks[1].inputMonitor = monitor;
+        return magda::engine::compileRenderPlan(tracks, makeMaster());
+    };
 
-    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
-    requireWellFormed(plan);
-    CHECK(plan.diagnostics.empty());
+    const auto idle = planFor(InputMonitorMode::Off);
+    const auto monitoring = planFor(InputMonitorMode::In);
+    requireWellFormed(idle);
+    requireWellFormed(monitoring);
 
-    // Track 2 is compiled first and its output reaches the sidechain slot.
-    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
-    magda::engine::OpId sourceMeter = magda::engine::INVALID_OP_ID;
-    for (const auto op : opsWithRole(plan, OpRole::TrackMeter))
-        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
-            sourceMeter = op;
-    REQUIRE(sourceMeter != magda::engine::INVALID_OP_ID);
-    CHECK(inputOp(plan, device, 2) == sourceMeter);
+    CHECK(magda::engine::planFingerprint(idle) == magda::engine::planFingerprint(monitoring));
+    CHECK(idle.diagnostics == monitoring.diagnostics);
 }
 
-TEST_CASE("An unmonitored MIDI route does not make its source compile MIDI",
-          "[engine][plan][compiler]") {
-    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
-    tracks[1].midiInputDevice = "track:1";
-    tracks[1].inputMonitor = InputMonitorMode::Off;
+TEST_CASE("A MIDI route makes its source compile MIDI however the destination monitors",
+          "[engine][plan][compiler][2612]") {
+    // One track's monitor button deciding another track's op set is what this
+    // is not: track 1 has no MIDI consumer of its own, and the route is what
+    // gives it one.
+    const auto planFor = [](InputMonitorMode monitor) {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[1].midiInputDevice = "track:1";
+        tracks[1].inputMonitor = monitor;
+        return magda::engine::compileRenderPlan(tracks, makeMaster());
+    };
 
-    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
-    requireWellFormed(plan);
+    const auto idle = planFor(InputMonitorMode::Off);
+    const auto monitoring = planFor(InputMonitorMode::In);
+    requireWellFormed(idle);
 
-    // Track 1 has no MIDI consumer of its own and nothing reads its MIDI, so
-    // compiling clip MIDI for it would leave ops no one consumes.
-    CHECK(countRole(plan, OpRole::ClipMidi) == 0);
-    CHECK(countRole(plan, OpRole::TrackMidiInput) == 0);
+    CHECK(countRole(idle, OpRole::ClipMidi) == 1);
+    CHECK(countRole(idle, OpRole::TrackMidiInput) == 2);
+    CHECK(magda::engine::planFingerprint(idle) == magda::engine::planFingerprint(monitoring));
 }
 
 TEST_CASE("A rack-level sidechain is an edge to the modulation system",
@@ -1685,45 +1699,49 @@ TEST_CASE("Sidechain discovery reaches every section emission does", "[engine][p
     CHECK(inputOp(plan, device, 2) == sourceMeter);
 }
 
-TEST_CASE("Auto input monitoring only counts while the track is armed",
-          "[engine][plan][compiler]") {
-    // Automatic monitoring passes input only while
-    // armed. Emitting a live op for an unarmed Auto track would both add a op
-    // the engine keeps silent and mark the whole chain downstream Live.
-    SECTION("unarmed Auto emits no live input") {
-        std::vector<TrackInfo> tracks{makeTrack(1)};
-        tracks[0].inputMonitor = InputMonitorMode::Auto;
-        tracks[0].audioInputDevice = "Input 1";
-        tracks[0].midiInputDevice = "Keyboard";
+TEST_CASE("Monitoring is a value on the input gate, not a shape",
+          "[engine][plan][compiler][2612]") {
+    // Auto passes input only while armed, In without arming, Off never. All
+    // four compile the same ops: what the switch moves is the gate's silence,
+    // so flipping it publishes values and rebuilds nothing.
+    const auto trackWith = [](InputMonitorMode monitor, bool armed) {
+        auto track = makeTrack(1);
+        track.inputMonitor = monitor;
+        track.recordArmed = armed;
+        track.audioInputDevice = "Input 1";
+        track.midiInputDevice = "Keyboard";
+        return track;
+    };
 
+    const auto gateIsSilent = [](const std::vector<TrackInfo>& tracks, const RenderPlan& plan) {
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(plan, tracks, makeMaster(), values);
+        const auto gates = opsWithRole(plan, OpRole::AudioInputGate);
+        REQUIRE(gates.size() == 1);
+        return values.ops[static_cast<std::size_t>(gates.front())].silent;
+    };
+
+    const std::vector<std::pair<InputMonitorMode, bool>> switches{{InputMonitorMode::Off, false},
+                                                                  {InputMonitorMode::Auto, false},
+                                                                  {InputMonitorMode::Auto, true},
+                                                                  {InputMonitorMode::In, false}};
+
+    std::optional<std::uint64_t> shape;
+    for (const auto& [monitor, armed] : switches) {
+        const std::vector<TrackInfo> tracks{trackWith(monitor, armed)};
         const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
         requireWellFormed(plan);
 
-        CHECK(countRole(plan, OpRole::LiveAudioInput) == 0);
-        CHECK(countRole(plan, OpRole::LiveMidiInput) == 0);
-        for (const auto& op : plan.ops)
-            CHECK(op.liveness == magda::engine::LivenessDomain::Deterministic);
-    }
-
-    SECTION("armed Auto emits it") {
-        std::vector<TrackInfo> tracks{makeTrack(1)};
-        tracks[0].inputMonitor = InputMonitorMode::Auto;
-        tracks[0].recordArmed = true;
-        tracks[0].audioInputDevice = "Input 1";
-
-        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
-        requireWellFormed(plan);
         CHECK(countRole(plan, OpRole::LiveAudioInput) == 1);
-    }
+        CHECK(countRole(plan, OpRole::LiveInputMeter) == 1);
+        CHECK(countRole(plan, OpRole::LiveMidiInput) == 1);
 
-    SECTION("In emits it without arming") {
-        std::vector<TrackInfo> tracks{makeTrack(1)};
-        tracks[0].inputMonitor = InputMonitorMode::In;
-        tracks[0].audioInputDevice = "Input 1";
+        const auto fingerprint = magda::engine::planFingerprint(plan);
+        if (shape)
+            CHECK(*shape == fingerprint);
+        shape = fingerprint;
 
-        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
-        requireWellFormed(plan);
-        CHECK(countRole(plan, OpRole::LiveAudioInput) == 1);
+        CHECK(gateIsSilent(tracks, plan) == !tracks.front().monitorsInput());
     }
 }
 

--- a/tests/engine/test_render_plan_compiler.cpp
+++ b/tests/engine/test_render_plan_compiler.cpp
@@ -1,9 +1,7 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
-#include <optional>
 #include <set>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "core/RackInfo.hpp"
@@ -1024,12 +1022,9 @@ TEST_CASE("An internal MIDI route reads the source track's MIDI", "[engine][plan
     REQUIRE(destMidi != magda::engine::INVALID_OP_ID);
 
     // Own clips first, arrangement then session, and the routed source behind
-    // them, through the gate the monitor switch lands on (#2612).
+    // them.
     REQUIRE(plan.ops[static_cast<std::size_t>(destMidi)].inputs.size() == 3);
-    const auto midiGate = inputOp(plan, destMidi, 2);
-    REQUIRE(midiGate != magda::engine::INVALID_OP_ID);
-    CHECK(plan.ops[static_cast<std::size_t>(midiGate)].key.role == OpRole::MidiInputGate);
-    CHECK(inputOp(plan, midiGate, 0) == sourceMidi);
+    CHECK(inputOp(plan, destMidi, 2) == sourceMidi);
 }
 
 TEST_CASE("An internal audio route reads the source track's post-mute output",
@@ -1056,10 +1051,7 @@ TEST_CASE("An internal audio route reads the source track's post-mute output",
     REQUIRE(destInput != magda::engine::INVALID_OP_ID);
 
     REQUIRE(plan.ops[static_cast<std::size_t>(destInput)].inputs.size() == 3);
-    const auto audioGate = inputOp(plan, destInput, 2);
-    REQUIRE(audioGate != magda::engine::INVALID_OP_ID);
-    CHECK(plan.ops[static_cast<std::size_t>(audioGate)].key.role == OpRole::AudioInputGate);
-    CHECK(inputOp(plan, audioGate, 0) == sourceMute);
+    CHECK(inputOp(plan, destInput, 2) == sourceMute);
 }
 
 TEST_CASE("Mute is applied after the meter and the sidechain tap", "[engine][plan][compiler]") {
@@ -1188,53 +1180,48 @@ TEST_CASE("A malformed track route is reported, not reinterpreted", "[engine][pl
     }
 }
 
-TEST_CASE("An internal route is an ordering dependency however the track monitors",
-          "[engine][plan][compiler][2612]") {
-    // Track 2 takes its input from track 1, and track 1 sidechains from track
-    // 2: a cycle, which the breaker resolves by dropping a connection. The
-    // monitor switch decides whether track 2 hears the route, not whether the
-    // route is there, so both switch positions compile the same plan.
-    const auto planFor = [](InputMonitorMode monitor) {
-        auto compressor = makeEffect(7);
-        compressor.sidechainPort = magda::monoAudioSidechain;
-        compressor.sidechain.type = SidechainConfig::Type::Audio;
-        compressor.sidechain.sourceTrackId = 2;
+TEST_CASE("An inactive internal route is not an ordering dependency", "[engine][plan][compiler]") {
+    // Track 2 has an input from track 1 but is neither armed nor monitoring, so
+    // it reads nothing. Track 1 sidechains from track 2. Counting the dead
+    // route as a dependency would close a cycle and cost the live sidechain.
+    auto compressor = makeEffect(7);
+    compressor.sidechainPort = magda::monoAudioSidechain;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
 
-        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
-        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
-        tracks[1].audioInputDevice = "track:1";
-        tracks[1].inputMonitor = monitor;
-        return magda::engine::compileRenderPlan(tracks, makeMaster());
-    };
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    tracks[1].audioInputDevice = "track:1";
+    tracks[1].recordArmed = false;
+    tracks[1].inputMonitor = InputMonitorMode::Off;
 
-    const auto idle = planFor(InputMonitorMode::Off);
-    const auto monitoring = planFor(InputMonitorMode::In);
-    requireWellFormed(idle);
-    requireWellFormed(monitoring);
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
 
-    CHECK(magda::engine::planFingerprint(idle) == magda::engine::planFingerprint(monitoring));
-    CHECK(idle.diagnostics == monitoring.diagnostics);
+    // Track 2 is compiled first and its output reaches the sidechain slot.
+    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
+    magda::engine::OpId sourceMeter = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMeter))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            sourceMeter = op;
+    REQUIRE(sourceMeter != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, device, 2) == sourceMeter);
 }
 
-TEST_CASE("A MIDI route makes its source compile MIDI however the destination monitors",
-          "[engine][plan][compiler][2612]") {
-    // One track's monitor button deciding another track's op set is what this
-    // is not: track 1 has no MIDI consumer of its own, and the route is what
-    // gives it one.
-    const auto planFor = [](InputMonitorMode monitor) {
-        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
-        tracks[1].midiInputDevice = "track:1";
-        tracks[1].inputMonitor = monitor;
-        return magda::engine::compileRenderPlan(tracks, makeMaster());
-    };
+TEST_CASE("An unmonitored MIDI route does not make its source compile MIDI",
+          "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[1].midiInputDevice = "track:1";
+    tracks[1].inputMonitor = InputMonitorMode::Off;
 
-    const auto idle = planFor(InputMonitorMode::Off);
-    const auto monitoring = planFor(InputMonitorMode::In);
-    requireWellFormed(idle);
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
 
-    CHECK(countRole(idle, OpRole::ClipMidi) == 1);
-    CHECK(countRole(idle, OpRole::TrackMidiInput) == 2);
-    CHECK(magda::engine::planFingerprint(idle) == magda::engine::planFingerprint(monitoring));
+    // Track 1 has no MIDI consumer of its own and nothing reads its MIDI, so
+    // compiling clip MIDI for it would leave ops no one consumes.
+    CHECK(countRole(plan, OpRole::ClipMidi) == 0);
+    CHECK(countRole(plan, OpRole::TrackMidiInput) == 0);
 }
 
 TEST_CASE("A rack-level sidechain is an edge to the modulation system",
@@ -1699,11 +1686,26 @@ TEST_CASE("Sidechain discovery reaches every section emission does", "[engine][p
     CHECK(inputOp(plan, device, 2) == sourceMeter);
 }
 
-TEST_CASE("Monitoring is a value on the input gate, not a shape",
-          "[engine][plan][compiler][2612]") {
-    // Auto passes input only while armed, In without arming, Off never. All
-    // four compile the same ops: what the switch moves is the gate's silence,
-    // so flipping it publishes values and rebuilds nothing.
+namespace {
+
+/// Whether the track hears its live audio input this publish.
+bool inputGateIsSilent(const std::vector<TrackInfo>& tracks, const RenderPlan& plan) {
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(plan, tracks, makeMaster(), values);
+
+    const auto gates = opsWithRole(plan, OpRole::LiveInputGate);
+    REQUIRE(gates.size() == 1);
+    return values.ops[static_cast<std::size_t>(gates.front())].silent;
+}
+
+}  // namespace
+
+TEST_CASE("Auto input monitoring only counts while the track is armed",
+          "[engine][plan][compiler]") {
+    // Automatic monitoring passes input only while armed. For the hardware
+    // audio input that is the gate's value, since the op and its meter are
+    // compiled either way (#2612). For live MIDI it still decides whether the
+    // op exists at all.
     const auto trackWith = [](InputMonitorMode monitor, bool armed) {
         auto track = makeTrack(1);
         track.inputMonitor = monitor;
@@ -1713,36 +1715,58 @@ TEST_CASE("Monitoring is a value on the input gate, not a shape",
         return track;
     };
 
-    const auto gateIsSilent = [](const std::vector<TrackInfo>& tracks, const RenderPlan& plan) {
-        magda::engine::PlanValues values;
-        magda::engine::resolvePlanValues(plan, tracks, makeMaster(), values);
-        const auto gates = opsWithRole(plan, OpRole::AudioInputGate);
-        REQUIRE(gates.size() == 1);
-        return values.ops[static_cast<std::size_t>(gates.front())].silent;
-    };
-
-    const std::vector<std::pair<InputMonitorMode, bool>> switches{{InputMonitorMode::Off, false},
-                                                                  {InputMonitorMode::Auto, false},
-                                                                  {InputMonitorMode::Auto, true},
-                                                                  {InputMonitorMode::In, false}};
-
-    std::optional<std::uint64_t> shape;
-    for (const auto& [monitor, armed] : switches) {
-        const std::vector<TrackInfo> tracks{trackWith(monitor, armed)};
+    SECTION("unarmed Auto hears neither") {
+        const std::vector<TrackInfo> tracks{trackWith(InputMonitorMode::Auto, false)};
         const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
         requireWellFormed(plan);
 
         CHECK(countRole(plan, OpRole::LiveAudioInput) == 1);
-        CHECK(countRole(plan, OpRole::LiveInputMeter) == 1);
-        CHECK(countRole(plan, OpRole::LiveMidiInput) == 1);
-
-        const auto fingerprint = magda::engine::planFingerprint(plan);
-        if (shape)
-            CHECK(*shape == fingerprint);
-        shape = fingerprint;
-
-        CHECK(gateIsSilent(tracks, plan) == !tracks.front().monitorsInput());
+        CHECK(inputGateIsSilent(tracks, plan));
+        CHECK(countRole(plan, OpRole::LiveMidiInput) == 0);
     }
+
+    SECTION("armed Auto hears both") {
+        const std::vector<TrackInfo> tracks{trackWith(InputMonitorMode::Auto, true)};
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        CHECK(countRole(plan, OpRole::LiveAudioInput) == 1);
+        CHECK_FALSE(inputGateIsSilent(tracks, plan));
+        CHECK(countRole(plan, OpRole::LiveMidiInput) == 1);
+    }
+
+    SECTION("In hears both without arming") {
+        const std::vector<TrackInfo> tracks{trackWith(InputMonitorMode::In, false)};
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        CHECK(countRole(plan, OpRole::LiveAudioInput) == 1);
+        CHECK_FALSE(inputGateIsSilent(tracks, plan));
+        CHECK(countRole(plan, OpRole::LiveMidiInput) == 1);
+    }
+}
+
+TEST_CASE("The monitor switch does not move the plan's shape for a hardware input",
+          "[engine][plan][compiler][2612]") {
+    // The whole point of the gate: every switch position compiles one plan, so
+    // the host publishes values and prepares nothing. A hardware input only --
+    // a route from another track is an ordering dependency, and still comes and
+    // goes with the switch.
+    const auto planFor = [](InputMonitorMode monitor, bool armed) {
+        auto track = makeTrack(1);
+        track.inputMonitor = monitor;
+        track.recordArmed = armed;
+        track.audioInputDevice = "Input 1";
+        return magda::engine::compileRenderPlan({track}, makeMaster());
+    };
+
+    const auto idle = planFor(InputMonitorMode::Off, false);
+    requireWellFormed(idle);
+    const auto shape = magda::engine::planFingerprint(idle);
+
+    CHECK(magda::engine::planFingerprint(planFor(InputMonitorMode::Auto, false)) == shape);
+    CHECK(magda::engine::planFingerprint(planFor(InputMonitorMode::Auto, true)) == shape);
+    CHECK(magda::engine::planFingerprint(planFor(InputMonitorMode::In, false)) == shape);
 }
 
 TEST_CASE("Audition gives every track that reads MIDI something to preview through",


### PR DESCRIPTION
Part of #2612 — the hardware **audio** input half. #2612 stays open for the rest.

## What it does

A track that names an audio input device compiles its `AudioInput` op and the
`LiveInputMeter` beside it whether or not the track is monitoring. The input
reaches the chain through a gate (`OpKind::Gain`, `OpRole::LiveInputGate`) whose
`OpValue::silent` is resolved from `monitorsInput()`. Flipping the switch changes one
boolean in the values table: the host publishes values, prepares nothing, and every
instance in the chain keeps its state and its tail.

The meter sits **ahead** of the gate, so a track that records without monitoring still
meters what it records.

## What it deliberately leaves alone

- **A route from another track** (`audioInputDevice = "track:1"`, and the MIDI
  equivalent). Those are ordering dependencies as well as connections. Resolving one
  unconditionally makes a dormant route close the same cycles a live one closes: where a
  track sidechains from the track it takes input from, the breaker drops the sidechain.
  That is already what happens the moment the track monitors — measured, both plans
  identical — but the state where it worked would disappear. It needs an explicit
  feedback policy, not a side effect. Still gated in `activeAudioInputRoute`.
- **Live MIDI.** Unchanged, so no new unbound-binding reports and no corpus churn.
- **The executor's unbound-live-input reports.** Reverted from the first pass. With the
  change confined to audio, no fixture names an audio input and nothing new is reported.
  Distinguishing offline from live binding belongs in its own change.

## Cost

Measured in a Debug build, 512 samples at 44.1 kHz (budget 11 610 µs/block):

| project | µs/block |
|---|---|
| bare track, no input named | 2.10 |
| same track naming an unmonitored hardware input | 4.67 |
| **delta per such track** | **2.57 (0.022% of budget)** |

Four extra ops — input, meter, gate, one mix-edge delay. Release is lower, and only
tracks pointed at hardware pay it. Removing it entirely wants a values-time prune of the
ops nothing audible reads; that pays off for mute, solo and bypass too, and is filed
separately.

## Tests

`[2612]`: the plan's fingerprint is identical across Off / Auto / Auto+armed / In for a
track naming a hardware input; the gate's silence follows `monitorsInput()`; the input
meter is compiled in every position; the input reaches the chain through the gate and
nowhere else. `Auto input monitoring only counts while the track is armed` now asserts
the audio half as a value and the MIDI half as a shape. In the host publish suite,
naming an audio input is a shape change and monitoring it is not.

`make test` — 4035 cases, 1,754,797 assertions, 0 failures, 13 skipped.
`make test-juce` — all passed.

## Before merging

The native engine is not the default, so none of this is audible unless the app is
launched with `MAGDA_AUDIO_ENGINE=magda`. Under that, worth checking by hand: monitoring
off — input meter moves, recording captures, nothing heard through the track; monitoring
on — heard, and toggling during playback keeps plugin state and tails; and both armed and
unarmed.

One thing that check will expose, which this PR does not change: `monitorsInput()` is
`recordArmed || inputMonitor == In`, so **arming a track makes its input audible even with
the monitor switch set to Off**. The gate preserves that rule exactly. Whether it is the
intended control is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rCviRzaXVzLAjNKwVCxN