### PR TITLE
Let the model own a device's parameters on the native engine

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -276,6 +276,8 @@ set(_magda_device_sdk_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceServices.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceSessionKey.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/IFaustEditorModel.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceCatalogParameters.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceCatalogParameters.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceStateHydration.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/DeviceStateHydration.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/plugins/InternalPluginRegistry.cpp"

--- a/magda/daw/audio/plugins/DeviceCatalogParameters.cpp
+++ b/magda/daw/audio/plugins/DeviceCatalogParameters.cpp
@@ -1,0 +1,95 @@
+#include "plugins/DeviceCatalogParameters.hpp"
+
+#include <algorithm>
+
+#include "core/DeviceState.hpp"
+#include "plugins/InternalPluginRegistry.hpp"
+#include "plugins/MagdaDevice.hpp"
+#include "plugins/compiled/CompiledPluginRegistry.hpp"
+
+namespace magda::daw::audio {
+
+juce::ValueTree deviceStateTree(const juce::String& savedState) {
+    if (magda::device_state::looksLikeLegacyEngineState(savedState)) {
+        auto tree = magda::device_state::legacyEngineStateTree(savedState);
+        adoptCanonicalPluginType(tree);
+        return tree;
+    }
+
+    const auto doc = magda::device_state::decode(savedState);
+    if (!doc)
+        return {};
+
+    auto tree = magda::device_state::toValueTree(doc->root);
+    tree.setProperty(juce::Identifier("type"), doc->deviceType, nullptr);
+    return tree;
+}
+
+std::unique_ptr<MagdaDevice> createDetachedDevice(const juce::String& pluginId,
+                                                  const juce::String& savedState) {
+    // No session key: the services behind one are a running engine's, and
+    // nothing here may reach them.
+    juce::ValueTree state(juce::Identifier("PLUGIN"));
+    state.setProperty(juce::Identifier("type"), pluginId, nullptr);
+    const DevicePluginCreationContext context{
+        .sessionKey = {}, .state = std::move(state), .isNewPlugin = true};
+
+    // The internal registry first, because that is the catalog an id is
+    // canonicalised against; a compiled device is not in it.
+    auto create = [&context, &pluginId]() -> std::unique_ptr<MagdaDevice> {
+        if (const auto* spec = findInternalPluginSpec(pluginId);
+            spec != nullptr && spec->createDevice != nullptr)
+            return spec->createDevice(context);
+
+        if (const auto* spec = compiled::findCompiledPluginSpec(pluginId);
+            spec != nullptr && spec->createDevice != nullptr)
+            return spec->createDevice(context);
+
+        return {};
+    };
+
+    auto device = create();
+    if (device == nullptr || savedState.isEmpty())
+        return device;
+
+    if (const auto tree = deviceStateTree(savedState); tree.isValid())
+        device->restoreState(tree);
+
+    return device;
+}
+
+bool seedDeclaredParameters(magda::DeviceInfo& device) {
+    if (device.format != magda::PluginFormat::Internal)
+        return false;
+
+    const auto declared = createDetachedDevice(device.pluginId, device.pluginState);
+    if (declared == nullptr)
+        return false;
+
+    bool added = false;
+    int slot = 0;
+    for (auto info : declared->parameters()) {
+        // Declaration order for a device that left paramIndex unset, which is
+        // the fallback both engine adapters address it by.
+        const int index = info.paramIndex >= 0 ? info.paramIndex : slot;
+        ++slot;
+
+        if (device.findParameterByIndex(index) != nullptr)
+            continue;
+
+        info.paramIndex = index;
+        info.currentValue = info.defaultValue;
+        device.parameters.push_back(std::move(info));
+        added = true;
+    }
+
+    if (added)
+        std::stable_sort(device.parameters.begin(), device.parameters.end(),
+                         [](const magda::ParameterInfo& a, const magda::ParameterInfo& b) {
+                             return a.paramIndex < b.paramIndex;
+                         });
+
+    return added;
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/DeviceCatalogParameters.hpp
+++ b/magda/daw/audio/plugins/DeviceCatalogParameters.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
+
+#include <memory>
+
+#include "core/DeviceInfo.hpp"
+
+namespace magda::daw::audio {
+
+class MagdaDevice;
+
+/**
+ * @brief A registered MAGDA device, built off the catalog to be questioned and
+ *        dropped.
+ *
+ * Neither engine is asked, so both get the same answer and no Edit is needed to
+ * hold a plugin in - which the native engine does not have (#2601). @p
+ * savedState is restored into it when given, for the devices whose parameter
+ * set depends on it (the runtime Faust device reads its slots out of its dsp
+ * source). Null for an id no catalog holds and for a device that is still a
+ * host plugin rather than a MagdaDevice.
+ */
+std::unique_ptr<MagdaDevice> createDetachedDevice(const juce::String& pluginId,
+                                                  const juce::String& savedState = {});
+
+/// A device's saved state as a tree, in whichever format the project holds it:
+/// most internal devices in a project folder are still saved as the engine's v1
+/// XML, which `decode()` refuses by design (#2602). Invalid for state neither
+/// reader accepts.
+juce::ValueTree deviceStateTree(const juce::String& savedState);
+
+/**
+ * @brief Give the model every parameter a MAGDA device declares (#2613).
+ *
+ * `DeviceInfo::parameters` is the sole authority for an internal device's
+ * parameters (#2317), and only the fork ever filled it: the array was read off
+ * a plugin living in the fork's Edit. A device added under the native engine
+ * had none, so every write to one was dropped for want of an entry to land on.
+ *
+ * Appends the declared parameters the model is missing, each at its own
+ * paramIndex and default value. Entries the model already carries are left
+ * alone, values included. Returns true when the device was changed.
+ */
+bool seedDeclaredParameters(magda::DeviceInfo& device);
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/DeviceCatalogParameters.hpp
+++ b/magda/daw/audio/plugins/DeviceCatalogParameters.hpp
@@ -12,36 +12,23 @@ namespace magda::daw::audio {
 class MagdaDevice;
 
 /**
- * @brief A registered MAGDA device, built off the catalog to be questioned and
- *        dropped.
+ * @brief A registered MAGDA device built off the catalog, with no Edit behind it (#2601).
  *
- * Neither engine is asked, so both get the same answer and no Edit is needed to
- * hold a plugin in - which the native engine does not have (#2601). @p
- * savedState is restored into it when given, for the devices whose parameter
- * set depends on it (the runtime Faust device reads its slots out of its dsp
- * source). Null for an id no catalog holds and for a device that is still a
- * host plugin rather than a MagdaDevice.
+ * @p savedState is restored into it when given, for devices whose parameter set
+ * depends on it. Null for an unknown id or a device that is still a host plugin.
  */
 std::unique_ptr<MagdaDevice> createDetachedDevice(const juce::String& pluginId,
                                                   const juce::String& savedState = {});
 
-/// A device's saved state as a tree, in whichever format the project holds it:
-/// most internal devices in a project folder are still saved as the engine's v1
-/// XML, which `decode()` refuses by design (#2602). Invalid for state neither
-/// reader accepts.
+/// A device's saved state as a tree, in either format a project holds it in;
+/// `decode()` refuses the engine's v1 XML by design (#2602). Invalid when unreadable.
 juce::ValueTree deviceStateTree(const juce::String& savedState);
 
 /**
- * @brief Give the model every parameter a MAGDA device declares (#2613).
+ * @brief Append the declared parameters `DeviceInfo::parameters` is missing (#2613).
  *
- * `DeviceInfo::parameters` is the sole authority for an internal device's
- * parameters (#2317), and only the fork ever filled it: the array was read off
- * a plugin living in the fork's Edit. A device added under the native engine
- * had none, so every write to one was dropped for want of an entry to land on.
- *
- * Appends the declared parameters the model is missing, each at its own
- * paramIndex and default value. Entries the model already carries are left
- * alone, values included. Returns true when the device was changed.
+ * Each at its own paramIndex and default value; existing entries keep their
+ * values. Returns true when the device was changed.
  */
 bool seedDeclaredParameters(magda::DeviceInfo& device);
 

--- a/magda/daw/audio/plugins/DeviceStateHydration.cpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.cpp
@@ -9,8 +9,8 @@
 #include "core/DeviceState.hpp"
 #include "core/ParameterUtils.hpp"
 #include "core/TrackInfo.hpp"
+#include "plugins/DeviceCatalogParameters.hpp"
 #include "plugins/DevicePluginHandle.hpp"
-#include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/MagdaDevice.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
 
@@ -78,21 +78,7 @@ ParamDomain resolveDomain(const DeviceInfo& device, const ds::Doc& doc,
 /// reads its slots out of its dsp source). Null for a device that has not
 /// crossed to MagdaDevice, whose documents were never normalised.
 std::unique_ptr<MagdaDevice> metadataDevice(const juce::String& pluginId, const ds::Doc& doc) {
-    auto create = [&pluginId]() -> std::unique_ptr<MagdaDevice> {
-        juce::ValueTree state{juce::Identifier("PLUGIN")};
-        state.setProperty(juce::Identifier("type"), pluginId, nullptr);
-        const DevicePluginCreationContext context{
-            .sessionKey = {}, .state = std::move(state), .isNewPlugin = true};
-        if (const auto* spec = findInternalPluginSpec(pluginId);
-            spec != nullptr && spec->createDevice != nullptr)
-            return spec->createDevice(context);
-        if (const auto* spec = compiled::findCompiledPluginSpec(pluginId);
-            spec != nullptr && spec->createDevice != nullptr)
-            return spec->createDevice(context);
-        return {};
-    };
-
-    auto device = create();
+    auto device = createDetachedDevice(pluginId);
     if (device != nullptr) {
         auto tree = ds::toValueTree(doc.root);
         tree.setProperty(juce::Identifier("type"), doc.deviceType, nullptr);
@@ -250,10 +236,15 @@ bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& prov
     return added;
 }
 
+void completeDeviceParameters(DeviceInfo& device, const Provenance& provenance) {
+    hydrateParametersFromDeviceState(device, provenance);
+    seedDeclaredParameters(device);
+}
+
 void hydrateChainElements(std::vector<ChainElement>& elements, const Provenance& provenance) {
     chain_walk::forEachDevice(elements, ChainNodePath{}, chain_walk::Pads::Enter,
                               [&provenance](DeviceInfo& device, const ChainNodePath&) {
-                                  hydrateParametersFromDeviceState(device, provenance);
+                                  completeDeviceParameters(device, provenance);
                                   return true;
                               });
 }
@@ -270,9 +261,9 @@ void hydrateStagedProject(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack
     auto hydrateTrack = [&provenance](TrackInfo& track) {
         hydrateChainElements(track.chain.fxChainElements, provenance);
         for (auto& element : track.chain.postFxChainElements)
-            hydrateParametersFromDeviceState(element.device, provenance);
+            completeDeviceParameters(element.device, provenance);
         for (auto& element : track.chain.mixerAnalysisElements)
-            hydrateParametersFromDeviceState(element.device, provenance);
+            completeDeviceParameters(element.device, provenance);
     };
 
     for (auto& track : tracks)

--- a/magda/daw/audio/plugins/DeviceStateHydration.cpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.cpp
@@ -23,12 +23,8 @@ namespace ds = magda::device_state;
 /// The domain a pre-#2317 document's parameter record used.
 enum class ParamDomain { Display, Normalized };
 
-/// Devices that were already behind `TracktionMagdaDevicePlugin` before the
-/// `paramsAreDisplayDomain` marker existed. Their unmarked documents have TWO
-/// eras: 0.19 captures from the retired host-native plugins hold display
-/// values, later captures from the wrapper hold normalised slots. Everything
-/// wrapped since the marker always writes it, so an unmarked document for any
-/// other device predates its wrapper and can only be display-domain.
+/// Devices wrapped before the `paramsAreDisplayDomain` marker existed: their
+/// unmarked documents may hold display values (0.19) or normalised slots (later).
 bool wrappedBeforeDomainMarker(const juce::String& deviceType) {
     static constexpr std::array<const char*, 5> kPreMarkerWrapped{
         "toneGenerator", "sidechain", "faust-fx", "oscilloscope", "spectrumanalyzer",
@@ -37,12 +33,8 @@ bool wrappedBeforeDomainMarker(const juce::String& deviceType) {
                        [&deviceType](const char* id) { return deviceType == id; });
 }
 
-/// Released-state-first fallback for a two-era document with no provenance:
-/// any value outside [0, 1] can only be display-domain (a 0.19 sidechain
-/// document always carries one - its release defaults to 15 ms). The residue -
-/// every value inside the unit interval - is read as normalised, which is
-/// exact for slots whose display range IS the unit interval and correct for
-/// wrapper-era captures of the rest.
+/// A two-era document with no provenance: a value outside [0, 1] can only be
+/// display-domain; all inside is read as normalised.
 bool anyValueOutsideUnitInterval(const ds::Doc& doc) {
     return std::any_of(doc.params.begin(), doc.params.end(), [](const ds::ParamValue& saved) {
         return saved.value < -1.0e-4f || saved.value > 1.0f + 1.0e-4f;
@@ -54,8 +46,7 @@ ParamDomain resolveDomain(const DeviceInfo& device, const ds::Doc& doc,
     if (doc.paramsAreDisplayDomain)
         return ParamDomain::Display;
 
-    // The compiled Faust pack's parameters were always normalised slots, and
-    // so were its documents, in every era.
+    // The compiled Faust pack's documents were normalised slots in every era.
     if (compiled::findCompiledPluginSpec(device.pluginId) != nullptr)
         return ParamDomain::Normalized;
 
@@ -65,18 +56,13 @@ ParamDomain resolveDomain(const DeviceInfo& device, const ds::Doc& doc,
         return anyValueOutsideUnitInterval(doc) ? ParamDomain::Display : ParamDomain::Normalized;
     }
 
-    // Every other unmarked document was captured from a plugin whose
-    // parameters ran in their own display range: either the device has never
-    // been wrapped, or it crossed after the marker existed and the document
-    // predates the crossing.
+    // Every other unmarked document predates its device's wrapper.
     return ParamDomain::Display;
 }
 
-/// A throwaway SDK device for the parameter metadata a normalised value needs
-/// to become a display one. Restored from the document's own root first, for
-/// the devices whose parameter set depends on it (the runtime Faust device
-/// reads its slots out of its dsp source). Null for a device that has not
-/// crossed to MagdaDevice, whose documents were never normalised.
+/// A throwaway SDK device for the parameter metadata, restored from the
+/// document's root for devices whose parameter set depends on it. Null for a
+/// device that is not a MagdaDevice.
 std::unique_ptr<MagdaDevice> metadataDevice(const juce::String& pluginId, const ds::Doc& doc) {
     auto device = createDetachedDevice(pluginId);
     if (device != nullptr) {
@@ -98,9 +84,8 @@ bool modelCarries(const DeviceInfo& device, const ds::ParamValue& saved) {
                        [&saved](const ParameterInfo& p) { return p.stableId == saved.id; });
 }
 
-/// A hydrated entry for a device without SDK metadata: value and identity only,
-/// with a range wide enough to hold the value. The device's processor fills in
-/// the real metadata at registration, preserving this value.
+/// An entry for a device without SDK metadata: value and identity, with a range
+/// wide enough to hold the value. The processor fills in the rest at registration.
 ParameterInfo minimalEntry(const ds::ParamValue& saved) {
     ParameterInfo info;
     info.paramIndex = saved.index;
@@ -121,8 +106,7 @@ Provenance provenanceFromMagdaVersion(const juce::String& version) {
     const auto rest = trimmed.fromFirstOccurrenceOf(".", false, false);
     const int minor = rest.upToFirstOccurrenceOf(".", false, false).getIntValue();
 
-    // Unparseable reads as 0.0: no build old enough to write no version at all
-    // postdates the cutover.
+    // Unparseable reads as 0.0, which is old.
     return {.savedBeforeWrapperCutover = major == 0 && minor < 20};
 }
 
@@ -134,13 +118,9 @@ bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& prov
     if (!doc || doc->params.empty())
         return false;
 
-    // A record saved against a parameter order this build has since renumbered
-    // is identified by ITS length, not the model array's - the model array is
-    // exactly what an old preset or imported chain does not have. Remap the
-    // frozen indices first, or every old index would be read as a current one
-    // and land on the wrong slot (the pre-Enabled EQ, the 7-slot limiter).
-    // Dropped indices are dropped for the same reason the project-level pass
-    // drops them: re-pointing a value at a neighbour is corruption.
+    // A renumbered parameter order is identified by the record's own length,
+    // since an old preset has no model array. Remap before matching, or an old
+    // index lands on the wrong slot. Dropped indices stay dropped.
     auto savedParams = doc->params;
     const auto* migration = device_param_migrations::findMigrationForSavedCount(
         device.pluginId, static_cast<int>(savedParams.size()));
@@ -168,12 +148,9 @@ bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& prov
     const bool arrayWasEmpty = device.parameters.empty();
     const auto domain = resolveDomain(device, *doc, provenance);
 
-    // Real slot metadata whenever the device has an SDK factory, whatever the
-    // domain: the plan's value layer converts through the MODEL's ParameterInfo
-    // ranges, so a made-up range would corrupt a headless native render before
-    // any live processor could refresh it. The minimal fallback is reserved for
-    // devices without a factory - exactly the ones the native engine refuses to
-    // build, so nothing downstream converts through the placeholder.
+    // Real slot metadata whenever the device has an SDK factory: the plan
+    // converts through the model's ranges, so a placeholder range would corrupt
+    // a headless native render. Devices without a factory never reach one.
     const auto metadata = metadataDevice(device.pluginId, *doc);
 
     bool added = false;
@@ -193,14 +170,11 @@ bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& prov
             device.parameters.push_back(minimalEntry(*saved));
             added = true;
         }
-        // A normalised value without slot metadata is meaningless and is
-        // dropped: there is no device to run it on either.
+        // A normalised value without slot metadata is dropped.
     }
 
-    // Parameters the migrated order ADDED, seeded so the device keeps doing
-    // what the old one did (an old EQ's bands were always running; today they
-    // default off). Seed values are display-domain by contract
-    // (DeviceParamMigrations.hpp), whatever domain the record itself used.
+    // Parameters the migrated order added, seeded so the device keeps doing
+    // what the old one did. Seed values are display-domain (DeviceParamMigrations.hpp).
     if (migration != nullptr) {
         for (const auto& seed : migration->seeded) {
             if (device.findParameterByIndex(seed.index) != nullptr)
@@ -224,9 +198,7 @@ bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& prov
         }
     }
 
-    // A fully hydrated array keeps the device's own display order; entries
-    // appended to a partial one land at the end, which only affects display
-    // order and only until the processor next refreshes the metadata.
+    // A fully hydrated array keeps the device's own display order.
     if (added && arrayWasEmpty)
         std::stable_sort(device.parameters.begin(), device.parameters.end(),
                          [](const ParameterInfo& a, const ParameterInfo& b) {

--- a/magda/daw/audio/plugins/DeviceStateHydration.hpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.hpp
@@ -55,6 +55,11 @@ Provenance provenanceFromMagdaVersion(const juce::String& version);
 /// carries. Returns true when the device was changed.
 bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& provenance = {});
 
+/// Hydrate as above, then give the model every parameter the device declares
+/// but neither the array nor the saved record carries (#2613). In that order:
+/// seeding first would make a saved value look like one the model already had.
+void completeDeviceParameters(DeviceInfo& device, const Provenance& provenance = {});
+
 /// Every internal device in a chain-element list (racks and pad chains
 /// included), for presets and imported chains. RackInfo overload for rack
 /// presets.

--- a/magda/daw/audio/plugins/DeviceStateHydration.hpp
+++ b/magda/daw/audio/plugins/DeviceStateHydration.hpp
@@ -16,61 +16,38 @@ namespace magda::daw::audio::device_state_hydration {
 /**
  * One-time load migration for the retired dual parameter authority (#2317).
  *
- * `DeviceInfo::parameters` is the sole persisted authority for an internal
- * device's automatable parameters, in the device's DISPLAY domain. Documents
- * written since #2317 carry no parameter record at all. Documents written
- * before it duplicate the parameters as `Doc::params`, in a domain that
- * depends on which build captured them; this module is the one place that
- * still knows that chronology, and it applies it exactly once - at load,
- * before either engine projection is constructed.
- *
- * Hydration never overwrites a parameter the model already carries: the model
- * array is the authority and the duplicate record is only consulted for
- * entries the array is missing (a state-only device preset, an imported
- * chain, a hand-edited file). The duplicate itself is not deleted here; it
- * disappears the next time the device is captured, because capture no longer
- * writes one.
+ * Documents written before #2317 duplicate the parameters as `Doc::params`, in
+ * a domain that depends on which build captured them. This module applies that
+ * chronology once at load, filling only entries the model array is missing.
  */
 
 /// What the container that carried the saved state says about the build that
-/// wrote it. Documents predating the `paramsAreDisplayDomain` marker cannot
-/// say on their own which domain they used; the container sometimes can.
+/// wrote it, for documents predating the `paramsAreDisplayDomain` marker.
 struct Provenance {
-    /// True when the container is known to have been written before the
-    /// wrapper cutover (a project whose `magdaVersion` is older than 0.20).
-    /// An unmarked document from such a container can only hold values in the
-    /// capturing plugin's display range.
+    /// True when the container's `magdaVersion` is older than 0.20; an unmarked
+    /// document from it holds values in the capturing plugin's display range.
     bool savedBeforeWrapperCutover = false;
 };
 
 /// Provenance from a container's saved MAGDA version string ("0.19.2").
-/// Unparseable or missing versions are read as old: every build that wrote a
-/// version at all predates the cutover or wrote the marker.
+/// Unparseable or missing versions are read as old.
 Provenance provenanceFromMagdaVersion(const juce::String& version);
 
-/// Hydrate `device.parameters` entries missing from the model out of the
-/// pre-#2317 duplicate parameter record in `device.pluginState`, converting to
-/// the display domain. No-op for external devices, empty or unreadable state,
-/// documents without a parameter record, and parameters the model already
-/// carries. Returns true when the device was changed.
+/// Fill `device.parameters` entries missing from the model out of the pre-#2317
+/// duplicate record in `device.pluginState`, in the display domain. No-op for
+/// external devices and unreadable state. Returns true when the device changed.
 bool hydrateParametersFromDeviceState(DeviceInfo& device, const Provenance& provenance = {});
 
-/// Hydrate as above, then give the model every parameter the device declares
-/// but neither the array nor the saved record carries (#2613). In that order:
-/// seeding first would make a saved value look like one the model already had.
+/// Hydrate, then seed the parameters the device declares but nothing saved (#2613).
+/// Seeding first would make a saved value look like one the model already had.
 void completeDeviceParameters(DeviceInfo& device, const Provenance& provenance = {});
 
-/// Every internal device in a chain-element list (racks and pad chains
-/// included), for presets and imported chains. RackInfo overload for rack
-/// presets.
+/// Every internal device in a chain-element list, racks and pad chains included.
 void hydrateChainElements(std::vector<ChainElement>& elements, const Provenance& provenance = {});
 void hydrateRack(RackInfo& rack, const Provenance& provenance = {});
 
-/// Every internal device staged for a project load, with provenance from the
-/// file's `magdaVersion`. Belongs at the end of the load-time migration chain:
-/// after the retired-device aliases (so ids are canonical) and the param-index
-/// migrations (so the array hydration merges against is current), before any
-/// engine projection exists.
+/// Every internal device staged for a project load. Runs after the retired-device
+/// aliases and the param-index migrations, before any engine projection exists.
 void hydrateStagedProject(std::vector<TrackInfo>& tracks, TrackInfo* masterTrack,
                           const juce::String& magdaVersion);
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -17,11 +17,8 @@ namespace magda::daw::audio::engine_adapter {
 
 namespace {
 
-/// One track's descent, written once, over whichever constness the caller has.
-///
-/// A flat stage's elements are devices rather than a tree, so it is walked
-/// directly; flat does not mean padless, and a device carrying pads is
-/// descended into the same way a tree device is.
+/// One track's descent over whichever constness the caller has. A flat stage
+/// is walked directly, but a device carrying pads is still descended into.
 template <typename Track, typename Devices>
 void collectTrackDevices(Track& track, Devices& devices) {
     const auto collectTree = [&devices](auto& elements, const magda::ChainNodePath& parentPath,
@@ -65,8 +62,7 @@ template <typename Tracks, typename Master> auto collectDevices(Tracks& tracks, 
     return devices;
 }
 
-/// Say out loud when a project's state could not be read. #2602 went unnoticed
-/// for as long as it did because this path dropped one without a word.
+/// Log an unreadable saved state rather than drop it silently (#2602).
 void reportUnreadableState(const juce::String& pluginId, const juce::String& savedState) {
     if (savedState.isNotEmpty() && !deviceStateTree(savedState).isValid())
         juce::Logger::writeToLog("EngineDeviceFactory: unreadable saved state for " + pluginId +
@@ -95,71 +91,47 @@ bool isExternalDevice(const magda::DeviceInfo& device) {
     return device.format != magda::PluginFormat::Internal;
 }
 
-/// enableAllBuses first, at the same point the fork does it
-/// (completePluginInstanceCreation) and for the same reason: a plugin whose
-/// sidechain or second output bus is disabled reports channels it does not
-/// have, and everything downstream -- the adapter's own channel adaptation, the
-/// plan's declared widths -- is read off those numbers.
+/// enableAllBuses first: a plugin with a disabled sidechain or second output
+/// bus reports channels it does not have, and the plan's widths are read off it.
 ExternalDeviceResult adaptExternalPluginInstance(
     std::unique_ptr<juce::AudioPluginInstance> instance, const magda::DeviceInfo& device,
     bool offlineRender) {
     instance->enableAllBuses();
 
-    // The saved array, then the overlay over it, then what that left behind. The
-    // order and the reasons are ExternalPluginState.hpp's; what matters here is
-    // that all three happen before the adapter exists, so the adapter never has
-    // to reason about which of a project's records it is looking at.
+    // Array, then preset, then chunk (ExternalPluginState.hpp), all before the
+    // adapter exists.
     const auto restoredFrom = magda::applySavedPluginState(*instance, device);
     if (restoredFrom == magda::SavedStateOutcome::Failed)
         return {.device = {},
                 .failure = "external plugin \"" + device.name +
                            "\" failed while restoring its own saved state"};
 
-    // Buses again, and the widths only now. setStateInformation is free to
-    // change a plugin's bus layout -- an instrument the patch switches to
-    // multi-out, a compressor whose sidechain the patch turns on -- so widths
-    // read before the chunk was applied describe a layout the instance no
-    // longer has, while EngineExternalDevice::prepare() goes on to process the
-    // one it does. Re-enabling keeps the all-buses policy the first call
-    // establishes: a chunk that disabled one would otherwise leave the device
-    // reporting channels the rest of the chain is wired for.
+    // Buses again: setStateInformation may change the bus layout, and a chunk
+    // that disabled one would leave the device narrower than the chain is wired.
     instance->enableAllBuses();
 
-    // Scan descriptions report the format's default buses, not the instance
-    // after the host has enabled its sidechains and extra outputs. These are
-    // the only channel counts safe to compile a live plan from.
+    // Scan descriptions report the format's default buses, not the enabled ones.
     auto resolvedDevice = device;
     resolvedDevice.audioInputChannels = instance->getTotalNumInputChannels();
     resolvedDevice.audioOutputChannels = instance->getTotalNumOutputChannels();
 
-    // An imported .vstpreset is spent by the load that applies it. The patch is
-    // now the instance's, the next save writes it out as a chunk, and a project
-    // that kept the preset would apply it again over whatever was saved in
-    // between. Only a published resolvedDevice clears it, so a load that failed
-    // leaves the project still holding the one thing that describes its plugin.
+    // An imported .vstpreset is spent by the load that applies it; kept, it
+    // would be applied again over whatever the next save wrote.
     if (restoredFrom == magda::SavedStateOutcome::RestoredFromPreset)
         resolvedDevice.vst3Preset = {};
 
-    // Promote only, the rule the model's other two writers follow
-    // (PluginManagerSync::updateDeviceCapabilityFlags,
-    // applyCachedCapabilitiesToDevice). A raw AudioProcessor::acceptsMidi() is
-    // narrower than what the incumbent engine asks -- it takes MIDI input for
-    // plugins whose processor does not advertise it -- so assigning it here
-    // clears a saved true and PlanCompiler stops routing MIDI to the device.
+    // Promote only, like the model's other writers: AudioProcessor::acceptsMidi()
+    // is narrower than what a saved true may have come from.
     if (!resolvedDevice.isInstrument && (instance->acceptsMidi() || instance->isMidiEffect()))
         resolvedDevice.canReceiveMidi = true;
     resolvedDevice.producesMidi = instance->producesMidi() || instance->isMidiEffect();
 
-    // After the chunk, which is free to rename a parameter or move its default.
-    // Nothing but the instance can enumerate a hosted plugin's parameters, and
-    // the model is what every reader downstream has (#2595).
+    // After the chunk, which may rename a parameter or move its default (#2595).
     auto described = magda::describeHostParameters(*instance, device);
     resolvedDevice.parameters = std::move(described.parameters);
     resolvedDevice.wrapperParameters = std::move(described.wrapperParameters);
 
-    // Before the device is built, because it copies these records and converts
-    // every block's value through them. The plan converts through the model's,
-    // and a config applied only to the model puts the two in different units.
+    // Before the device is built, which copies these records.
     magda::PluginParameterConfigStore::applyToDevice(resolvedDevice);
 
     auto restored = magda::snapshotHostParameters(*instance);
@@ -173,16 +145,13 @@ ExternalDeviceResult adaptExternalPluginInstance(
 
 namespace {
 
-/// Why a plugin nobody could find is missing, said once so both entry points
-/// say it the same way.
+/// The missing-plugin failure, worded once for both entry points.
 juce::String describeMissingPlugin(const magda::DeviceInfo& device) {
     return "external plugin \"" + device.name + "\" (" + device.getFormatString() +
            ") is not installed on this machine";
 }
 
-/// Apply only a role JUCE's installed description can author. MIDI and Analysis
-/// are explicit MAGDA roles, and replacing either with Effect/Instrument would
-/// change the plan rather than enrich it.
+/// Apply the installed role, except over MAGDA's own MIDI and Analysis roles.
 void applyInstalledRole(magda::DeviceInfo& device, bool isInstrument) {
     if (device.deviceType == magda::DeviceType::MIDI ||
         device.deviceType == magda::DeviceType::Analysis)
@@ -196,12 +165,8 @@ void applyInstalledRole(magda::DeviceInfo& device, bool isInstrument) {
 
 std::unique_ptr<magda::engine::EngineDevice> createEngineDevice(const magda::DeviceInfo& device,
                                                                 bool offlineRender) {
-    // Built with its state already in it, not restored after: EngineMagdaDevice
-    // snapshots the device's parameter metadata when it is constructed, so a
-    // device that restored later would be mapped against the parameters it had
-    // before. Parameters themselves do not travel this way -- the plan's value
-    // layer resolves each one per block -- but everything else does: the runtime
-    // Faust device's dsp source, an EQ's collapsed curve.
+    // Built with its state in it: EngineMagdaDevice snapshots the parameter
+    // metadata at construction, and the runtime Faust device's slots come from it.
     auto sdkDevice = createDetachedDevice(device.pluginId, device.pluginState);
     if (sdkDevice == nullptr)
         return {};
@@ -231,10 +196,7 @@ ExternalPluginResolution resolveEngineExternalPlugin(const magda::DeviceInfo& de
     ExternalPluginResolution resolved{.planDevice = device};
 
     if (services.formats == nullptr || services.knownPlugins == nullptr) {
-        // Named, like every other failure here. A caller collecting these has a
-        // project's worth of devices and needs to know which one it is holding,
-        // and "no plugin formats" on its own reads as one global complaint
-        // rather than one per plugin the render went without.
+        // Named per device, so a project's worth of these stays attributable.
         resolved.failure = "external plugin \"" + device.name +
                            "\" cannot be resolved: no plugin formats or scan results were given "
                            "to the engine";
@@ -243,11 +205,8 @@ ExternalPluginResolution resolveEngineExternalPlugin(const magda::DeviceInfo& de
 
     const auto match = magda::matchInstalledPlugin(device, *services.knownPlugins);
 
-    // Unfound is refused rather than attempted. The app tries the saved
-    // description anyway and lets the format's own lookup have a go, which is
-    // right for a session where a user is watching and can be told; a render is
-    // not that, and a plugin resolved by a route nothing recorded is the kind
-    // of difference a null-diff corpus cannot attribute afterwards.
+    // Unfound is refused rather than attempted, so a render never resolves a
+    // plugin by a route nothing recorded.
     if (!match.found) {
         resolved.failure = describeMissingPlugin(device);
         return resolved;
@@ -256,8 +215,8 @@ ExternalPluginResolution resolveEngineExternalPlugin(const magda::DeviceInfo& de
     resolved.description = match.description;
     applyInstalledRole(resolved.planDevice, match.description.isInstrument);
 
-    // Keep the project's identity and preference key. The capability cache is
-    // nevertheless queried with the exact installed identity resolution found.
+    // The project keeps its identity; the capability cache is keyed by the
+    // installed one.
     const auto resolvedIdentifier = match.description.createIdentifierString();
     magda::applyCachedCapabilitiesToDevice(resolved.planDevice, resolvedIdentifier);
     return resolved;
@@ -294,18 +253,9 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
                                                 bool offlineRender) {
     const auto& requestedName = requested.displayName;
 
-    // The identity boundary, and the first thing asked. Scan metadata may have
-    // changed in every field while the plugin loaded, including the role the
-    // plan compiles from; those are facts learned about this assignment, not
-    // about another one, so none of them is consulted here. What decides is
-    // whether the runtime still holds the very assignment the load was started
-    // against, which no copy of the model can carry and no unregistered device
-    // can claim.
+    // Whether the runtime still holds the assignment the load was started
+    // against; no copy of the model can answer that.
     if (!requested.assignment.isStillWanted()) {
-        // Which of the two it was, for a person reading the log: a key held
-        // under a different assignment is a slot now asking for something else,
-        // and anything else -- a released key, a runtime that is gone, a
-        // registration nobody made -- is a device there is no longer one of.
         return {.device = {},
                 .failure =
                     requested.assignment.keyWasReassigned()
@@ -313,9 +263,7 @@ ExternalDeviceResult completeExternalPluginLoad(std::unique_ptr<juce::AudioPlugi
                         : "the device was removed while \"" + requestedName + "\" was loading"};
     }
 
-    // Then the model, before anything is done with the instance. Everything
-    // below restores from it, and it is a different object from the one the
-    // load was requested with: seconds have passed.
+    // The model as it is now, not as it was when the load was requested.
     const auto* device = currentDevice ? currentDevice(requested.assignment.key) : nullptr;
 
     if (device == nullptr)
@@ -353,16 +301,9 @@ ExternalPluginResolution createEngineExternalDeviceAsync(
                                      .resolvedIsInstrument = resolved.description.isInstrument},
          currentDevice = std::move(currentDevice), offlineRender, completed = std::move(completed)](
             std::unique_ptr<juce::AudioPluginInstance> instance, const juce::String& error) {
-            // The lifetime gate, before anything is called rather than after.
-            // This lambda is stored by JUCE and run a turn or more later, and
-            // `completed` is the runtime's own: it publishes the device into the
-            // project and reports the failures. A runtime that is gone has
-            // nowhere to publish and nobody to tell, so calling it at all is the
-            // use-after-free -- refusing inside it would already be too late.
-            //
-            // Deliberately not isStillWanted(): a device deleted while its
-            // runtime lives is a load to refuse *and say so about*, because
-            // something is still waiting to hear it.
+            // JUCE runs this a turn or more later; `completed` belongs to the
+            // runtime, so a dead runtime must not be called at all. Not
+            // isStillWanted(): a deleted device is a load to refuse and report.
             if (!requested.assignment.runtimeIsAlive())
                 return;
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -4,6 +4,7 @@
 
 #include "core/ChainWalk.hpp"
 #include "core/PluginCapabilities.hpp"
+#include "core/PluginParameterConfigStore.hpp"
 #include "plugin_manager/ExternalPluginLookup.hpp"
 #include "plugin_manager/ExternalPluginState.hpp"
 #include "plugins/DeviceCatalogParameters.hpp"
@@ -155,6 +156,11 @@ ExternalDeviceResult adaptExternalPluginInstance(
     auto described = magda::describeHostParameters(*instance, device);
     resolvedDevice.parameters = std::move(described.parameters);
     resolvedDevice.wrapperParameters = std::move(described.wrapperParameters);
+
+    // Before the device is built, because it copies these records and converts
+    // every block's value through them. The plan converts through the model's,
+    // and a config applied only to the model puts the two in different units.
+    magda::PluginParameterConfigStore::applyToDevice(resolvedDevice);
 
     auto restored = magda::snapshotHostParameters(*instance);
 

--- a/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
+++ b/magda/daw/audio/plugins/engine/EngineDeviceFactory.cpp
@@ -3,10 +3,10 @@
 #include <utility>
 
 #include "core/ChainWalk.hpp"
-#include "core/DeviceState.hpp"
 #include "core/PluginCapabilities.hpp"
 #include "plugin_manager/ExternalPluginLookup.hpp"
 #include "plugin_manager/ExternalPluginState.hpp"
+#include "plugins/DeviceCatalogParameters.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
 #include "plugins/engine/EngineExternalDevice.hpp"
@@ -64,88 +64,12 @@ template <typename Tracks, typename Master> auto collectDevices(Tracks& tracks, 
     return devices;
 }
 
-/// The property a spec is looked up by, which is what a plugin state tree
-/// carries and what both catalogs match their ids and aliases against.
-const juce::Identifier& typeProperty() {
-    static const juce::Identifier type("type");
-    return type;
-}
-
-/// The creation context a catalog's factory takes.
-///
-/// A tree with the type in it and nothing else. The device's own state does not
-/// travel this way yet (see the header), and the session key is empty because a
-/// device built for a render belongs to no host session: the services behind
-/// that key are the current engine's, and nothing the engine runs may reach
-/// them.
-DevicePluginCreationContext creationContext(const juce::String& pluginId) {
-    juce::ValueTree state(juce::Identifier("PLUGIN"));
-    state.setProperty(typeProperty(), pluginId, nullptr);
-
-    return {.sessionKey = {}, .state = std::move(state), .isNewPlugin = true};
-}
-
-/// The SDK factory registered for @p pluginId, from whichever catalog has it.
-///
-/// The internal registry first, because that is the one an id is canonicalised
-/// against and the one an alias resolves through. A compiled device is not in
-/// it -- only its parameter aliases are (BaseDevicePack) -- so the compiled
-/// catalog is asked second rather than instead.
-std::unique_ptr<MagdaDevice> createSdkDevice(const juce::String& pluginId) {
-    if (const auto* spec = findInternalPluginSpec(pluginId); spec != nullptr)
-        if (spec->createDevice != nullptr)
-            return spec->createDevice(creationContext(pluginId));
-
-    if (const auto* spec = compiled::findCompiledPluginSpec(pluginId); spec != nullptr)
-        if (spec->createDevice != nullptr)
-            return spec->createDevice(creationContext(pluginId));
-
-    return {};
-}
-
-/// The device's own state as a tree, in whichever format the project holds it.
-///
-/// Most internal devices in a project folder are still saved as the engine's
-/// v1 XML, which `decode()` refuses by design, so reading only v2 took every
-/// one of them and ran its defaults (#2602).
-juce::ValueTree savedStateTree(const juce::String& savedState) {
-    if (magda::device_state::looksLikeLegacyEngineState(savedState)) {
-        auto tree = magda::device_state::legacyEngineStateTree(savedState);
-        adoptCanonicalPluginType(tree);
-        return tree;
-    }
-
-    const auto doc = magda::device_state::decode(savedState);
-    if (!doc)
-        return {};
-
-    auto tree = magda::device_state::toValueTree(doc->root);
-    tree.setProperty(typeProperty(), doc->deviceType, nullptr);
-    return tree;
-}
-
-/// Hand the device whatever the project saved for it.
-///
-/// Parameters are not this: the plan's value layer resolves every one of them
-/// per block and the adapter writes them before each process() call. What this
-/// carries is everything else -- the runtime Faust device's dsp source, an EQ's
-/// collapsed curve -- without which a device built here runs its defaults and
-/// renders a project nobody saved.
-void restoreSavedState(MagdaDevice& device, const juce::String& pluginId,
-                       const juce::String& savedState) {
-    if (savedState.isEmpty())
-        return;
-
-    const auto tree = savedStateTree(savedState);
-    if (!tree.isValid()) {
-        // Said out loud. #2602 went unnoticed for as long as it did because
-        // this path dropped a project's state without a word.
+/// Say out loud when a project's state could not be read. #2602 went unnoticed
+/// for as long as it did because this path dropped one without a word.
+void reportUnreadableState(const juce::String& pluginId, const juce::String& savedState) {
+    if (savedState.isNotEmpty() && !deviceStateTree(savedState).isValid())
         juce::Logger::writeToLog("EngineDeviceFactory: unreadable saved state for " + pluginId +
                                  ", running its defaults");
-        return;
-    }
-
-    device.restoreState(tree);
 }
 
 }  // namespace
@@ -266,14 +190,17 @@ void applyInstalledRole(magda::DeviceInfo& device, bool isInstrument) {
 
 std::unique_ptr<magda::engine::EngineDevice> createEngineDevice(const magda::DeviceInfo& device,
                                                                 bool offlineRender) {
-    auto sdkDevice = createSdkDevice(device.pluginId);
+    // Built with its state already in it, not restored after: EngineMagdaDevice
+    // snapshots the device's parameter metadata when it is constructed, so a
+    // device that restored later would be mapped against the parameters it had
+    // before. Parameters themselves do not travel this way -- the plan's value
+    // layer resolves each one per block -- but everything else does: the runtime
+    // Faust device's dsp source, an EQ's collapsed curve.
+    auto sdkDevice = createDetachedDevice(device.pluginId, device.pluginState);
     if (sdkDevice == nullptr)
         return {};
 
-    // Before the adapter, not after. EngineMagdaDevice snapshots the device's
-    // parameter metadata when it is constructed, so a device that restores its
-    // state later would be mapped against the parameters it had before.
-    restoreSavedState(*sdkDevice, device.pluginId, device.pluginState);
+    reportUnreadableState(device.pluginId, device.pluginState);
 
     return std::make_unique<EngineMagdaDevice>(std::move(sdkDevice), offlineRender);
 }

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <utility>
 
 #include "core/ParameterUtils.hpp"
@@ -15,28 +16,22 @@ namespace magda::daw::audio::engine_adapter {
 
 namespace {
 
-/// What an encoded event costs before its own bytes. Derived from the engine's
-/// own cost model, the same way EngineMagdaDevice derives it, so the two cannot
-/// drift apart.
+/// What an encoded event costs before its own bytes, as EngineMagdaDevice
+/// derives it.
 constexpr int kMidiEventOverheadBytes =
     magda::engine::kMidiShortMessageBytes - 3;  // a short message is three bytes of data
 
-/// Below this the fork treats the dry level as off and skips the mix entirely,
-/// which is what makes the common case one processBlock and no copy.
+/// Below this the dry level is off and the mix is skipped.
 constexpr float kDryLevelFloor = 0.00004f;
 
-/// Above this the fork treats the wet level as unity and skips the gain pass.
+/// Above this the wet level is unity and the gain pass is skipped.
 constexpr float kWetLevelCeiling = 0.999f;
 
-/// The parameter slots the fork puts in front of a plugin's own: dry, then wet.
+/// The slots in front of a plugin's own: dry, then wet.
 constexpr int kWrapperParameterCount = 2;
 
 /// The model's description of the parameter at plan slot @p index, or none.
-///
-/// Both buckets, because MAGDA splits the fork's one list in two: the plugin's
-/// parameters and the wrapper pair it never declared. Both carry the fork's
-/// index in paramIndex, which is what the plan addresses them by, so the split
-/// is a UI concern and this is the one place that has to put them back together.
+/// Both buckets, since the wrapper pair shares the plugin's index space.
 std::optional<magda::ParameterInfo> modelParameterAt(const magda::DeviceInfo& device, int index) {
     for (const auto* bucket : {&device.parameters, &device.wrapperParameters})
         for (const auto& info : *bucket)
@@ -49,16 +44,7 @@ std::optional<magda::ParameterInfo> modelParameterAt(const magda::DeviceInfo& de
 /**
  * @brief Replace anything that is not a number with silence (#2240).
  *
- * A NaN is not a loud sound, it is a permanent one: it survives every gain,
- * poisons every sum it reaches, and the track stays silent-but-broken after the
- * plugin that made it has been bypassed. An infinity does the same on the first
- * multiply by zero. Neither is a level to be managed, so neither is clamped:
- * they are cleared.
- *
- * Deliberately not the fork's rule, which clamps to a magnitude of 100 and only
- * looks at all when the CPU raised its denormal flag during the call, on Intel.
- * That gate is for denormals and says nothing about a NaN, and the magnitude is
- * a number nothing derives: +40 dBFS protects no speaker.
+ * Cleared rather than clamped: a NaN survives every gain and poisons every sum.
  */
 void clearNonFinite(juce::AudioBuffer<float>& audio, int numSamples) {
     for (int channel = 0; channel < audio.getNumChannels(); ++channel) {
@@ -73,21 +59,9 @@ void clearNonFinite(juce::AudioBuffer<float>& audio, int numSamples) {
 }  // namespace
 
 /**
- * @brief Where the transport is, as a plugin asks for it.
- *
- * A block's own description, published for the plugin to read during the call.
- * Held in atomics rather than as a pointer to the block, for the fork's own
- * reason: a plugin is entitled to ask on the message thread, hours after the
- * block that produced the answer, and some do. The worst that can do here is
- * report a stale position, which is what the fork does too.
- */
-/**
  * @brief The plugin's editor in a window of its own (#2580).
  *
- * A DocumentWindow rather than the fork's te::PluginWindowState, which is built
- * around a te::Plugin this side does not have. Its close button tells the
- * owner rather than deleting itself, so the owner's pointer is also the answer
- * to whether it is open.
+ * Its close button tells the owner rather than deleting itself.
  */
 class EngineExternalDevice::EditorWindow final : public juce::DocumentWindow {
   public:
@@ -103,8 +77,7 @@ class EngineExternalDevice::EditorWindow final : public juce::DocumentWindow {
         setVisible(true);
     }
 
-    /// The editor goes before the window it sits in, and while the plugin is
-    /// still there to be told it has gone.
+    /// The editor goes while the plugin is still there to be told.
     ~EditorWindow() override {
         clearContentComponent();
     }
@@ -119,6 +92,65 @@ class EngineExternalDevice::EditorWindow final : public juce::DocumentWindow {
     std::function<void()> closed_;
 };
 
+/**
+ * @brief Where the transport is, as a plugin asks for it.
+ *
+ * Atomics rather than a pointer to the block: a plugin may ask on the message
+ * thread long after the block, and a stale position is the accepted answer.
+ */
+/// Records a parameter the plugin moved itself and queues one flush. JUCE
+/// calls this on whatever thread made the change, the audio thread included.
+class EngineExternalDevice::PluginListener final : public juce::AudioProcessorListener {
+  public:
+    PluginListener(std::shared_ptr<PluginEdits> edits, const std::vector<int>& slotOfParameter,
+                   const std::atomic<bool>& writing)
+        : edits_(std::move(edits)), slotOfParameter_(slotOfParameter), writing_(writing) {}
+
+    void audioProcessorParameterChanged(juce::AudioProcessor*, int parameterIndex,
+                                        float newValue) override {
+        if (writing_.load(std::memory_order_relaxed))
+            return;
+
+        if (parameterIndex < 0 || parameterIndex >= static_cast<int>(slotOfParameter_.size()))
+            return;
+
+        const auto slot = slotOfParameter_[static_cast<std::size_t>(parameterIndex)];
+        if (slot < 0)
+            return;
+
+        auto& edits = *edits_;
+        edits.pending[static_cast<std::size_t>(slot)].store(newValue, std::memory_order_relaxed);
+        edits.dirty[static_cast<std::size_t>(slot)].store(true, std::memory_order_release);
+
+        if (edits.flushQueued.exchange(true, std::memory_order_acq_rel))
+            return;
+
+        juce::MessageManager::callAsync([weak = std::weak_ptr<PluginEdits>(edits_)] {
+            const auto edits = weak.lock();
+            if (edits == nullptr)
+                return;
+
+            edits->flushQueued.store(false, std::memory_order_release);
+
+            for (std::size_t slot = 0; slot < edits->dirty.size(); ++slot) {
+                if (!edits->dirty[slot].exchange(false, std::memory_order_acq_rel))
+                    continue;
+
+                if (edits->sink)
+                    edits->sink(static_cast<int>(slot),
+                                edits->pending[slot].load(std::memory_order_relaxed));
+            }
+        });
+    }
+
+    void audioProcessorChanged(juce::AudioProcessor*, const ChangeDetails&) override {}
+
+  private:
+    std::shared_ptr<PluginEdits> edits_;
+    const std::vector<int>& slotOfParameter_;
+    const std::atomic<bool>& writing_;
+};
+
 class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
   public:
     void setBlock(const magda::engine::BlockInfo& block, double sampleRate) {
@@ -130,9 +162,7 @@ class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
         ppqPosition_.store(block.beats.start, std::memory_order_relaxed);
 
         if (block.tempo == nullptr) {
-            // A caller assembling a block by hand: the defaults are what the
-            // transport would have published, and the bar grid is the one the
-            // engine's own default map has.
+            // A block assembled by hand: the engine's default map.
             bpm_.store(kDefaultBpm, std::memory_order_relaxed);
             numerator_.store(4, std::memory_order_relaxed);
             denominator_.store(4, std::memory_order_relaxed);
@@ -141,19 +171,10 @@ class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
             return;
         }
 
-        // The tempo and the bar grid the block's first sample sounds under, not
-        // the ones its first beat sits in: a block can open a hundredth of a
-        // sample before a boundary it is otherwise entirely past
-        // (BlockInfo::openingBeat), and taking them from there would run the
-        // call on the section it had already left.
-        //
-        // One bpm and one signature for the whole call is all this interface
-        // has to give, so a block spanning a tempo change reports what its
-        // first sample is in for all of it. That is what every host does and
-        // what plugins are built to tolerate (#2340).
-        //
-        // Where the block is stays its own: the time and the PPQ position above
-        // are its first sample's, which is what the plugin is being handed.
+        // Read at the beat the first sample sounds under
+        // (BlockInfo::openingBeat). One bpm and one signature per call is all
+        // the interface gives, so a block spanning a change reports its first
+        // sample's for all of it (#2340).
         const auto opening = block.openingBeat();
 
         bpm_.store(block.tempo->bpmAt(opening), std::memory_order_relaxed);
@@ -162,20 +183,11 @@ class EngineExternalDevice::PlayHead final : public juce::AudioPlayHead {
         numerator_.store(position.numerator, std::memory_order_relaxed);
         denominator_.store(position.denominator, std::memory_order_relaxed);
 
-        // PPQ counts quarter notes and the position inside a bar is counted in
-        // the signature's own beats, so the two part company anywhere the
-        // denominator is not four: three eighths into a 6/8 bar is one and a
-        // half quarter notes, not three.
+        // PPQ counts quarter notes; the position in the bar is in the
+        // signature's own beats.
         const auto quartersPerBeat = 4.0 / std::max(1, position.denominator);
 
-        // The bar the block's first sample is in, under the signature it
-        // renders in. Not the bar its middle is in: a block is not cut at bar
-        // lines, so a long one straddles one, and taking the middle's bar would
-        // make what the plugin is told depend on how the host happened to size
-        // the callback.
-        //
-        // Straight back from where the grid was read, because the opening beat
-        // already carries the tolerance a sample's question is answered to.
+        // The bar the first sample is in, back from where the grid was read.
         ppqOfBarStart_.store(opening - (position.beat * quartersPerBeat),
                              std::memory_order_relaxed);
     }
@@ -218,12 +230,8 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
       offlineRender_(offlineRender) {
     jassert(instance_ != nullptr);
 
-    // The fork's list, rebuilt: the wrapper pair first, then the plugin's own
-    // automatable parameters in plugin order. A parameter the plugin says is
-    // not automatable is not in the list at all, which is why this cannot be
-    // the plugin's parameter array with two added -- it is a filtered view of
-    // it, and the filter is what decides which slot a project's saved value
-    // lands on.
+    // The wrapper pair first, then the plugin's automatable parameters in
+    // plugin order; non-automatable ones are not in the list at all.
     const auto mappingFor = [](juce::AudioProcessorParameter* parameter, magda::WrapperRole role,
                                std::optional<magda::ParameterInfo> info) {
         return ParameterMapping{.parameter = parameter, .role = role, .info = std::move(info)};
@@ -234,11 +242,8 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
     parameters_.push_back(
         mappingFor(nullptr, magda::WrapperRole::WetGain, modelParameterAt(device, 1)));
 
-    // The pairs past the main one, in the plan's own order: extraOutputs[k] is
-    // pair k + 1. Read from the model rather than from the instance's bus
-    // layout, because it is the model the plan compiled its ports from -- the
-    // two agree, and where they do not it is the plan that decided how many
-    // ports there are.
+    // The pairs past the main one, from the model the plan compiled its ports
+    // from: extraOutputs[k] is pair k + 1.
     const auto& pairs = device.multiOut.outputPairs;
     for (std::size_t pair = 1; pair < pairs.size(); ++pair) {
         const auto& declared = pairs[pair];
@@ -250,19 +255,32 @@ EngineExternalDevice::EngineExternalDevice(std::unique_ptr<juce::AudioPluginInst
     for (int slot = kWrapperParameterCount; slot < static_cast<int>(order.size()); ++slot)
         parameters_.push_back(mappingFor(order[static_cast<std::size_t>(slot)],
                                          magda::WrapperRole::None, modelParameterAt(device, slot)));
+
+    lastTable_.assign(parameters_.size(), std::numeric_limits<float>::quiet_NaN());
+
+    slotOfParameter_.assign(static_cast<std::size_t>(instance_->getParameters().size()), -1);
+    for (int slot = 0; slot < static_cast<int>(parameters_.size()); ++slot)
+        if (const auto* parameter = parameters_[static_cast<std::size_t>(slot)].parameter)
+            slotOfParameter_[static_cast<std::size_t>(parameter->getParameterIndex())] = slot;
+
+    edits_ = std::make_shared<PluginEdits>(parameters_.size());
+    listener_ = std::make_unique<PluginListener>(edits_, slotOfParameter_, writing_);
+    instance_->addListener(listener_.get());
+}
+
+void EngineExternalDevice::listenForPluginEdits(std::function<void(int, float)> sink) {
+    edits_->sink = std::move(sink);
 }
 
 EngineExternalDevice::~EngineExternalDevice() {
-    // First: the editor is the plugin's own component and has to go while the
-    // plugin is still there to take it back (#2580). A window open here means
-    // this is being destroyed on the thread that opened it.
+    // First: the editor is the plugin's own component (#2580).
     jassert(editor_ == nullptr || juce::MessageManager::existsAndIsCurrentThread());
     editor_.reset();
 
-    // The playhead outlives nothing: the instance is told to forget it before
-    // either is destroyed, because JUCE leaves the pointer where it was and a
-    // plugin asking after the fact would read freed memory. The fork does the
-    // same thing in the same order (deinitialise: "must be done first").
+    instance_->removeListener(listener_.get());
+
+    // JUCE leaves the playhead pointer in place, so the instance is told to
+    // forget it before either is destroyed.
     instance_->setPlayHead(nullptr);
 
     if (prepared_)
@@ -270,20 +288,14 @@ EngineExternalDevice::~EngineExternalDevice() {
 }
 
 void EngineExternalDevice::prepare(const magda::engine::RenderContext& context) {
-    // Before prepareToPlay, because it is what a plugin reads when it decides
-    // how much work a block is worth: an oversampling saturator sizes its
-    // filters here.
+    // Before prepareToPlay, which is where a plugin reads it.
     instance_->setNonRealtime(offlineRender_);
     instance_->setPlayHead(playHead_.get());
 
     instance_->setRateAndBufferSizeDetails(context.sampleRate, context.maxBlockSize);
 
-    // Prepared once, and again only when the rate or the block size actually
-    // moved. This is the fork's rule and its comment is worth carrying with it:
-    // it used to call releaseResources() before re-preparing, and with VST3
-    // that shuts down the MIDI input buses with no way to get them back, which
-    // breaks every synth. So a device the store retains across a re-prepare at
-    // the same settings is left alone rather than torn down and rebuilt.
+    // Re-prepared only when the rate or block size moved, and never through
+    // releaseResources(): on VST3 that shuts down the MIDI input buses for good.
     if (!prepared_ || context.sampleRate != sampleRate_ ||
         context.maxBlockSize != preparedBlockSize_) {
         instance_->prepareToPlay(context.sampleRate, context.maxBlockSize);
@@ -298,28 +310,20 @@ void EngineExternalDevice::prepare(const magda::engine::RenderContext& context) 
     const auto totalInputs = instance_->getTotalNumInputChannels();
     const auto totalOutputs = instance_->getTotalNumOutputChannels();
 
-    // The main bus is what the chain feeds; anything after it is where a
-    // sidechain key goes, which is how every dynamics plugin takes one. A
-    // plugin with no bus layout at all reports its channels only in total, and
-    // then all of them are the main bus.
+    // The chain feeds the main bus; a sidechain key goes to whatever follows.
+    // A plugin with no bus layout reports only a total, all of it main.
     const auto* mainBus = instance_->getBus(true, 0);
     mainInputChannels_ = mainBus != nullptr ? mainBus->getNumberOfChannels() : totalInputs;
     sidechainInputChannels_ = std::max(0, totalInputs - mainInputChannels_);
 
-    // The fork's width, verbatim: a plugin is processed at its own channel
-    // count whatever the chain around it is, and never at none.
+    // Processed at its own width, never at none.
     processChannels_ = std::max({1, totalInputs, totalOutputs});
 
-    // What the plugin actually writes, which is not the same number and is the
-    // one the chain has to be filled from. A plugin with more inputs than
-    // outputs -- a stereo-in mono-out utility, anything with a sidechain -- is
-    // processed at the wider count, and the channels past its outputs still
-    // hold what was copied in. Reading those back as output hands the chain its
-    // own input, or a sidechain key, in place of the second half of a signal.
+    // What the plugin writes. Channels past this still hold what was copied
+    // in, so the chain is filled from this count and not the processed width.
     outputChannels_ = std::max(1, totalOutputs);
 
-    // Wide enough for either path: the block's channels when the plugin's width
-    // already matches, the plugin's when it does not.
+    // Wide enough for either path.
     channels_.assign(static_cast<std::size_t>(std::max(processChannels_, context.numChannels)),
                      nullptr);
 
@@ -327,9 +331,7 @@ void EngineExternalDevice::prepare(const magda::engine::RenderContext& context) 
     dryScratch_.setSize(std::max(processChannels_, context.numChannels), context.maxBlockSize,
                         false, true, false);
 
-    // What comes in, plus room for a plugin that answers with more than it was
-    // given. Both are the port's own budget, which is the only figure either
-    // side of this is sized from.
+    // What comes in, plus room for a plugin that answers with more.
     midi_.ensureSize(static_cast<std::size_t>(midiInputBoundBytes_) +
                      magda::engine::kMaxMidiBytesPerPort);
 }
@@ -359,24 +361,17 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
         const auto& mapping = parameters_[static_cast<std::size_t>(slot)];
         const auto values = params[slot];
 
-        // A slot the table does not carry is one nothing resolved: a project
-        // that saved fewer parameters than this build of the plugin has, or a
-        // wrapper pair a project never wrote. The plugin keeps whatever its own
-        // state put there, which for the pair is fully wet.
+        // A slot nothing resolved: the plugin keeps its own state, which for
+        // the wrapper pair is fully wet.
         if (values.empty())
             continue;
 
-        // The table's position, not its value: a hosted parameter is normalised
-        // by definition, and its configured display range is a reading of that
-        // position. Converting out through the range and back in is the identity
-        // only while the range is finite and agrees with the plugin's steps, and
-        // a detected dB range starts at minus infinity.
+        // The position, not the value: a hosted parameter is normalised by
+        // definition, and a configured range can be degenerate (-inf dB).
         const auto normalised = values.position();
 
         switch (mapping.role) {
             case magda::WrapperRole::DryGain:
-                // The wrapper pair is the host's own number and no chunk can
-                // carry it, so it is always taken from the model.
                 dryGain_ = normalised;
                 break;
 
@@ -384,28 +379,22 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
                 wetGain_ = normalised;
                 break;
 
-            default:
+            default: {
                 if (mapping.parameter == nullptr)
                     break;
 
-                // What the plan resolved, with nothing read into it. Whether
-                // this value came from the project's array, a lane, a macro or
-                // a knob somebody just turned is the model's business, and the
-                // one case where the model could hold something the plugin has
-                // already corrected -- a stale array beside a good chunk -- is
-                // settled before this device exists, by the restoration handing
-                // the corrected values back to whoever owns the model
-                // (ExternalPluginState.hpp). A device that tried to work that
-                // out from the numbers could not: no comparison tells a stale
-                // value apart from a lane passing through the same one.
+                // Only when the host's value moved. Comparing against the
+                // plugin's own value would revert every edit made in its editor.
+                auto& last = lastTable_[static_cast<std::size_t>(slot)];
+                if (last == normalised)
+                    break;
+                last = normalised;
 
-                // Only on a change, which is the fork's rule rather than a
-                // saving: a plugin is entitled to treat every write as a
-                // gesture, and one that rebuilds a filter or repaints an editor
-                // on each would do it every block on a parameter nobody moved.
-                if (mapping.parameter->getValue() != normalised)
-                    mapping.parameter->setValue(normalised);
+                writing_.store(true, std::memory_order_relaxed);
+                mapping.parameter->setValue(normalised);
+                writing_.store(false, std::memory_order_relaxed);
                 break;
+            }
         }
     }
 }
@@ -413,10 +402,8 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
 void EngineExternalDevice::readMidiIn(const juce::MidiBuffer& in, bool allNotesOff) {
     midi_.clear();
 
-    // The port carries the panic beside its events, since a juce::MidiBuffer
-    // has nowhere to put it (#2418), and a plugin can only be told in MIDI.
-    // Every channel: which ones it is holding notes on is its own business.
-    // Ahead of the block's own events, which may re-assert what it drops.
+    // The panic travels beside the buffer (#2418); every channel, ahead of
+    // the block's own events.
     if (allNotesOff)
         for (int channel = 1; channel <= 16; ++channel)
             midi_.addEvent(juce::MidiMessage::allNotesOff(channel), 0);
@@ -426,19 +413,13 @@ void EngineExternalDevice::readMidiIn(const juce::MidiBuffer& in, bool allNotesO
 }
 
 void EngineExternalDevice::writeMidiOut(juce::MidiBuffer& out, int numSamples) const {
-    // The plugin's own output: JUCE hands it one buffer for both directions and
-    // refills it before returning. A chain that wants the raw input asks the
-    // plan for it (DeviceInfo::midiInThru) rather than asking the plugin.
-    //
-    // JUCE's AU path refills only under wantsMidiMessages, so for a plugin with
-    // no MIDI of its own the buffer is still the input, and writing that back
-    // doubles it behind a ChainMidiMerge (#2348).
+    // JUCE's AU path refills the buffer only under wantsMidiMessages, so for a
+    // plugin with no MIDI of its own it is still the input (#2348).
     const bool pluginHasMidiOfItsOwn = instance_->acceptsMidi() || instance_->producesMidi();
     if (!pluginHasMidiOfItsOwn)
         return;
 
-    // Counted in bytes against what the executor reserved for this port, rather
-    // than the flat constant (#2341).
+    // In bytes, against what the executor reserved for this port (#2341).
     int bytesWritten = 0;
 
     for (const auto metadata : midi_) {
@@ -468,11 +449,7 @@ void EngineExternalDevice::writeExtraOutputs(magda::engine::DeviceBlock& block,
         for (int channel = 0; channel < channels; ++channel) {
             const auto from = source.firstChannel + channel;
 
-            // A pair whose channels the plugin does not have is left as it
-            // arrived, which is cleared. That is a model that recorded more
-            // pairs than this build of the plugin reports, and silence is the
-            // honest answer: the alternative is handing a track whatever
-            // happened to be in the buffer at that index.
+            // A pair this build of the plugin does not have stays cleared.
             if (from >= outputChannels_ || from >= processed.getNumChannels())
                 break;
 
@@ -503,8 +480,7 @@ void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
 
     instance_->processBlock(audio, midi_);
 
-    // Before the dry is added back, so a plugin that produced nothing usable
-    // leaves the dry signal rather than poisoning it.
+    // Before the dry is added back, so a NaN cannot poison it.
     clearNonFinite(audio, numSamples);
 
     if (wetGain_ < kWetLevelCeiling)
@@ -515,11 +491,6 @@ void EngineExternalDevice::processPluginBlock(juce::AudioBuffer<float>& audio) {
 }
 
 /// The plugin's own buffer, filled from the block, processed, and copied back.
-///
-/// The path taken whenever the plugin's width and the chain's differ, or the
-/// plugin has a sidechain bus to fill: both need a buffer that is not the
-/// executor's, since the executor's is exactly the chain's width and carries no
-/// key.
 void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& block, int numSamples,
                                                  int destChannels) {
     juce::AudioBuffer<float> audio(scratch_.getArrayOfWritePointers(), processChannels_, 0,
@@ -534,18 +505,13 @@ void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& blo
             audio.clear(channel, 0, numSamples);
     }
 
-    // The fork's two bridging rules, against the plugin's main bus rather than
-    // against its total input count. They mean the same thing: the fork's
-    // buffer already has the sidechain channels appended by the rack around it,
-    // so its total is this main count wherever these two cases can fire, and
-    // naming the main bus is what keeps a mono plugin with a mono key out of
-    // the stereo branch.
+    // Bridged against the main bus, so a mono plugin with a mono key stays out
+    // of the stereo branch.
     if (destChannels == 1 && mainInputChannels_ == 2) {
-        // Mono in, stereo wanted: duplicate rather than leave a silent side.
+        // Mono in, stereo wanted: duplicate.
         audio.copyFrom(1, 0, audio, 0, 0, numSamples);
     } else if (destChannels == 2 && mainInputChannels_ == 1) {
-        // Stereo in, mono wanted: the average, which is the sum at half gain
-        // and not the left channel.
+        // Stereo in, mono wanted: the average.
         audio.addFrom(0, 0, block.audio.getChannelPointer(1), numSamples);
         audio.applyGain(0, 0, numSamples, 0.5f);
     }
@@ -576,15 +542,7 @@ void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& blo
             juce::FloatVectorOperations::copy(destination, audio.getReadPointer(channel),
                                               numSamples);
         else if (channel < 2)
-            // A mono plugin in a stereo chain: its one output goes to both
-            // sides, so what follows it has two channels to read rather than a
-            // silent right.
-            //
-            // Bounded by the plugin's output count and not by the width it was
-            // processed at. Those differ for anything with more inputs than
-            // outputs, and there the channels between the two hold input rather
-            // than answer: a sidechain key, or the right half of a signal the
-            // plugin summed to mono.
+            // A mono plugin in a stereo chain: its one output goes to both sides.
             juce::FloatVectorOperations::copy(destination, audio.getReadPointer(0), numSamples);
         else
             juce::FloatVectorOperations::clear(destination, numSamples);
@@ -592,27 +550,10 @@ void EngineExternalDevice::processThroughScratch(magda::engine::DeviceBlock& blo
 }
 
 void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
-    // The plugin's own callback lock, and its own suspended flag. A host reading
-    // or writing this plugin's state holds one and sets the other
-    // (ExternalPluginState.hpp), and what a block may not do is touch the plugin
-    // at all while that is happening: it is entitled to be halfway through
-    // swapping a sample or a program, and neither its DSP nor its parameters are
-    // safe to reach into meanwhile.
-    //
-    // Everything plugin-facing is inside this, parameter writes included. They
-    // are the reason the gate is here rather than around the processBlock call:
-    // a capture reads the plugin's chunk and then its parameter values, and a
-    // block that moved a parameter between those two reads would produce a
-    // saved pair that disagrees with itself.
-    //
-    // Tried rather than waited on, because this is the audio thread. A block
-    // that arrives mid-transaction leaves the buffer as it was handed over,
-    // which is the passthrough the plan already gives a Device op with no
-    // instance bound.
-    //
-    // The lock is the half that makes suspension mean anything. Holding it here
-    // is what makes suspendProcessing() wait for a block already in progress
-    // rather than set a flag and return while the plugin is still running.
+    // A state read or write holds the callback lock and sets suspended
+    // (ExternalPluginState.hpp). Tried, not waited on: a block that arrives
+    // mid-transaction passes through. Parameter writes are inside the gate so
+    // a capture's chunk and parameter values agree.
     const juce::ScopedTryLock guard(instance_->getCallbackLock());
     if (!guard.isLocked() || instance_->isSuspended())
         return;
@@ -631,20 +572,9 @@ void EngineExternalDevice::process(magda::engine::DeviceBlock& block) {
 
     if (destChannels == processChannels_ && sidechainInputChannels_ == 0 &&
         outputChannels_ >= destChannels && block.extraOutputs.empty()) {
-        // The plugin's width and the block's already agree and it writes every
-        // channel the slot will be read at, so it processes the executor's own
-        // buffer and nothing is copied. The fork's fast path, and the one
-        // almost every plugin in a stereo chain takes.
-        //
-        // The output count is part of the test rather than a detail: a
-        // stereo-in mono-out plugin matches the first half of it and leaves the
-        // right channel holding the input it was handed, which is not silence
-        // and is not its answer.
-        //
-        // A multi-out instrument is out of it entirely: its further pairs live
-        // in the channels past the ones the chain reads, and processing in
-        // place into the chain's own two would leave nowhere for them to be
-        // written.
+        // In place: the widths agree and the plugin writes every channel the
+        // slot is read at. A multi-out instrument needs the scratch path for
+        // its further pairs.
         for (int channel = 0; channel < destChannels; ++channel)
             channels_[static_cast<std::size_t>(channel)] =
                 block.audio.getChannelPointer(static_cast<std::size_t>(channel));
@@ -681,18 +611,12 @@ bool EngineExternalDevice::isEditorOpen() const {
 }
 
 std::optional<magda::ExternalPluginSnapshot> EngineExternalDevice::captureState() {
-    // The read itself is engine-agnostic and stated once: what a plugin holds,
-    // in the encoding a project keeps it in, with the plugin suspended across
-    // the whole of it (ExternalPluginState.hpp). What this adds is the only
-    // thing that could not live there -- that nothing else can reach the
-    // instance to do it, so the suspension the read asks for is a suspension
-    // this device's own process() is already honouring.
+    // Shared with the fork in ExternalPluginState.hpp; process() honours the
+    // suspension it asks for.
     return magda::captureExternalPluginState(*instance_);
 }
 
 magda::SavedStateOutcome EngineExternalDevice::applyState(const magda::DeviceInfo& saved) {
-    // The write itself, including the suspension, is shared with the fork in
-    // ExternalPluginState.hpp.
     return magda::applySavedPluginState(*instance_, saved);
 }
 
@@ -700,13 +624,11 @@ juce::String EngineExternalDevice::parameterText(int slot, float normalised) con
     if (slot < 0 || slot >= static_cast<int>(parameters_.size()))
         return {};
 
-    // Null for the wrapper pair, and for a slot whose parameter this build of
-    // the plugin no longer has.
+    // Null for the wrapper pair and for a parameter this build no longer has.
     const auto* parameter = parameters_[static_cast<std::size_t>(slot)].parameter;
     if (parameter == nullptr)
         return {};
 
-    // The length the fork asks for (ExternalAutomatableParameter::valueToString).
     constexpr int kMaxTextLength = 16;
     return parameter->getText(std::clamp(normalised, 0.0f, 1.0f), kMaxTextLength);
 }

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -384,15 +384,8 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
                 break;
 
             default: {
-                if (mapping.parameter == nullptr)
+                if (mapping.parameter == nullptr || !hostValueMoved(slot, normalised))
                     break;
-
-                // Only when the host's value moved. Comparing against the
-                // plugin's own value would revert every edit made in its editor.
-                auto& last = lastTable_[static_cast<std::size_t>(slot)];
-                if (last == normalised)
-                    break;
-                last = normalised;
 
                 writing_.store(true, std::memory_order_relaxed);
                 mapping.parameter->setValue(normalised);

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -366,14 +366,12 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
         if (values.empty())
             continue;
 
-        // Through the model's own inverse rather than as a raw number. An
-        // external parameter's units are already normalised, so this is the
-        // identity for almost all of them, and the almost is the point: it is
-        // the same conversion the value went into the table through, and
-        // ParameterUtils is the only thing that knows where it is not.
-        const auto normalised =
-            mapping.info ? magda::ParameterUtils::realToNormalized(values.value(), *mapping.info)
-                         : std::clamp(values.value(), 0.0f, 1.0f);
+        // The table's position, not its value: a hosted parameter is normalised
+        // by definition, and its configured display range is a reading of that
+        // position. Converting out through the range and back in is the identity
+        // only while the range is finite and agrees with the plugin's steps, and
+        // a detected dB range starts at minus infinity.
+        const auto normalised = values.position();
 
         switch (mapping.role) {
             case magda::WrapperRole::DryGain:

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
+#include <atomic>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -15,54 +17,12 @@
  * @file EngineExternalDevice.hpp
  * @brief A VST3, AU or LV2 plugin, as the native engine's executor sees it (#2241).
  *
- * The one adapter with no MAGDA device behind it: it hosts a binary somebody
- * else shipped, whose only contract is juce::AudioPluginInstance, and owes
- * the corpus the same thing every device does -- given one project, render
- * what the fork renders. That makes this a transcription of what
- * te::ExternalPlugin does with a block, in the same order, rather than a
- * design: a difference here is a difference in every project hosting a
- * plugin, with no third opinion to appeal to. Each parity point is named
- * beside the fork's reason for it, so a future fork change shows up as a
- * diff here rather than an archaeology exercise:
- *
- * - **Channel adaptation.** Processed at `max(max(1, inputs), outputs)`
- *   channels; a mismatch with the block is bridged by the fork's rules: mono
- *   feeding stereo duplicates, stereo feeding mono averages at half gain, a
- *   mono output is spread back over a stereo block.
- * - **Wet/dry.** Every external plugin gets a slot-level dry/wet pair it
- *   never declared, defaulting fully wet, mixed in after processing and
- *   persisted (DeviceInfo::wrapperParameters) so both engines agree on what
- *   "40% wet" means.
- * - **Parameter identity.** The automatable list is dry, then wet, then the
- *   plugin's own parameters in plugin order -- the same positions MAGDA saved
- *   as ParameterInfo::paramIndex, so the live mapping must reproduce that
- *   list rather than invent one.
- * - **Chunk vs. parameter array.** A project saves a plugin both ways; where
- *   they disagree the chunk wins. Resolved before this class exists
- *   (ExternalPluginState.hpp) -- by render time the model is the answer and
- *   this only writes what the plan resolves from it.
- * - **Further output pairs.** A multi-out sampler's extra channels get a plan
- *   port each, copied out by the same mapping the engine wires its rack pins
- *   by, not a second guess at plugin output layout.
- * - **Latency.** Read once from the instance after prepareToPlay, reported to
- *   the executor, compensated like any device.
- * - **The playhead.** A tempo-synced plugin told nothing about the transport
- *   renders a different project; the block already carries the answer.
- *
- * Three known, named differences:
- *
- * - **All-notes-off flag.** The fork's MIDI container carries one and expands
- *   it into per-channel note-offs, sustain releases and an MPE reset before
- *   the plugin sees the block. juce::MidiBuffer has no such flag -- the same
- *   gap EngineMagdaDevice has, closed in one place for both.
- * - **Denormal sanitising.** The fork clamps plugin output on Intel when the
- *   CPU's denormal flag was raised. The native engine has none yet anywhere,
- *   so this isn't the place to add it -- an executor-wide question (#2240),
- *   and a no-op on Apple silicon regardless.
- * - **Transport state.** The fork's playhead reports recording state and loop
- *   points; a device under the plan gets a stretch of timeline, not a
- *   transport, so those fields stay unset until the recording/launcher
- *   subsystems can supply them (#1894, #1895).
+ * Processed at max(max(1, inputs), outputs) channels: mono feeding stereo
+ * duplicates, stereo feeding mono averages at half gain, a mono output is
+ * spread over a stereo block. Slot 0 is dry, slot 1 wet
+ * (DeviceInfo::wrapperParameters), then the plugin's automatable parameters
+ * in plugin order. Transport recording state and loop points stay unset
+ * (#1894, #1895).
  */
 
 namespace magda::daw::audio::engine_adapter {
@@ -70,30 +30,17 @@ namespace magda::daw::audio::engine_adapter {
 /**
  * @brief One external plugin instance bound to one Device op.
  *
- * Owns the instance. Everything the audio thread touches is sized in
- * prepare(): the channel pointer array, processing scratch, the dry copy the
- * wet/dry mix reads, and the MIDI buffer.
- *
- * The instance arrives created with buses already enabled; the project's
- * saved state is applied here since that order is bound up with the
- * parameter list this class builds. Instantiation itself is a message-thread
- * job elsewhere (EngineDeviceFactory.hpp).
+ * Owns the instance, which arrives created with its buses enabled
+ * (EngineDeviceFactory.hpp). Everything the audio thread touches is sized in
+ * prepare().
  */
 class EngineExternalDevice final : public magda::engine::EngineDevice {
   public:
     /**
      * @brief Binds @p instance, whose parameters @p device describes.
      *
-     * @p device is read only for parameter metadata: the plan resolves a
-     * slot's value in that parameter's own units, and its ParameterInfo
-     * converts it to the normalised position the plugin takes. The
-     * slot-to-live-parameter mapping comes from the instance, not the model
-     * -- a stale model would otherwise write a project's values onto
-     * whatever the plugin's parameters are called this version.
-     *
-     * @p offlineRender is the flag the fork sets on every external plugin
-     * before a bounce and clears after; a plugin may legitimately behave
-     * differently under it (e.g. oversampling only when bouncing).
+     * The slot-to-parameter mapping comes from the instance, not the model.
+     * @p offlineRender is passed to setNonRealtime() before prepareToPlay().
      */
     EngineExternalDevice(std::unique_ptr<juce::AudioPluginInstance> instance,
                          const magda::DeviceInfo& device, bool offlineRender);
@@ -110,150 +57,134 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
      * processed, MIDI carried.
      *
      * Passes the block through untouched while a control-side state read or
-     * write holds the plugin, instead of blocking the audio thread the way
-     * the fork's processMutex does -- the one place this class doesn't
-     * transcribe the fork verbatim. The two can only differ mid-save, and a
-     * corpus render never triggers one.
+     * write holds the plugin.
      */
     void process(magda::engine::DeviceBlock& block) override;
 
     /**
      * @brief What the plugin holds now: chunk, parameter values, VST3 records.
      *
-     * Lives here rather than behind a raw instance pointer (#2270) because
-     * reading a plugin and rendering through it must not overlap, and this
-     * object -- which holds the instance and honours the suspension in
-     * process() -- is the only thing that can enforce that.
-     *
-     * Nullopt when the plugin throws describing itself.
-     *
-     * Called on the control executor, which serialises it against every
-     * other control operation on this device (ControlExecutor.hpp) -- needed
-     * because the read suspends and resumes the plugin, and two overlapping
-     * readers would race that. process() itself is gated by the plugin's own
-     * callback lock and suspended flag, tried rather than waited on, so a
-     * capture in flight costs a block its passthrough, never the deadline.
-     *
-     * Read-only: what to do with a snapshot, and whether the device it came
-     * from is still the one the model means, is the caller's job in the
-     * control plane (DeviceControl.hpp).
+     * Call on the control executor (#2270): the read suspends the plugin, and
+     * process() honours that. Nullopt when the plugin throws describing itself.
      */
     std::optional<magda::ExternalPluginSnapshot> captureState();
 
     /**
      * @brief Write @p saved into the plugin: parameter array, then state chunk.
      *
-     * Here rather than behind the instance pointer for the same reason as
-     * captureState() (#2573). Call on the control executor. A Failed return
-     * means the plugin threw partway through and must not be read back.
+     * Call on the control executor (#2573). A Failed return means the plugin
+     * threw partway through and must not be read back.
      */
     magda::SavedStateOutcome applyState(const magda::DeviceInfo& saved);
 
     /**
      * @brief The plugin's own text for @p normalised at plan slot @p slot (#2600).
      *
-     * Empty for a slot with no live parameter and for the wrapper pair, which
-     * the plugin has never heard of.
-     *
-     * The one device operation that does not go through the control plane, and
-     * deliberately: a value's text is read inside a paint, once per cell per
-     * repaint and hundreds of times over when a lane labels its axis, so no
-     * queued round trip can serve it. It is also the only operation that
-     * earns the exemption -- it neither suspends the plugin nor changes
-     * anything about it, which is why the fork calls the same JUCE method
-     * unlocked from the message thread today
-     * (DeviceProcessor::formatParameterValue). Message thread, which is the
-     * control executor's own (ControlExecutor.hpp), so this overlaps no other
-     * control operation either.
+     * Message thread, not the control executor: it is read inside a paint.
+     * Empty for a slot with no live parameter and for the wrapper pair.
      */
     juce::String parameterText(int slot, float normalised) const;
 
-    // ===== The plugin's own window (#2580) =====
-    //
-    // Here for the same reason again: the instance has no accessor, and the
-    // object that owns it is the only one allowed to reach its editor. Call on
-    // the control executor, which is the message thread's.
+    // ===== The plugin's own window (#2580). Call on the control executor. =====
 
-    /// Open the editor, or bring it to the front. False for a plugin with no
-    /// editor of its own.
+    /// False for a plugin with no editor of its own.
     bool showEditor();
 
-    /// Close it. Silent for a window that is not open.
     void hideEditor();
 
     bool isEditorOpen() const;
 
+    /**
+     * @brief Report a parameter the plugin moved itself, on the message thread.
+     *
+     * @p sink gets the plan slot and the normalised value, coalesced per slot
+     * to one call per flush. The host's own writes are not reported.
+     */
+    void listenForPluginEdits(std::function<void(int slot, float normalised)> sink);
+
   private:
     class PlayHead;
     class EditorWindow;
+    class PluginListener;
 
     void writeParameters(const magda::engine::DeviceParams& params);
 
-    /// The plugin over one buffer, wet/dry mixed. @p audio is the buffer the
-    /// plugin processes in place, at the width it asked for.
+    /// The plugin over one buffer in place, wet/dry mixed.
     void processPluginBlock(juce::AudioBuffer<float>& audio);
 
-    /// The block through a buffer of the plugin's own width, for a plugin
-    /// whose width differs from the chain's or has a sidechain bus to fill.
+    /// For a plugin whose width differs from the chain's or has a sidechain.
     void processThroughScratch(magda::engine::DeviceBlock& block, int numSamples, int destChannels);
 
     void readMidiIn(const juce::MidiBuffer& in, bool allNotesOff);
     void writeMidiOut(juce::MidiBuffer& out, int numSamples) const;
 
-    /// The plugin's further output pairs, onto the ports the plan opened for
-    /// them. @p processed is the buffer the plugin just wrote, at its own width.
+    /// The plugin's further output pairs, onto the ports the plan opened.
     void writeExtraOutputs(magda::engine::DeviceBlock& block,
                            const juce::AudioBuffer<float>& processed, int numSamples) const;
 
     std::unique_ptr<juce::AudioPluginInstance> instance_;
     std::unique_ptr<PlayHead> playHead_;
 
-    /// The plugin's window while it is open, and null while it is not: closing
-    /// it from its own title bar is what destroys it, so this is also the
-    /// answer to whether it is showing.
+    /// Null while the window is not open; its close button resets it.
     std::unique_ptr<EditorWindow> editor_;
 
     /**
      * @brief What the plan's parameter slot at this index addresses.
      *
-     * Indexed by the fork's automatable-parameter index: zero is dry, one is
-     * wet, the rest are the plugin's own parameters in plugin order. A slot
-     * with no live parameter behind it (a plugin that has since dropped one)
-     * carries a null and is skipped, leaving the plugin at its own state.
+     * A slot with no live parameter behind it carries a null and is skipped.
      */
     struct ParameterMapping {
         juce::AudioProcessorParameter* parameter = nullptr;
         magda::WrapperRole role = magda::WrapperRole::None;
 
-        /// The model's description of this parameter, if any -- used to
-        /// convert a value out of the plan's units the same way it went in.
+        /// The model's description of this parameter, if any.
         std::optional<magda::ParameterInfo> info;
     };
 
     std::vector<ParameterMapping> parameters_;
 
-    /// The wet/dry pair, held rather than written through: the host's own
-    /// numbers, which the plugin has never heard of.
+    /// What the table delivered per slot last block. A write happens only when
+    /// this moves, so an edit made in the plugin's own editor is not reverted.
+    std::vector<float> lastTable_;
+
+    /// Set around the host's own setValue, so the listener can tell its echo
+    /// from an edit the plugin made.
+    std::atomic<bool> writing_{false};
+
+    /// Plan slot per plugin parameter index, or -1.
+    std::vector<int> slotOfParameter_;
+
+    /// The plugin's own edits, recorded on any thread and flushed on the
+    /// message thread. Shared so a flush queued before the device died is a
+    /// no-op rather than a use-after-free.
+    struct PluginEdits {
+        explicit PluginEdits(std::size_t slots) : pending(slots), dirty(slots) {}
+
+        std::vector<std::atomic<float>> pending;
+        std::vector<std::atomic<bool>> dirty;
+        std::atomic<bool> flushQueued{false};
+        std::function<void(int, float)> sink;
+    };
+
+    std::shared_ptr<PluginEdits> edits_;
+    std::unique_ptr<PluginListener> listener_;
+
+    /// The wet/dry pair: the host's own numbers, never written to the plugin.
     float dryGain_ = 0.0f;
     float wetGain_ = 1.0f;
 
     /// The width the plugin is processed at: max(max(1, inputs), outputs).
     int processChannels_ = 0;
 
-    /// How many of those channels the plugin writes -- not the same as
-    /// processChannels_ whenever it has more inputs than outputs; this is
-    /// the count the chain is filled from.
+    /// How many of those channels the plugin writes; the chain is filled from
+    /// these, not from processChannels_.
     int outputChannels_ = 0;
 
     /**
      * @brief Where each further output pair starts in the plugin's own output.
      *
-     * Entry k is the plan's `extraOutputs[k]`, i.e. pair k + 1 (pair 0 is the
-     * main output the chain carries on from). The start channel is what the
-     * model recorded reading the plugin's output buses
-     * (MultiOutOutputPair::firstPin, one-based) -- the same mapping the
-     * engine wires its rack pins by. Empty for the (near-universal) case of
-     * a non-multi-out plugin.
+     * Entry k is the plan's extraOutputs[k], pair k + 1; firstChannel is
+     * MultiOutOutputPair::firstPin made zero-based.
      */
     struct OutputPair {
         int firstChannel = 0;
@@ -262,17 +193,15 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     std::vector<OutputPair> extraOutputPairs_;
 
-    /// Input channels on the plugin's main bus, and how many follow -- the
-    /// latter is where a sidechain key lands, how every dynamics plugin takes one.
+    /// Input channels on the plugin's main bus, and how many follow it, which
+    /// is where a sidechain key lands.
     int mainInputChannels_ = 0;
     int sidechainInputChannels_ = 0;
 
-    /// Non-owning view over the block, used when the plugin's width and the
-    /// block's already agree and nothing needs copying.
+    /// Non-owning view over the block for the in-place path.
     std::vector<float*> channels_;
 
-    /// The plugin's buffer when they don't agree, and the dry copy the mix
-    /// reads. Both sized in prepare(), never resized on the audio thread.
+    /// The plugin's buffer when widths differ, and the dry copy the mix reads.
     juce::AudioBuffer<float> scratch_;
     juce::AudioBuffer<float> dryScratch_;
 
@@ -280,17 +209,14 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     double sampleRate_ = 44100.0;
 
-    /// What the instance was last prepared at, so a repeat prepare() at the
-    /// same settings is a no-op.
+    /// What the instance was last prepared at; a repeat at the same settings
+    /// is a no-op.
     int preparedBlockSize_ = 0;
 
     int latencySamples_ = 0;
     int midiInputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
 
-    /// What the executor reserved on the output port (one producer's worth --
-    /// every JUCE format replaces the host's MIDI-out buffer with what the
-    /// plugin declared, #2345). Read from the executor rather than the
-    /// constant because the figure is the port's (#2341).
+    /// What the executor reserved on the output port (#2341, #2345).
     int midiOutputBoundBytes_ = magda::engine::kMaxMidiBytesPerPort;
     bool offlineRender_ = false;
     bool prepared_ = false;

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -124,6 +124,21 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
         return slot >= 0 && slot < static_cast<int>(parameters_.size());
     }
 
+    /**
+     * @brief Whether the table's value for @p slot moved, recording it if so.
+     *
+     * Comparing against the plugin's own value instead would revert every edit
+     * made in its editor.
+     */
+    bool hostValueMoved(int slot, float normalised) {
+        auto& last = lastTable_[static_cast<std::size_t>(slot)];
+        if (last == normalised)
+            return false;
+
+        last = normalised;
+        return true;
+    }
+
     /// The plugin over one buffer in place, wet/dry mixed.
     void processPluginBlock(juce::AudioBuffer<float>& audio);
 

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
@@ -68,28 +68,15 @@ std::optional<FourOscPluginState> FourOscProcessor::capturePluginState(te::Plugi
 }
 
 void FourOscProcessor::customiseParameterInfo(int index, ParameterInfo& info) const {
-    // filterFreq stores a MIDI note in 0..135.076 that TE turns into Hz via
-    // valueToString. The custom UI pins A4 (note 69, 440 Hz) to the visual
-    // centre with setSkewForCentre(69.0); mirror that on the shared
-    // ParameterInfo so the automation lane, generic slot slider, and curve
-    // playback all agree with the plugin UI's skew. Without this, visual
-    // centre lands on note 67.5 / ~404 Hz, which doesn't match what a user
-    // dragging the FREQ knob sees.
+    // filterFreq is a MIDI note in 0..135.076; the custom UI skews it with
+    // setSkewForCentre(69.0), and the shared ParameterInfo has to match.
     if (auto params = getAutomatableParameters(); index >= 0 && index < params.size() &&
                                                   params[index] &&
                                                   params[index]->paramID == "filterFreq")
         info.scaleAnchor = 69.0f;
 
-    // 4OSC exposes raw values (note number for filter freq, 0..100 for
-    // percentage-shaped params, etc.) and relies on TE's valueToString to
-    // convert them to the correct display text (e.g. "440 Hz" for note 69).
-    // Without a DisplayTextProvider the custom-UI sliders fall through
-    // DeviceSlotComponent::updateSliders -> TextSlider::setParameterInfo,
-    // which replaces the hand-written Hz formatter with the generic
-    // ParameterUtils::formatValue one - and for a linear-scale, empty-unit
-    // parameter that just prints the raw note number. Routing the formatter
-    // through TE keeps the custom UI label correct and matches what users
-    // see in the plugin's native UI.
+    // 4OSC exposes raw values and relies on TE's valueToString for display
+    // text, so the generic formatter would print a note number instead of Hz.
     if (info.scale != ParameterScale::Boolean && info.scale != ParameterScale::Discrete &&
         info.valueTable.empty()) {
         info.displayText = makeDeviceParameterDisplayTextProvider({}, getDeviceId(), index);
@@ -102,9 +89,8 @@ void FourOscProcessor::customiseParameterInfo(int index, ParameterInfo& info) co
 
 namespace {
 
-// Shared by the effect and the instrument: both pool the same way, and both
-// filter `[hidden:1]` here rather than in meterInfoFromOutput, so "which
-// outputs get a cell" stays a display decision.
+// Shared by the effect and the instrument. `[hidden:1]` is filtered here so
+// which outputs get a cell stays a display decision.
 void populateFaustMeters(const daw::audio::FaustParamPool& pool, DeviceInfo& info) {
     info.meters.clear();
     for (int i = 0; i < daw::audio::FaustParamPool::kOutputSize; ++i) {
@@ -148,15 +134,9 @@ void FaustProcessor::populateParametersFromEngine(DeviceInfo& info) const {
         return;
     }
     info.sidechainPort = faust->properties().sidechain;
-    // Only push active, non-hidden slots so the standard ParamGridComponent
-    // shows populated cells only. Each ParameterInfo carries its real slot
-    // index in `paramIndex`, so links / automation / MIDI Learn still
-    // bind to the stable pool slot; display order is not slot identity.
-    //
-    // `[hidden:1]` slots are active - the host still writes their zone every
-    // block (that is the whole point of [role:projecttempo]) - they just get
-    // no cell. Filtering here rather than in paramInfoFromSlot keeps "which
-    // params are displayed" a display decision.
+    // Active, non-hidden slots only; `paramIndex` keeps the real slot index so
+    // links and automation bind to the stable slot. A `[hidden:1]` slot is still
+    // written every block, it just gets no cell.
     int active = 0;
     auto params = plugin_->getAutomatableParameters();
     for (int i = 0; i < daw::audio::FaustParamPool::kSize; ++i) {
@@ -239,10 +219,7 @@ void FaustInstrumentProcessor::populateParametersFromEngine(DeviceInfo& info) co
             plugin_.get());
     if (faust == nullptr)
         return;
-    // Only push active, non-hidden slots; each ParameterInfo carries its real
-    // slot index in `paramIndex` so links / automation / MIDI Learn bind to
-    // the stable slot. See the effect processor above for why `[hidden:1]`
-    // is filtered here rather than in paramInfoFromSlot.
+    // Same slot rule as FaustProcessor::populateParametersFromEngine.
     auto params = plugin_->getAutomatableParameters();
     for (int i = 0; i < daw::audio::FaustParamPool::kSize; ++i) {
         const auto& slot = faust->getPool().slot(i);
@@ -256,9 +233,7 @@ void FaustInstrumentProcessor::populateParametersFromEngine(DeviceInfo& info) co
         }
     }
 
-    // Host-owned voice allocation, appended after the patch's own controls so
-    // they read as device settings rather than as part of the patch. Present
-    // for every runtime Faust instrument, whatever the .dsp declares.
+    // Host-owned voice settings, appended after the patch's own controls.
     for (int hostIndex = 0; hostIndex < daw::audio::FaustInstrumentPlugin::kHostParamCount;
          ++hostIndex) {
         auto hostInfo = daw::audio::faustInstrumentHostParamInfo(hostIndex);

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
@@ -32,7 +32,7 @@ MagdaConvolutionProcessor::MagdaConvolutionProcessor(DeviceId deviceId, te::Plug
     : MagdaDeviceProcessor(deviceId, std::move(plugin)) {}
 
 SidechainProcessor::SidechainProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
-    : AutomatablePluginProcessor(deviceId, std::move(plugin)) {}
+    : MagdaDeviceProcessor(deviceId, std::move(plugin)) {}
 
 // =============================================================================
 // FourOscProcessor

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
@@ -9,12 +9,7 @@ namespace magda {
 
 namespace te = tracktion;
 
-/**
- * @brief Non-automatable plugin state for the 4OSC synth.
- *
- * These are CachedValues that are not exposed as AutomatableParameters, so
- * the FourOscProcessor captures them from the live plugin for the custom UI.
- */
+/// 4OSC's non-automatable CachedValues, captured from the live plugin for the custom UI.
 struct FourOscPluginState {
     int oscWaveShape[4] = {0, 0, 0, 0};
     int oscVoices[4] = {1, 1, 1, 1};
@@ -31,83 +26,45 @@ struct FourOscPluginState {
     int globalVoices = 32;  // Max polyphony
 };
 
-/**
- * @brief Processor for the built-in Magda Sampler device.
- *
- * The sampler is a MagdaDevice (#2271), so the chain holds the host's wrapper
- * and the display metadata comes from the device's own slots.
- */
+/// Processor for the built-in Magda Sampler, a MagdaDevice (#2271).
 class MagdaSamplerProcessor : public MagdaDeviceProcessor {
   public:
     MagdaSamplerProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };
 
-/**
- * @brief Processor for the native Mutable Instruments Elements synth.
- *
- * Elements is a MagdaDevice (#2299), so the chain holds the host's wrapper
- * and the display metadata comes from the device's own slots.
- */
+/// Processor for the native Mutable Instruments Elements synth, a MagdaDevice (#2299).
 class MutableElementsProcessor : public MagdaDeviceProcessor {
   public:
     MutableElementsProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };
 
-/**
- * @brief Processor for the native Mutable Instruments Rings resonator.
- *
- * Rings is a MagdaDevice (#2299), so the chain holds the host's wrapper and
- * the display metadata comes from the device's own slots.
- */
+/// Processor for the native Mutable Instruments Rings resonator, a MagdaDevice (#2299).
 class MutableRingsProcessor : public MagdaDeviceProcessor {
   public:
     MutableRingsProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };
 
-/**
- * @brief Processor for the native Mutable Instruments Clouds granular FX.
- *
- * Clouds is a MagdaDevice (#2299), so the chain holds the host's wrapper and
- * the display metadata comes from the device's own slots.
- */
+/// Processor for the native Mutable Instruments Clouds granular FX, a MagdaDevice (#2299).
 class MutableCloudsProcessor : public MagdaDeviceProcessor {
   public:
     MutableCloudsProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };
 
-/**
- * @brief Processor for the native convolution device (IR Reverb).
- *
- * The device is a MagdaDevice (#2299): gain, low cut, high cut, mix and
- * filter Q come from its slots. The impulse response itself is not a
- * parameter - it lives in the device's state and is loaded through the
- * `impulseResponseLoadFile` device command.
- */
+/// Processor for the native convolution device, a MagdaDevice (#2299). The
+/// impulse response is device state, loaded via the `impulseResponseLoadFile` command.
 class MagdaConvolutionProcessor : public MagdaDeviceProcessor {
   public:
     MagdaConvolutionProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };
 
-/**
- * @brief Processor for the Sidechain volume-shaper insert.
- *
- * A MagdaDevice behind the host wrapper, so its parameters are read through
- * the device rather than off the wrapper's normalised slots: attack and
- * release are milliseconds, and a plain AutomatablePluginProcessor wrote the
- * model's milliseconds straight into a 0-to-1 slot, where anything past 1 ms
- * clamped to the top of the range (#2613).
- */
+/// Processor for the Sidechain volume-shaper. Reads through the device, not the
+/// wrapper's normalised slots: attack and release are milliseconds (#2613).
 class SidechainProcessor : public MagdaDeviceProcessor {
   public:
     SidechainProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };
 
-/**
- * @brief Processor for the built-in 4OSC synthesizer
- *
- * Enumerates parameters generically from plugin->getAutomatableParameters().
- * The UI maps each control to its param index.
- */
+/// Processor for the built-in 4OSC synthesizer.
 class FourOscProcessor : public AutomatablePluginProcessor {
   public:
     FourOscProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
@@ -121,11 +78,8 @@ class FourOscProcessor : public AutomatablePluginProcessor {
 /**
  * @brief Processor for the MAGDA-native Faust DSP host.
  *
- * Faust's parameters live in a fixed pool of 64 lifetime-stable
- * AutomatableParameters managed by FaustPlugin. ParameterInfo per
- * slot comes from `paramInfoFromSlot(slot)`; inactive slots return a
- * placeholder so paramIndex (== slot index) stays addressable for
- * automation lane lookups.
+ * Parameters are FaustPlugin's fixed pool of 64 stable slots; paramIndex is the
+ * slot index, and an inactive slot returns a placeholder so it stays addressable.
  */
 class FaustProcessor : public DeviceProcessor {
   public:
@@ -139,12 +93,8 @@ class FaustProcessor : public DeviceProcessor {
     float getParameterByIndex(int paramIndex) const;
 };
 
-/**
- * @brief Processor for the MAGDA-native Faust polyphonic instrument.
- *
- * Identical pool-backed parameter model to FaustProcessor, but bound to
- * FaustInstrumentPlugin (the synth sibling of the Faust effect host).
- */
+/// Processor for the MAGDA-native Faust polyphonic instrument. Same pool model
+/// as FaustProcessor, bound to FaustInstrumentPlugin.
 class FaustInstrumentProcessor : public DeviceProcessor {
   public:
     FaustInstrumentProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.hpp
@@ -91,10 +91,13 @@ class MagdaConvolutionProcessor : public MagdaDeviceProcessor {
 /**
  * @brief Processor for the Sidechain volume-shaper insert.
  *
- * Parameters (gain / attack / release) are addressed by index off the
- * plugin's automatable parameters.
+ * A MagdaDevice behind the host wrapper, so its parameters are read through
+ * the device rather than off the wrapper's normalised slots: attack and
+ * release are milliseconds, and a plain AutomatablePluginProcessor wrote the
+ * model's milliseconds straight into a 0-to-1 slot, where anything past 1 ms
+ * clamped to the top of the range (#2613).
  */
-class SidechainProcessor : public AutomatablePluginProcessor {
+class SidechainProcessor : public MagdaDeviceProcessor {
   public:
     SidechainProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 };

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -1,6 +1,8 @@
 #include "PluginParameterConfigStore.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <optional>
 #include <unordered_map>
 
 #include "AppPaths.hpp"
@@ -171,12 +173,17 @@ std::optional<PluginParameterConfig> load(const juce::String& uniqueId) {
                 entry.unit = paramElem->getStringAttribute("unit");
             if (paramElem->hasAttribute("scale"))
                 entry.scale = scaleFromString(paramElem->getStringAttribute("scale"));
-            if (paramElem->hasAttribute("min"))
-                entry.rangeMin = static_cast<float>(paramElem->getDoubleAttribute("min"));
-            if (paramElem->hasAttribute("max"))
-                entry.rangeMax = static_cast<float>(paramElem->getDoubleAttribute("max"));
-            if (paramElem->hasAttribute("center"))
-                entry.rangeCenter = static_cast<float>(paramElem->getDoubleAttribute("center"));
+            // A detected dB range can start at minus infinity; nothing converts
+            // through that, so the plugin's own range stands instead.
+            const auto finiteAttribute = [&](const char* name) -> std::optional<float> {
+                if (!paramElem->hasAttribute(name))
+                    return std::nullopt;
+                const auto value = static_cast<float>(paramElem->getDoubleAttribute(name));
+                return std::isfinite(value) ? std::optional<float>(value) : std::nullopt;
+            };
+            entry.rangeMin = finiteAttribute("min");
+            entry.rangeMax = finiteAttribute("max");
+            entry.rangeCenter = finiteAttribute("center");
             if (auto* choicesElem = paramElem->getChildByName("Choices")) {
                 std::vector<juce::String> choices;
                 for (auto* choice : choicesElem->getChildIterator())

--- a/magda/daw/core/PluginParameterConfigStore.hpp
+++ b/magda/daw/core/PluginParameterConfigStore.hpp
@@ -15,21 +15,14 @@ struct DeviceInfo;
  * @brief One parameter's saved customization, as stored in the per-plugin
  * config XML.
  *
- * `index` is the position in `DeviceInfo::parameters`, used when `id` cannot
- * answer. The optional fields are
- * detection overrides (unit, scale, range, choices, value table): absent means
- * "leave whatever the device reports", which is how legacy files that predate
- * detection data keep working.
+ * An absent optional means "leave whatever the device reports".
  */
 struct PluginParameterConfigEntry {
+    /// Position in `DeviceInfo::parameters`; the fallback when `id` is absent.
     int index = -1;
 
-    /// The parameter's own id (ParameterInfo::stableId), which for a hosted
-    /// plugin is the `paramID` it declares. What an entry is matched by, with
-    /// `index` as the fallback for the files written before this existed and
-    /// for plugins that declare no ids: a plugin that gains a parameter in an
-    /// update renumbers everything after it, and a config addressed by
-    /// position then describes the wrong controls.
+    /// The parameter's own id (ParameterInfo::stableId). Matched by first, since
+    /// a plugin update that inserts a parameter renumbers everything after it.
     juce::String id;
 
     juce::String name;
@@ -53,34 +46,20 @@ struct PluginParameterConfig {
 };
 
 /**
- * @brief The per-plugin parameter customization files, owned end to end.
- *
- * One file per plugin under `paths::pluginConfigsDir()`, written by the
- * Configure Parameters dialog and by the remote API's
- * `devices.setParameterConfig`. Every reader and writer goes through here so
- * the format has exactly one owner.
+ * @brief The per-plugin parameter customization files, one per plugin under
+ * `paths::pluginConfigsDir()`. Every reader and writer goes through here.
  */
 namespace PluginParameterConfigStore {
 
-/// The wire/XML name of a parameter scale ("linear", "logarithmic",
-/// "exponential", "discrete", "boolean", "fader_db"). One owner for the
-/// vocabulary shared by the config XML and the remote API.
+/// The XML and remote API name of a parameter scale ("linear", "discrete", ...).
 juce::String scaleToString(ParameterScale scale);
 ParameterScale scaleFromString(const juce::String& name);
 
 /**
  * @brief Where each of @p config's entries lands among @p currentIds.
  *
- * One answer for every reader of a config file, because a stored entry and a
- * live parameter list can disagree: a plugin update inserts a parameter and
- * everything after it moves. Parallel to `config.entries`; -1 for an entry
- * whose parameter the plugin no longer has.
- *
- * The id decides where it can. A miss is a parameter that is gone, and is
- * dropped rather than falling back -- the position it held belongs to
- * something else now, and that something else has an entry of its own.
- * Position is the answer only when nothing can be matched: a file written
- * before ids were stored, or a plugin whose parameters declare none.
+ * Parallel to `config.entries`; -1 for a parameter the plugin no longer has.
+ * Matched by id; by position only when the file or the plugin has no ids at all.
  */
 std::vector<int> entryPositions(const PluginParameterConfig& config,
                                 const std::vector<juce::String>& currentIds);
@@ -88,32 +67,24 @@ std::vector<int> entryPositions(const PluginParameterConfig& config,
 /// The config file for `uniqueId`, whether or not it exists yet.
 juce::File configFileFor(const juce::String& uniqueId);
 
-/// Nullopt when no config exists or it does not parse. Legacy files that only
-/// list visible parameters load as entries with every other flag off and no
-/// detection overrides.
+/// Nullopt when no config exists or it does not parse.
 std::optional<PluginParameterConfig> load(const juce::String& uniqueId);
 
 bool save(const juce::String& uniqueId, const PluginParameterConfig& config);
 
-/// A config describing `device` as it stands: its parameters, its visible /
-/// mini-mixer / AI selections and its prompt. The starting point when a plugin
-/// has no config file yet.
+/// A config describing `device` as it stands.
 PluginParameterConfig fromDevice(const DeviceInfo& device);
 
-/// Load `uniqueId`'s config onto `device`: rebuilds the visible / mini-mixer /
-/// AI selections and applies any detection overrides. False when no config
-/// exists or it does not parse.
+/// Load `uniqueId`'s config onto `device`. False when none exists or it does not parse.
 bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device);
 
-/// @overload Filed under the device's own id, which is its `uniqueId` where it
-/// has one and its `pluginId` otherwise -- older devices carry only the latter.
+/// @overload Filed under the device's `uniqueId`, or `pluginId` for older devices.
 bool applyToDevice(DeviceInfo& device);
 
 /// Whether any parameter is opted in to AI/agent control, without a device.
 bool hasAiSoundDesignerParameters(const juce::String& uniqueId);
 
-/// Re-apply `uniqueId`'s config to every live device instance and notify the
-/// affected tracks. Message thread only.
+/// Re-apply `uniqueId`'s config to every live device instance. Message thread only.
 void refreshLiveDevices(const juce::String& uniqueId);
 
 }  // namespace PluginParameterConfigStore

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -431,8 +431,8 @@ bool PresetManager::loadDevicePreset(const juce::String& pluginFolder,
     legacy_devices::migrateRetiredDevice(outDevice);
     device_param_migrations::migrateDevicePreset(outDevice);
     namespace hydration = daw::audio::device_state_hydration;
-    hydration::hydrateParametersFromDeviceState(
-        outDevice, hydration::provenanceFromMagdaVersion(savedVersion));
+    hydration::completeDeviceParameters(outDevice,
+                                        hydration::provenanceFromMagdaVersion(savedVersion));
     return true;
 }
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -22,6 +22,7 @@
 #include "RackInfo.hpp"
 #include "RangesHelpers.hpp"
 #include "SelectionManager.hpp"
+#include "audio/plugins/DeviceCatalogParameters.hpp"
 #include "audio/plugins/InternalPluginRegistry.hpp"
 
 namespace magda {
@@ -2181,6 +2182,7 @@ DeviceId TrackManager::addDeviceToPostFx(TrackId trackId, const DeviceInfo& devi
     DeviceInfo newDevice = device;
     newDevice.id = nextPostFxDeviceId_++;
     applyCachedCapabilitiesToDevice(newDevice);
+    daw::audio::seedDeclaredParameters(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
         newDevice.deviceType = DeviceType::Analysis;
 
@@ -2252,6 +2254,7 @@ DeviceId TrackManager::addDeviceToMixerAnalysis(TrackId trackId, const DeviceInf
     DeviceInfo newDevice = device;
     newDevice.id = nextMixerAnalysisDeviceId_++;
     applyCachedCapabilitiesToDevice(newDevice);
+    daw::audio::seedDeclaredParameters(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
         newDevice.deviceType = DeviceType::Analysis;
     track->chain.mixerAnalysisElements.push_back(PostFxChainElement{newDevice});

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -6,6 +6,7 @@
 #include "../audio/AudioBridge.hpp"
 #include "../audio/TracktionHelpers.hpp"
 #include "../audio/plugin_manager/ExternalPluginStateUtil.hpp"
+#include "../audio/plugins/DeviceCatalogParameters.hpp"
 #include "../audio/plugins/InternalPluginRegistry.hpp"
 #include "../audio/plugins/tracktion/TracktionDeviceStateBridge.hpp"
 #include "../engine/AudioEngine.hpp"
@@ -2081,6 +2082,7 @@ DeviceInfo TrackManager::prepareNewDevice(TrackId trackId, const DeviceInfo& dev
     retargetPadLinks(newDevice, trackId, ids);
 
     applyCachedCapabilitiesToDevice(newDevice);
+    daw::audio::seedDeclaredParameters(newDevice);
     stampDefaultKitIfMissing(newDevice);
     if (daw::audio::isInternalAnalysisPlugin(newDevice.pluginId))
         newDevice.deviceType = DeviceType::Analysis;

--- a/magda/daw/engine/DeviceParameterScan.cpp
+++ b/magda/daw/engine/DeviceParameterScan.cpp
@@ -4,38 +4,14 @@
 #include <memory>
 #include <utility>
 
-#include "../audio/plugins/InternalPluginRegistry.hpp"
+#include "../audio/plugins/DeviceCatalogParameters.hpp"
 #include "../audio/plugins/MagdaDevice.hpp"
-#include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "../core/ParameterUtils.hpp"
 
 namespace magda {
 namespace {
 
 namespace audio = daw::audio;
-
-/// A device built to be asked questions and dropped. No session key: the
-/// services behind one are a running engine's, and nothing here may reach them.
-/// EngineDeviceFactory does the same for a device it is about to run, but that
-/// lives in the native engine's own target and the fork cannot link it.
-std::unique_ptr<audio::MagdaDevice> createDetachedDevice(const juce::String& pluginId) {
-    juce::ValueTree state(juce::Identifier("PLUGIN"));
-    state.setProperty(juce::Identifier("type"), pluginId, nullptr);
-    const audio::DevicePluginCreationContext context{
-        .sessionKey = {}, .state = std::move(state), .isNewPlugin = true};
-
-    // The internal registry first, because that is the catalog an id is
-    // canonicalised against; a compiled device is not in it.
-    if (const auto* spec = audio::findInternalPluginSpec(pluginId); spec != nullptr)
-        if (spec->createDevice != nullptr)
-            return spec->createDevice(context);
-
-    if (const auto* spec = audio::compiled::findCompiledPluginSpec(pluginId); spec != nullptr)
-        if (spec->createDevice != nullptr)
-            return spec->createDevice(context);
-
-    return {};
-}
 
 /// One scan record off one parameter's own description. `position` is where the
 /// record lands in the result rather than the slot it was read from: a skipped
@@ -86,7 +62,7 @@ ScannedPluginParameter scanRecord(const ParameterInfo& info, int position) {
 std::vector<ScannedPluginParameter> scanDeviceParameters(const juce::String& pluginId) {
     std::vector<ScannedPluginParameter> result;
 
-    const auto device = createDetachedDevice(pluginId);
+    const auto device = audio::createDetachedDevice(pluginId);
     if (device == nullptr)
         return result;
 

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -20,7 +20,6 @@
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ChainWalk.hpp"
 #include "../../core/ClipManager.hpp"
-#include "../../core/PluginParameterConfigStore.hpp"
 #include "../../core/TempoMap.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../project/ProjectManager.hpp"
@@ -817,12 +816,6 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         // Asked with the segment, because a DeviceId is section-local and on
         // its own names up to three devices (#1899).
         const auto path = TrackManager::getInstance().findDevicePath(key.deviceId, key.segment);
-
-        // What the plugin's parameters were detected to mean, over the bare
-        // normalised records the adapter builds from the instance. Here because
-        // the array is rebuilt on every load, and a unit that only survived
-        // until the next one is a unit nobody configured twice (#2601).
-        PluginParameterConfigStore::applyToDevice(*device);
 
         // Here rather than where the parameters were described, because this is
         // where the device's address is known: a DeviceInfo does not say which

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -242,6 +242,15 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
                   }) {
         factory_.loadExternalsWith(loader_);
 
+        // Captures nothing: the model is a singleton and the request guards
+        // the key, so a project that closed first is a no-op.
+        loader_.onPluginEdit([](engine::DeviceKey key, int slot, float normalised) {
+            auto& tracks = TrackManager::getInstance();
+            const auto path = tracks.findDevicePath(key.deviceId, key.segment);
+            if (path.isValid())
+                tracks.setDeviceParameterValueFromPlugin(path, slot, normalised);
+        });
+
         // A tap read late loses nothing, since the peak is held until
         // something takes it, so this is how smooth a meter looks.
         startTimer(kMeterIntervalMs);

--- a/magda/daw/engine/host/ExternalPluginLoader.cpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.cpp
@@ -3,6 +3,8 @@
 #include <set>
 #include <utility>
 
+#include "../../audio/plugins/engine/EngineExternalDevice.hpp"
+
 namespace magda::daw::engine_host {
 
 namespace adapter = magda::daw::audio::engine_adapter;
@@ -30,6 +32,10 @@ void ExternalPluginLoader::setServices(juce::AudioPluginFormatManager* formats,
                                        const juce::KnownPluginList* knownPlugins) {
     services_.formats = formats;
     services_.knownPlugins = knownPlugins;
+}
+
+void ExternalPluginLoader::onPluginEdit(PluginEdit sink) {
+    pluginEdit_ = std::move(sink);
 }
 
 void ExternalPluginLoader::setContext(const engine::RenderContext& context) {
@@ -166,6 +172,13 @@ void ExternalPluginLoader::complete(engine::DeviceKey key, std::uint64_t generat
 
         return;
     }
+
+    if (auto* external = dynamic_cast<adapter::EngineExternalDevice*>(result.device.get()))
+        external->listenForPluginEdits(
+            [sink = pluginEdit_, request = assignments_.request(key), key](int at, float value) {
+                if (sink && request.isStillWanted())
+                    sink(key, at, value);
+            });
 
     slot.instance = std::move(result.device);
     juce::Logger::writeToLog("[engine] loaded \"" + result.resolvedDevice->name + "\"");

--- a/magda/daw/engine/host/ExternalPluginLoader.hpp
+++ b/magda/daw/engine/host/ExternalPluginLoader.hpp
@@ -74,6 +74,12 @@ class ExternalPluginLoader final {
      */
     void syncAssignments(const std::map<engine::DeviceKey, DeviceInfo>& devices);
 
+    using PluginEdit = std::function<void(engine::DeviceKey key, int slot, float normalised)>;
+
+    /// Where a parameter the plugin moved itself is reported, on the message
+    /// thread, for as long as the key still names that plugin.
+    void onPluginEdit(PluginEdit sink);
+
     /**
      * @brief The instance for @p key, or nothing yet.
      *
@@ -131,6 +137,7 @@ class ExternalPluginLoader final {
 
     audio::engine_adapter::CurrentDeviceLookup currentDevice_;
     Loaded loaded_;
+    PluginEdit pluginEdit_;
 
     audio::engine_adapter::ExternalPluginServices services_;
     audio::engine_adapter::PluginAssignments assignments_;

--- a/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolySynthUI.cpp
@@ -519,6 +519,7 @@ void PolySynthUI::updateFromParameters(const std::vector<magda::ParameterInfo>& 
         }
         c.slider->setValue(info.currentValue, juce::dontSendNotification);
 
+        syncGraphFromParam(idx, info.currentValue);
         syncFilterCurveFromParam(idx, info.currentValue);
         if (idx < kNumOscillators * kOscSlotCount && (idx % kOscSlotCount) == 0)
             updateWaveSelectors();  // wave slot -> dropdown

--- a/magda/engine/param/ParamBlock.hpp
+++ b/magda/engine/param/ParamBlock.hpp
@@ -10,23 +10,10 @@
 
 /**
  * @file ParamBlock.hpp
- * @brief What a device reads when it asks what a parameter is right now.
+ * @brief The resolved parameter values a device reads for one block.
  *
- * A parameter is written by several things at once: the stored value a fader or
- * a control surface sets, the automation curve playing over it, the modifiers
- * linked to it. None of that reaches a device. What reaches a device is one
- * resolved value stream per parameter, in the parameter's own units, already
- * clamped and already quantised, and it is the only thing a device is allowed to
- * read. Nothing downstream of here can rediscover what automation and modulation
- * do to each other, because nothing downstream of here is shown them.
- *
- * The stream is segments rather than a scalar, and that is what lets "resolved
- * once per block" and "a ramp inside the block" both be true. A parameter that
- * does not move is one segment and costs a float; a parameter sweeping under
- * automation is a handful, and a device that asked for them reads a value per
- * sample without any of them asking where it came from.
- *
- * Resolution itself is ParamResolve.hpp. This is the shape the answer has.
+ * Stored value, automation and modulation are combined by ParamResolve.hpp into
+ * one segment stream per parameter; a device reads only that stream.
  */
 
 namespace magda::engine {
@@ -34,26 +21,11 @@ namespace magda::engine {
 /**
  * @brief One stretch of a block over which a parameter moves linearly.
  *
- * The value at @ref startSample is @ref startValue, and it travels to
- * @ref endValue, which is the value at the first sample the next segment covers,
- * or one past the block's last sample for the final segment. Two segments in a
- * row therefore meet exactly, and a step is a segment whose start differs from
- * the previous one's end rather than a pair of points at one sample.
- *
- * Normalised positions, unclamped, wherever a segment appears: in an automation
- * lane on the way in, and in the resolved stream on the way out. A device still
- * reads Hz and dB, because ParamValues converts on the way past, and the two
- * facts have to go together.
- *
- * A segment that carried the parameter's own units could not be read correctly
- * at any sample but its ends. Interpolating between two converted endpoints is
- * only the same as converting the interpolated position when the scale is a
- * straight line: on a logarithmic cutoff sweeping its whole range, the halfway
- * point is 632 Hz through the scale and 10,010 Hz through the chord across it.
- * Leaving the values unclamped is the same argument one step further out. A ramp
- * that leaves the range partway through holds at the top from there on, and a
- * pair of clamped endpoints describes a slower ramp that arrives at the end
- * instead, which is a plateau the parameter never had.
+ * @ref endValue is the value at the first sample of the next segment, or one
+ * past the block for the last. Values are unclamped normalised positions: the
+ * scale and the clamp are applied per sample by ParamValues, since converting or
+ * clamping the endpoints first misreads a curved scale or a ramp that leaves the
+ * range mid-block.
  */
 struct ParamSegment {
     int startSample = 0;
@@ -64,13 +36,8 @@ struct ParamSegment {
 /**
  * @brief One parameter's resolved value over one block.
  *
- * A view over segments the resolver wrote; it owns nothing and outlives
- * nothing. Handed to a device inside its DeviceBlock and dead when the block is.
- *
- * The clamp and the scale are applied here rather than by the resolver, at the
- * position being read rather than at the ends of a segment, which is the only
- * place either can be applied correctly (see ParamSegment). The device sees the
- * parameter's own units and no sign of where the arithmetic happened.
+ * A non-owning view over the resolver's segments, valid for the block only.
+ * Converts to the parameter's own units at the sample being read.
  */
 class ParamValues {
   public:
@@ -80,54 +47,30 @@ class ParamValues {
                 const magda::ParameterUtils::ParameterDomain& domain, int numSamples)
         : segments_(segments), domain_(domain), numSamples_(numSamples) {}
 
-    /**
-     * @brief The parameter's value for the block.
-     *
-     * The value at its first sample, which is what the incumbent engine's
-     * parameters take at a block boundary. A device that has not asked for
-     * segments reads this and is no further from the fork than the fork is from
-     * itself.
-     */
+    /// The value at the block's first sample, in the parameter's own units.
     float value() const {
         return segments_.empty()
                    ? 0.0f
                    : magda::ParameterUtils::normalizedToReal(segments_.front().startValue, domain_);
     }
 
-    /**
-     * @brief The parameter's normalised position for the block, in 0..1.
-     *
-     * For a device whose parameter is normalised by definition, a hosted
-     * plugin's: its display range is a reading of the position, not a unit the
-     * position has to pass through and back.
-     */
+    /// The normalised position at the block's first sample, clamped to 0..1.
+    /// For a hosted plugin, whose parameter is normalised by definition.
     float position() const {
         return segments_.empty() ? 0.0f : juce::jlimit(0.0f, 1.0f, segments_.front().startValue);
     }
 
-    /**
-     * @brief The parameter's value at one sample of the block.
-     *
-     * For a device that asked for segment accuracy. Offsets outside the block
-     * clamp to its ends rather than reading off either side of the segments.
-     */
+    /// The value at @p sampleOffset, clamped to the block's ends.
     float valueAt(int sampleOffset) const;
 
-    /// Whether the parameter holds one value for the whole block. True for
-    /// everything the port produces, since the fork settles parameters at block
-    /// boundaries and nothing opts out of that during the port.
-    ///
-    /// Read off the stored positions rather than the values they convert to, so
-    /// a stream that moves only outside the range says it moves. A device using
-    /// this to skip a per-sample read is told to do the work it did not need,
-    /// which is the direction that costs nothing but time.
+    /// Whether the parameter holds one value for the whole block. Judged on the
+    /// stored positions, so a ramp entirely outside the range still counts as moving.
     bool isConstant() const {
         return segments_.size() <= 1 &&
                (segments_.empty() || segments_.front().startValue == segments_.front().endValue);
     }
 
-    /// No segments at all, which is a parameter nothing resolved. A device
-    /// reading one is a bug upstream of it, not a value it should try to use.
+    /// No segments: nothing resolved this parameter.
     bool empty() const {
         return segments_.empty();
     }
@@ -151,12 +94,9 @@ class ParamValues {
 };
 
 /**
- * @brief The parameters of one device, in the order the device declared them.
+ * @brief The parameters of one device, indexed by ParameterInfo::paramIndex.
  *
- * A device indexes its own parameters from zero, the way ParameterInfo's
- * paramIndex does, and never learns where in the table they sit. The window is
- * contiguous because a device's parameters are allocated together, which is what
- * makes this a pair of integers rather than a map.
+ * A contiguous window of the table; the device never sees table ids.
  */
 class DeviceParams {
   public:
@@ -175,10 +115,7 @@ class DeviceParams {
         return static_cast<int>(counts_.size());
     }
 
-    /// The device's parameter @p paramIndex. An index the device does not have
-    /// is an empty view: the table is sized from the device's own specs when the
-    /// plan is prepared, so this is a device asking for a parameter it never
-    /// declared.
+    /// The device's parameter @p paramIndex; empty for one it never declared.
     ParamValues operator[](int paramIndex) const;
 
   private:
@@ -192,28 +129,17 @@ class DeviceParams {
 /**
  * @brief Every parameter behind one plan, resolved for one block.
  *
- * One table, indexed by the parameter ids the plan hands out, with each
- * parameter's segments in a fixed-width slot of a flat arena. Fixed width
- * because the arena is allocated once, off the audio thread, and a parameter
- * that needed to grow mid-block would be an allocation on it.
- *
- * The width is a budget, like the MIDI one in EngineDevice.hpp, and a curve with
- * more breakpoints than fit is coarsened rather than cut off. What that means
- * differs by what the parameter is, and both readings keep the destination: a
- * continuous parameter rolls the tail into its last segment, which ramps to
- * where the curve ends, and a stepped one spends its last slot on the step the
- * curve ends on, losing the steps in between instead of the arrival.
+ * A flat arena of fixed-width segment slots, allocated once off the audio
+ * thread. A curve with more breakpoints than fit is coarsened, keeping its end
+ * value: a continuous parameter ramps its last segment to it, a stepped one
+ * lands its last slot on it.
  */
 class ResolvedParams {
   public:
-    /// Segments per parameter when nothing says otherwise. Sixteen breakpoints
-    /// is a curve moving faster than a block at any usable block size, and a
-    /// parameter that is not automated uses one of them.
+    /// Segments per parameter when nothing says otherwise.
     static constexpr int kDefaultSegmentCapacity = 16;
 
-    /// Off the audio thread, before the first block. Every parameter starts
-    /// empty; a block that resolves nothing hands out empty views rather than
-    /// stale ones.
+    /// Off the audio thread, before the first block. Every parameter starts empty.
     void prepare(int numParams, int segmentCapacity = kDefaultSegmentCapacity);
 
     /// How many parameters the table holds.
@@ -230,28 +156,15 @@ class ResolvedParams {
         return numSamples_;
     }
 
-    /// On the audio thread, at the top of a block, before anything resolves
-    /// into it. Empties every parameter and records the block length, so a
-    /// parameter nobody resolved this block reads as empty rather than as
-    /// whatever it was last block.
+    /// Audio thread, at the top of a block: empties every parameter and records
+    /// the block length, so an unresolved parameter reads as empty, not stale.
     void beginBlock(int numSamples);
 
-    /// On the audio thread: the values @p param resolved to. Empty for a
-    /// parameter the table does not have.
+    /// Audio thread: the values @p param resolved to; empty for an unknown param.
     ParamValues operator[](int param) const;
 
-    /**
-     * @brief What a link reading @p param as its source gets.
-     *
-     * The position the parameter opens the block at, clamped into range: a
-     * macro is a source between nothing and everything whatever the arithmetic
-     * that produced it did, and a source is read once per block because that is
-     * what a modulation contribution is.
-     *
-     * Zero for a parameter that has not resolved yet, which the resolution
-     * order exists to make unreachable: a source is resolved before whatever
-     * reads it.
-     */
+    /// What a link reading @p param as its source gets: the clamped position at
+    /// the block's first sample. Zero if it has not resolved yet.
     float sourceValue(int param) const;
 
     /// The window a device reads: @p count parameters from @p firstParam.
@@ -261,15 +174,11 @@ class ResolvedParams {
     /// parameter the table has; @ref segmentCapacity() wide.
     ParamSegment* slotFor(int param);
 
-    /// How many segments @p param currently holds, and what it holds after the
-    /// resolver has written them.
+    /// How many segments @p param holds.
     int segmentCount(int param) const;
     void setSegmentCount(int param, int count);
 
-    /// The scale @p param's stored positions are read through. Written by the
-    /// resolver from the parameter's spec, and travelling with the values
-    /// rather than beside them, because a position without the scale that
-    /// interprets it is not a value at all.
+    /// The scale @p param's stored positions are read through.
     void setDomain(int param, const magda::ParameterUtils::ParameterDomain& domain);
 
   private:

--- a/magda/engine/param/ParamBlock.hpp
+++ b/magda/engine/param/ParamBlock.hpp
@@ -95,6 +95,17 @@ class ParamValues {
     }
 
     /**
+     * @brief The parameter's normalised position for the block, in 0..1.
+     *
+     * For a device whose parameter is normalised by definition, a hosted
+     * plugin's: its display range is a reading of the position, not a unit the
+     * position has to pass through and back.
+     */
+    float position() const {
+        return segments_.empty() ? 0.0f : juce::jlimit(0.0f, 1.0f, segments_.front().startValue);
+    }
+
+    /**
      * @brief The parameter's value at one sample of the block.
      *
      * For a device that asked for segment accuracy. Offsets outside the block

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -512,13 +512,16 @@ void Builder::allocateDevice(const Node& node) {
             continue;
         }
 
-        // The model's own inverse, rather than a straight read of the range:
-        // an external plugin's stored value and its display range are not the
-        // same number, and only ParameterUtils knows which parameters those
-        // are.
-        const auto normalised = magda::ParameterUtils::modelToNormalizedValue(
-            magda::ParameterModelValue{info->currentValue}, *info);
-        add(key, paramSpecFrom(*info), normalised.value);
+        // A hosted plugin's stored value is the normalised one, whatever range
+        // a config gave it to display through. Only an internal device's is
+        // read through the model's inverse, which guesses from the ranges and
+        // guesses wrong for a configured external parameter.
+        const auto normalised = device.format == magda::PluginFormat::Internal
+                                    ? magda::ParameterUtils::modelToNormalizedValue(
+                                          magda::ParameterModelValue{info->currentValue}, *info)
+                                          .value
+                                    : std::clamp(info->currentValue, 0.0f, 1.0f);
+        add(key, paramSpecFrom(*info), normalised);
     }
 
     // Reported for a device MAGDA ships and not for one it hosts, because it is

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TEST_SOURCES
     devices/test_plugin_format.cpp
     devices/test_device_authored_state.cpp
     devices/test_sampler_model_edits.cpp
+    devices/test_device_catalog_parameters.cpp
     devices/test_device_state_hydration.cpp
     devices/test_internal_plugin_registry.cpp
     # Engine-neutral internal device state schema v2 (issue #1887)

--- a/tests/devices/test_device_catalog_parameters.cpp
+++ b/tests/devices/test_device_catalog_parameters.cpp
@@ -1,0 +1,127 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/audio/plugins/ArpeggiatorPlugin.hpp"
+#include "magda/daw/audio/plugins/DeviceCatalogParameters.hpp"
+#include "magda/daw/audio/plugins/DeviceStateHydration.hpp"
+#include "magda/daw/audio/plugins/compiled/MagdaPolySynthCompiledPlugin.hpp"
+#include "magda/daw/core/ChainWalk.hpp"
+#include "magda/daw/core/DeviceState.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+
+using namespace magda;
+namespace ds = magda::device_state;
+namespace hydration = magda::daw::audio::device_state_hydration;
+
+// ============================================================================
+// #2613 - the model carries a MAGDA device's parameters whichever engine
+// renders. Only the fork ever filled the array, off a plugin in its Edit, so a
+// device added under the native engine had none and every write to one was
+// dropped for want of an entry to land on.
+// ============================================================================
+
+namespace {
+
+using magda::daw::audio::seedDeclaredParameters;
+
+DeviceInfo internalDevice(const juce::String& pluginId) {
+    DeviceInfo device;
+    device.id = 1;
+    device.format = PluginFormat::Internal;
+    device.pluginId = pluginId;
+    return device;
+}
+
+const char* kPolySynth = magda::daw::audio::compiled::MagdaPolySynthCompiledPlugin::xmlTypeName;
+
+}  // namespace
+
+TEST_CASE("Seeding gives the model every parameter a device declares", "[device-catalog-params]") {
+    auto device = internalDevice(kPolySynth);
+    REQUIRE(device.parameters.empty());
+
+    REQUIRE(seedDeclaredParameters(device));
+    REQUIRE_FALSE(device.parameters.empty());
+
+    // Addressed by the index the device declared, and carrying the metadata the
+    // plan's value layer converts through.
+    for (int index = 0; index < static_cast<int>(device.parameters.size()); ++index) {
+        const auto* param = device.findParameterByIndex(index);
+        REQUIRE(param != nullptr);
+        CHECK(param->name.isNotEmpty());
+        CHECK(param->currentValue == Catch::Approx(param->defaultValue));
+    }
+}
+
+TEST_CASE("Seeding leaves a parameter the model already carries alone", "[device-catalog-params]") {
+    auto device = internalDevice(kPolySynth);
+
+    ParameterInfo edited;
+    edited.paramIndex = 0;
+    edited.name = "Osc 1 Wave";
+    edited.currentValue = 2.0f;
+    device.parameters.push_back(edited);
+
+    REQUIRE(seedDeclaredParameters(device));
+
+    const auto* kept = device.findParameterByIndex(0);
+    REQUIRE(kept != nullptr);
+    CHECK(kept->currentValue == Catch::Approx(2.0f));
+    CHECK(device.parameters.size() > 1);
+
+    // And a second pass finds nothing left to add.
+    CHECK_FALSE(seedDeclaredParameters(device));
+}
+
+TEST_CASE("Seeding is not for a plugin somebody else shipped", "[device-catalog-params]") {
+    auto device = internalDevice(kPolySynth);
+    device.format = PluginFormat::VST3;
+
+    CHECK_FALSE(seedDeclaredParameters(device));
+    CHECK(device.parameters.empty());
+}
+
+TEST_CASE("A saved value survives the seed that completes its array", "[device-catalog-params]") {
+    // Hydration first, seeding second: the other order would make the saved
+    // value look like one the model already had, and it would be dropped.
+    auto device = internalDevice(daw::audio::ArpeggiatorPlugin::xmlTypeName);
+
+    ds::Doc doc;
+    doc.deviceType = device.pluginId;
+    doc.paramsAreDisplayDomain = true;
+    doc.params.push_back({daw::audio::ArpeggiatorPlugin::kGate, "gate", 0.8f});
+    device.pluginState = ds::encode(doc);
+
+    hydration::completeDeviceParameters(device);
+
+    const auto* gate = device.findParameterByIndex(daw::audio::ArpeggiatorPlugin::kGate);
+    REQUIRE(gate != nullptr);
+    CHECK(gate->currentValue == Catch::Approx(0.8f));
+    CHECK(device.parameters.size() > 1);
+}
+
+TEST_CASE("A device added to a track takes a parameter write",
+          "[device-catalog-params][.singleton]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = tracks.createTrack("Synth");
+
+    DeviceInfo synth;
+    synth.name = "Poly Synth";
+    synth.pluginId = kPolySynth;
+    synth.format = PluginFormat::Internal;
+    const auto deviceId = tracks.addDeviceToTrack(trackId, synth);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    const auto path = chain_walk::deviceIn(ChainNodePath::trackLevel(trackId), deviceId);
+    const auto* placed = tracks.getDeviceInChainByPath(path);
+    REQUIRE(placed != nullptr);
+    REQUIRE_FALSE(placed->parameters.empty());
+
+    const auto* before = placed->findParameterByIndex(0);
+    REQUIRE(before != nullptr);
+    const auto moved = before->currentValue + 1.0f;
+
+    tracks.setDeviceParameterValue(path, 0, moved);
+    CHECK(tracks.getDeviceInChainByPath(path)->findParameterByIndex(0)->currentValue ==
+          Catch::Approx(moved));
+}

--- a/tests/engine/test_automation_bake.cpp
+++ b/tests/engine/test_automation_bake.cpp
@@ -62,6 +62,9 @@ DeviceInfo makeDevice(DeviceId id, int numParameters = 1) {
     device.id = id;
     device.name = "Effect " + juce::String(id);
     device.deviceType = DeviceType::Effect;
+    // An internal device: its stored value is the display one, which is what
+    // the ranges below describe. A hosted plugin's would be normalised.
+    device.format = PluginFormat::Internal;
     device.macros = createDefaultMacros(1);
     device.mods = createDefaultMods(0);
 

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -1327,11 +1327,8 @@ TEST_CASE("A parameter that did not move is not written again", "[engine][extern
         device.process(deviceBlock);
     }
 
-    // Once, on the block that moved it. The fork writes a plugin parameter only
-    // when the value differs from what the plugin already reports, because a
-    // plugin is entitled to treat every write as a gesture: one that rebuilds a
-    // filter or repaints an editor on each would do it every block on a
-    // parameter nobody touched.
+    // Once, on the block that moved it: a plugin is entitled to treat every
+    // write as a gesture.
     CHECK(raw->gain->writes == writesAfterConstruction + 1);
 
     ParamArena moved({0.0f, 1.0f, 0.7f, 0.0f});
@@ -1339,6 +1336,38 @@ TEST_CASE("A parameter that did not move is not written again", "[engine][extern
     device.process(movedBlock);
 
     CHECK(raw->gain->writes == writesAfterConstruction + 2);
+}
+
+TEST_CASE("An edit made in the plugin's own editor is not reverted", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    ParamArena held({0.0f, 1.0f, 0.6f, 0.0f});
+    Block block(context, 2);
+
+    auto first = block.deviceBlock(held.params(context.maxBlockSize));
+    device.process(first);
+    REQUIRE(raw->gain->getValue() == Catch::Approx(0.6f));
+
+    // The plugin moves its own knob. The table still says 0.6, and the host did
+    // not move it, so the next block must leave the plugin's value alone.
+    raw->gain->setValue(0.8f);
+    const auto writesBefore = raw->gain->writes;
+
+    auto second = block.deviceBlock(held.params(context.maxBlockSize));
+    device.process(second);
+    CHECK(raw->gain->getValue() == Catch::Approx(0.8f));
+    CHECK(raw->gain->writes == writesBefore);
+
+    // A value the host did move still lands.
+    ParamArena moved({0.0f, 1.0f, 0.3f, 0.0f});
+    auto third = block.deviceBlock(moved.params(context.maxBlockSize));
+    device.process(third);
+    CHECK(raw->gain->getValue() == Catch::Approx(0.3f));
 }
 
 TEST_CASE("A parameter the table does not carry is left where it was", "[engine][external]") {

--- a/tests/project/test_utility_width_migration.cpp
+++ b/tests/project/test_utility_width_migration.cpp
@@ -63,10 +63,15 @@ struct MigrationFixture {
     }
 };
 
+/// MagdaUtilityCompiledPlugin::kWidthSlot. The device declares seven more
+/// parameters the model seeds around this one (#2613), so Width is addressed by
+/// its index rather than by where it sits in the array.
+constexpr int kWidthSlot = 2;
+
 ParameterInfo makeWidthParam(float minValue, float maxValue, float defaultValue,
                              float currentValue) {
     ParameterInfo param;
-    param.paramIndex = 2;  // MagdaUtilityCompiledPlugin::kWidthSlot
+    param.paramIndex = kWidthSlot;
     param.name = "Width";
     param.minValue = minValue;
     param.maxValue = maxValue;
@@ -109,13 +114,13 @@ TEST_CASE("Old-scale Utility Width migrates to percent on load",
     REQUIRE(isDevice(track->chain.fxChainElements[0]));
 
     const auto& device = getDevice(track->chain.fxChainElements[0]);
-    REQUIRE(device.parameters.size() == 1);
-    const auto& width = device.parameters[0];
-    CHECK(width.currentValue == 150.0f);
-    CHECK(width.minValue == 0.0f);
-    CHECK(width.maxValue == 200.0f);
-    CHECK(width.defaultValue == 100.0f);
-    CHECK(width.unit == "%");
+    const auto* width = device.findParameterByIndex(kWidthSlot);
+    REQUIRE(width != nullptr);
+    CHECK(width->currentValue == 150.0f);
+    CHECK(width->minValue == 0.0f);
+    CHECK(width->maxValue == 200.0f);
+    CHECK(width->defaultValue == 100.0f);
+    CHECK(width->unit == "%");
 }
 
 TEST_CASE("Percent-scale Utility Width passes through load unchanged",
@@ -146,7 +151,8 @@ TEST_CASE("Percent-scale Utility Width passes through load unchanged",
     REQUIRE(track->chain.fxChainElements.size() == 1);
 
     const auto& device = getDevice(track->chain.fxChainElements[0]);
-    REQUIRE(device.parameters.size() == 1);
-    CHECK(device.parameters[0].currentValue == 150.0f);
-    CHECK(device.parameters[0].maxValue == 200.0f);
+    const auto* width = device.findParameterByIndex(kWidthSlot);
+    REQUIRE(width != nullptr);
+    CHECK(width->currentValue == 150.0f);
+    CHECK(width->maxValue == 200.0f);
 }


### PR DESCRIPTION
Four commits on the parameter path that #2613 opened up.

**Seed a MAGDA device's parameters into the model from the catalog.** A MAGDA device's parameter records come off the catalog at creation, so a faceplate built from the model has something to build from on either engine.

**Read the Sidechain's parameters through the device, not the wrapper's slots.** The Sidechain processor reads its parameters by the device's own indices.

**Apply a plugin's parameter config before the native device is built.** The factory built `EngineExternalDevice` from a copy of the parameter list where every parameter was 0..1, and only afterwards did the host apply the saved parameter config to the model. The plan converted values out through the config's units and the device converted them back through plain 0..1, so every configured parameter reached the plugin through two different domains, on every block. Diva's Output is configured as 0 to 200 dB and clamped to full; discrete and boolean entries landed on wrong steps. Diva was glitchy and left-only; only plugins with a config on disk were affected.

**Hand a hosted plugin the table's normalised position, not a round trip.** A hosted plugin's parameter is normalised by definition, and the model stores it that way. The compiler seeded the table through `modelToNormalizedValue`, which guesses the convention from the ranges and guesses wrong for a configured parameter with no text provider yet, and the device converted the real-unit value back through the same range. Serum 2's detected Main Vol starts at minus infinity, the round trip produced NaN, and the plugin was silent. The compiler now seeds a hosted device's slot from the clamped stored value, the external device reads `ParamValues::position()` directly, and the config store ignores a non-finite min, max or center on load.

Verified against the installed Diva and Serum 2 by ear, and Serum 2 in a harness: rendered with the plan's parameter table, its output is sample-identical to rendering without one. The external, param and bake Catch2 suites pass.

The remaining shape of the problem is filed as #2623, #2624 and #2625.

Closes #2613

https://claude.ai/code/session_01Vu7WyvmB7W5e5ajW9oLpof