### PR TITLE
Deliver a device's parameters by slot, and answer which of them something addresses

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -276,12 +276,16 @@ add_library(magda_types STATIC
     # the engine links a leaf instead of the whole DAW.
     core/ClipOcclusion.cpp
     core/ClipFades.cpp
+    # Which of a device's parameters something addresses (#2630). Model-only,
+    # so the table compiler and the save path ask the same question.
+    core/AddressedParameters.cpp
     # value-type headers (listed to document the leaf's surface)
     core/TypeIds.hpp
     core/ClipInfo.hpp
     core/ClipOcclusion.hpp
     core/ClipFades.hpp
     core/TechnicalText.hpp
+    core/AddressedParameters.hpp
     core/ChainNodePath.hpp
     core/ControlTarget.hpp
     core/ParameterInfo.hpp

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -358,7 +358,7 @@ void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& pa
     // The entries the table carries, not every slot the plugin has (#2629).
     for (int entry = 0; entry < params.size(); ++entry) {
         const auto slot = params.slotAt(entry);
-        if (slot < 0 || slot >= static_cast<int>(parameters_.size()))
+        if (!mapsSlot(slot))
             continue;
 
         const auto& mapping = parameters_[static_cast<std::size_t>(slot)];

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -355,14 +355,16 @@ int EngineExternalDevice::latencySamples() const {
 }
 
 void EngineExternalDevice::writeParameters(const magda::engine::DeviceParams& params) {
-    for (int slot = 0; slot < static_cast<int>(parameters_.size()); ++slot) {
-        const auto& mapping = parameters_[static_cast<std::size_t>(slot)];
-        const auto values = params[slot];
+    // The entries the table carries, not every slot the plugin has (#2629).
+    for (int entry = 0; entry < params.size(); ++entry) {
+        const auto slot = params.slotAt(entry);
+        if (slot < 0 || slot >= static_cast<int>(parameters_.size()))
+            continue;
 
-        // A slot the table does not carry is one nothing resolved: a project
-        // that saved fewer parameters than this build of the plugin has, or a
-        // wrapper pair a project never wrote. The plugin keeps whatever its own
-        // state put there, which for the pair is fully wet.
+        const auto& mapping = parameters_[static_cast<std::size_t>(slot)];
+        const auto values = params.valuesAt(entry);
+
+        // Nothing resolved it, so the plugin keeps what its own state put there.
         if (values.empty())
             continue;
 

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -189,8 +189,7 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     void writeParameters(const magda::engine::DeviceParams& params);
 
-    /// Whether @p slot is one of this plugin's, i.e. @ref parameters_ has a row
-    /// for it.
+    /// Whether @ref parameters_ has a row for @p slot.
     bool mapsSlot(int slot) const {
         return slot >= 0 && slot < static_cast<int>(parameters_.size());
     }

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -189,6 +189,12 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
 
     void writeParameters(const magda::engine::DeviceParams& params);
 
+    /// Whether @p slot is one of this plugin's, i.e. @ref parameters_ has a row
+    /// for it.
+    bool mapsSlot(int slot) const {
+        return slot >= 0 && slot < static_cast<int>(parameters_.size());
+    }
+
     /// The plugin over one buffer, wet/dry mixed. @p audio is the buffer the
     /// plugin processes in place, at the width it asked for.
     void processPluginBlock(juce::AudioBuffer<float>& audio);

--- a/magda/daw/core/AddressedParameters.cpp
+++ b/magda/daw/core/AddressedParameters.cpp
@@ -37,12 +37,20 @@ AddressedParameters AddressedParameters::from(const AddressingSources& sources) 
     const auto device = [&links, &record](const DeviceInfo& info, const ChainNodePath& path) {
         links(info);
 
+        // The UI lists hold positions in DeviceInfo::parameters, not slots: a
+        // hosted plugin's array starts at slot 2, past the wrapper pair.
+        const auto slotAt = [&info](int position) {
+            return position >= 0 && position < static_cast<int>(info.parameters.size())
+                       ? info.parameters[static_cast<std::size_t>(position)].paramIndex
+                       : -1;
+        };
+
         // An empty list is the UI's "show what the device has" (#2634), which
         // addresses nothing.
         for (const auto* list :
              {&info.visibleParameters, &info.miniMixerParameters, &info.aiSoundDesignerParameters})
-            for (const auto paramIndex : *list)
-                record(path, paramIndex);
+            for (const auto position : *list)
+                record(path, slotAt(position));
     };
 
     const auto track = [&links, &device](const TrackInfo& info) {

--- a/magda/daw/core/AddressedParameters.cpp
+++ b/magda/daw/core/AddressedParameters.cpp
@@ -23,8 +23,7 @@ AddressedParameters AddressedParameters::from(const AddressingSources& sources) 
             record(control.devicePath, control.paramIndex);
     };
 
-    // A track, a rack and a device all hold macros and modifiers, and a link
-    // from any of them can name any device in the project.
+    // A link from a track, rack or device scope can name any device.
     const auto links = [&target](const auto& owner) {
         for (const auto& macro : owner.macros)
             for (const auto& link : macro.links)
@@ -38,8 +37,8 @@ AddressedParameters AddressedParameters::from(const AddressingSources& sources) 
     const auto device = [&links, &record](const DeviceInfo& info, const ChainNodePath& path) {
         links(info);
 
-        // An empty list is the UI's "show what the device has", which reads the
-        // instance (#2634) rather than addressing every slot.
+        // An empty list is the UI's "show what the device has" (#2634), which
+        // addresses nothing.
         for (const auto* list :
              {&info.visibleParameters, &info.miniMixerParameters, &info.aiSoundDesignerParameters})
             for (const auto paramIndex : *list)

--- a/magda/daw/core/AddressedParameters.cpp
+++ b/magda/daw/core/AddressedParameters.cpp
@@ -1,0 +1,96 @@
+#include "AddressedParameters.hpp"
+
+#include <algorithm>
+
+#include "AutomationInfo.hpp"
+#include "ChainWalk.hpp"
+#include "DeviceInfo.hpp"
+#include "RackInfo.hpp"
+#include "TrackInfo.hpp"
+
+namespace magda {
+
+AddressedParameters AddressedParameters::from(const AddressingSources& sources) {
+    AddressedParameters addressed;
+
+    const auto record = [&addressed](const ChainNodePath& path, int paramIndex) {
+        if (path.isValid() && paramIndex >= 0)
+            addressed.byDevice_[path].push_back(paramIndex);
+    };
+
+    const auto target = [&record](const ControlTarget& control) {
+        if (control.kind == ControlTarget::Kind::PluginParam)
+            record(control.devicePath, control.paramIndex);
+    };
+
+    // A track, a rack and a device all hold macros and modifiers, and a link
+    // from any of them can name any device in the project.
+    const auto links = [&target](const auto& owner) {
+        for (const auto& macro : owner.macros)
+            for (const auto& link : macro.links)
+                target(link.target);
+
+        for (const auto& mod : owner.mods)
+            for (const auto& link : mod.links)
+                target(link.target);
+    };
+
+    const auto device = [&links, &record](const DeviceInfo& info, const ChainNodePath& path) {
+        links(info);
+
+        // An empty list is the UI's "show what the device has", which reads the
+        // instance (#2634) rather than addressing every slot.
+        for (const auto* list :
+             {&info.visibleParameters, &info.miniMixerParameters, &info.aiSoundDesignerParameters})
+            for (const auto paramIndex : *list)
+                record(path, paramIndex);
+    };
+
+    const auto track = [&links, &device](const TrackInfo& info) {
+        links(info);
+
+        chain_walk::forEachNode(info.chain.fxChainElements, ChainNodePath::trackLevel(info.id),
+                                chain_walk::Pads::Enter, device,
+                                [&links](const RackInfo& rack, const ChainNodePath&) {
+                                    links(rack);
+                                    return chain_walk::Descend::Into;
+                                });
+
+        for (const auto& element : info.chain.postFxChainElements)
+            device(element.device, ChainNodePath::postFxDevice(info.id, element.device.id));
+
+        for (const auto& element : info.chain.mixerAnalysisElements)
+            device(element.device, ChainNodePath::mixerAnalysisDevice(info.id, element.device.id));
+    };
+
+    for (const auto& info : sources.tracks)
+        track(info);
+
+    if (sources.master != nullptr)
+        track(*sources.master);
+
+    for (const auto& lane : sources.lanes)
+        target(lane.target);
+
+    for (const auto& control : sources.bound)
+        target(control);
+
+    for (auto& [path, slots] : addressed.byDevice_) {
+        std::ranges::sort(slots);
+        slots.erase(std::ranges::unique(slots).begin(), slots.end());
+    }
+
+    return addressed;
+}
+
+std::span<const int> AddressedParameters::forDevice(const ChainNodePath& devicePath) const {
+    const auto found = byDevice_.find(devicePath);
+    return found == byDevice_.end() ? std::span<const int>{} : found->second;
+}
+
+bool AddressedParameters::addresses(const ChainNodePath& devicePath, int paramIndex) const {
+    const auto slots = forDevice(devicePath);
+    return std::ranges::binary_search(slots, paramIndex);
+}
+
+}  // namespace magda

--- a/magda/daw/core/AddressedParameters.cpp
+++ b/magda/daw/core/AddressedParameters.cpp
@@ -37,16 +37,15 @@ AddressedParameters AddressedParameters::from(const AddressingSources& sources) 
     const auto device = [&links, &record](const DeviceInfo& info, const ChainNodePath& path) {
         links(info);
 
-        // The UI lists hold positions in DeviceInfo::parameters, not slots: a
-        // hosted plugin's array starts at slot 2, past the wrapper pair.
+        // Positions in DeviceInfo::parameters, not slots: a hosted plugin's
+        // array starts at slot 2, past the wrapper pair.
         const auto slotAt = [&info](int position) {
             return position >= 0 && position < static_cast<int>(info.parameters.size())
                        ? info.parameters[static_cast<std::size_t>(position)].paramIndex
                        : -1;
         };
 
-        // An empty list is the UI's "show what the device has" (#2634), which
-        // addresses nothing.
+        // An empty list is the UI's "show everything" (#2634): it addresses none.
         for (const auto* list :
              {&info.visibleParameters, &info.miniMixerParameters, &info.aiSoundDesignerParameters})
             for (const auto position : *list)

--- a/magda/daw/core/AddressedParameters.hpp
+++ b/magda/daw/core/AddressedParameters.hpp
@@ -13,9 +13,8 @@
  * @file AddressedParameters.hpp
  * @brief Which of a device's parameters something addresses (#2630).
  *
- * A hosted plugin's value is mirrored in the model only for a slot something
- * addresses; the chunk carries the rest (#2629). The table compiler, the
- * plugin-edit filter and the save path read one answer rather than three.
+ * A hosted plugin's value is mirrored only for a slot something addresses; the
+ * chunk carries the rest (#2629).
  */
 
 namespace magda {
@@ -28,20 +27,16 @@ struct AddressingSources {
     std::span<const TrackInfo> tracks;
     const TrackInfo* master = nullptr;
 
-    /// Every lane the project holds, whatever its authority state: a lane that
-    /// is not playing still holds the value the user drew against.
+    /// Every lane the project holds, playing or not: one that is not playing
+    /// still holds the value the user drew against.
     std::span<const AutomationLaneInfo> lanes;
 
-    /// Controller bindings, MIDI learn and the aliases the AI writes through,
-    /// resolved to concrete targets by the registries that own them.
+    /// Controller bindings, MIDI learn and the AI's aliases, resolved to
+    /// targets by the registries that own them.
     std::span<const ControlTarget> bound;
 };
 
-/**
- * @brief The addressed slots of every device in one project.
- *
- * Built once over the model and asked per device.
- */
+/** @brief The addressed slots of every device in one project. */
 class AddressedParameters {
   public:
     static AddressedParameters from(const AddressingSources& sources);

--- a/magda/daw/core/AddressedParameters.hpp
+++ b/magda/daw/core/AddressedParameters.hpp
@@ -27,12 +27,11 @@ struct AddressingSources {
     std::span<const TrackInfo> tracks;
     const TrackInfo* master = nullptr;
 
-    /// Every lane the project holds, playing or not: one that is not playing
-    /// still holds the value the user drew against.
+    /// Every lane the project holds, playing or not.
     std::span<const AutomationLaneInfo> lanes;
 
-    /// Controller bindings, MIDI learn and the AI's aliases, resolved to
-    /// targets by the registries that own them.
+    /// Controller bindings, MIDI learn and the AI's aliases, already resolved
+    /// to targets by the registries that own them.
     std::span<const ControlTarget> bound;
 };
 

--- a/magda/daw/core/AddressedParameters.hpp
+++ b/magda/daw/core/AddressedParameters.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <map>
+#include <span>
+#include <vector>
+
+#include "AutomationInfo.hpp"
+#include "ChainNodePath.hpp"
+#include "ControlTarget.hpp"
+#include "TrackInfo.hpp"
+
+/**
+ * @file AddressedParameters.hpp
+ * @brief Which of a device's parameters something addresses (#2630).
+ *
+ * A hosted plugin's value is mirrored in the model only for a slot something
+ * addresses; the chunk carries the rest (#2629). The table compiler, the
+ * plugin-edit filter and the save path read one answer rather than three.
+ */
+
+namespace magda {
+
+struct AutomationLaneInfo;
+struct TrackInfo;
+
+/** @brief Everything that can address a parameter of a device. */
+struct AddressingSources {
+    std::span<const TrackInfo> tracks;
+    const TrackInfo* master = nullptr;
+
+    /// Every lane the project holds, whatever its authority state: a lane that
+    /// is not playing still holds the value the user drew against.
+    std::span<const AutomationLaneInfo> lanes;
+
+    /// Controller bindings, MIDI learn and the aliases the AI writes through,
+    /// resolved to concrete targets by the registries that own them.
+    std::span<const ControlTarget> bound;
+};
+
+/**
+ * @brief The addressed slots of every device in one project.
+ *
+ * Built once over the model and asked per device.
+ */
+class AddressedParameters {
+  public:
+    static AddressedParameters from(const AddressingSources& sources);
+
+    /// @p devicePath's addressed slots, ascending and without repeats.
+    std::span<const int> forDevice(const ChainNodePath& devicePath) const;
+
+    bool addresses(const ChainNodePath& devicePath, int paramIndex) const;
+
+    /// How many devices have at least one addressed slot.
+    int numDevices() const {
+        return static_cast<int>(byDevice_.size());
+    }
+
+  private:
+    std::map<ChainNodePath, std::vector<int>> byDevice_;
+};
+
+}  // namespace magda

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -457,17 +457,11 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                        op.padLevelParam >= 0) {
                 // The exception to the line above: a Drum Grid's pad level and
                 // pan are real parameters of the device that owns the pad, so a
-                // lane over them has to reach this fader. Read through the
-                // owner's window, which is indexed by the device's own
-                // parameter index.
-                const auto window = params->windowFor(op.key.deviceKey());
-                const auto slot = [&](int index) {
-                    return index >= 0 && index < window.count
-                               ? static_cast<ParamId>(window.first + index)
-                               : INVALID_PARAM_ID;
-                };
-                mixerParamForOp_[i].gain = slot(op.padLevelParam);
-                mixerParamForOp_[i].pan = slot(op.padPanParam);
+                // lane over them has to reach this fader. Asked by slot, since
+                // the owner's window carries only the parameters it declared.
+                mixerParamForOp_[i].gain =
+                    params->deviceParam(op.key.deviceKey(), op.padLevelParam);
+                mixerParamForOp_[i].pan = params->deviceParam(op.key.deviceKey(), op.padPanParam);
             } else if (op.kind == OpKind::SendTap) {
                 key.kind = ParamKey::Kind::SendLevel;
                 key.index = op.key.index;
@@ -1655,7 +1649,7 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
                                         !block.continuous || midiInPanic(op.inputs[1]) || rerouted,
                                     .midiOut = deviceMidiOut,
                                     .sidechain = {},
-                                    .params = paramValues_.device(window.first, window.count),
+                                    .params = deviceParams(window),
                                     .block = block};
             if (op.inputs[2].valid())
                 deviceBlock.sidechain = audioIn(op.inputs[2], numSamples);

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -743,6 +743,16 @@ class PlanExecutor {
     /// const and the prefix needs the answer before the resolve does.
     void settleBlockTable(const PlanValues& values);
 
+    /// What the device behind @p window reads this block: one (slot, value)
+    /// pair per parameter the table carries for it.
+    DeviceParams deviceParams(const ParamTable::DeviceWindow& window) const {
+        if (blockTable_ == nullptr)
+            return {};
+
+        return paramValues_.device(window.first, window.count, blockTable_->slotsIn(window),
+                                   blockTable_->drivenIn(window));
+    }
+
     /// Read one modulation tap: hand the source's level to the followers
     /// listening to it, and its rises and falls to the triggered ones.
     void renderModSource(OpId id, const BlockInfo& block);

--- a/magda/engine/param/ParamBlock.cpp
+++ b/magda/engine/param/ParamBlock.cpp
@@ -33,14 +33,36 @@ float ParamValues::valueAt(int sampleOffset) const {
     return magda::ParameterUtils::normalizedToReal(position, domain_);
 }
 
-ParamValues DeviceParams::operator[](int paramIndex) const {
-    if (paramIndex < 0 || paramIndex >= size())
+int DeviceParams::slotAt(int entry) const {
+    if (entry < 0 || entry >= static_cast<int>(slots_.size()))
+        return -1;
+
+    return slots_[static_cast<std::size_t>(entry)];
+}
+
+ParamValues DeviceParams::valuesAt(int entry) const {
+    if (entry < 0 || entry >= size())
         return {};
 
-    const auto index = static_cast<std::size_t>(paramIndex);
+    const auto index = static_cast<std::size_t>(entry);
     const auto offset = index * static_cast<std::size_t>(stride_);
     const auto count = static_cast<std::size_t>(counts_[index]);
     return ParamValues{segments_.subspan(offset, count), domains_[index], numSamples_};
+}
+
+bool DeviceParams::drivenAt(int entry) const {
+    if (entry < 0 || entry >= static_cast<int>(driven_.size()))
+        return false;
+
+    return driven_[static_cast<std::size_t>(entry)] != 0;
+}
+
+ParamValues DeviceParams::operator[](int paramIndex) const {
+    const auto found = std::ranges::lower_bound(slots_, paramIndex);
+    if (found == slots_.end() || *found != paramIndex)
+        return {};
+
+    return valuesAt(static_cast<int>(std::distance(slots_.begin(), found)));
 }
 
 void ResolvedParams::prepare(int numParams, int segmentCapacity) {
@@ -80,8 +102,13 @@ float ResolvedParams::sourceValue(int param) const {
                         segments_[index * static_cast<std::size_t>(stride_)].startValue);
 }
 
-DeviceParams ResolvedParams::device(int firstParam, int count) const {
+DeviceParams ResolvedParams::device(int firstParam, int count, std::span<const int> slots,
+                                    std::span<const std::uint8_t> driven) const {
     if (firstParam < 0 || count <= 0 || firstParam + count > size())
+        return {};
+
+    // Without the slots the entries are values nothing can be matched to.
+    if (static_cast<int>(slots.size()) != count)
         return {};
 
     const auto first = static_cast<std::size_t>(firstParam);
@@ -92,7 +119,10 @@ DeviceParams ResolvedParams::device(int firstParam, int count) const {
         std::span<const ParamSegment>{segments_}.subspan(offset, width),
         std::span<const int>{counts_}.subspan(first, span),
         std::span<const magda::ParameterUtils::ParameterDomain>{domains_}.subspan(first, span),
-        stride_, numSamples_};
+        slots,
+        driven,
+        stride_,
+        numSamples_};
 }
 
 ParamSegment* ResolvedParams::slotFor(int param) {

--- a/magda/engine/param/ParamBlock.hpp
+++ b/magda/engine/param/ParamBlock.hpp
@@ -3,6 +3,7 @@
 #include <juce_core/juce_core.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <span>
 #include <vector>
 
@@ -140,40 +141,54 @@ class ParamValues {
 };
 
 /**
- * @brief The parameters of one device, in the order the device declared them.
+ * @brief The parameters of one device, as (slot, value) pairs.
  *
- * A device indexes its own parameters from zero, the way ParameterInfo's
- * paramIndex does, and never learns where in the table they sit. The window is
- * contiguous because a device's parameters are allocated together, which is what
- * makes this a pair of integers rather than a map.
+ * One entry per parameter of this device the table carries, ascending by slot.
+ * An entry's position is not the slot it stands for (#2629): walk the entries
+ * for what the table has, ask by slot for one parameter.
  */
 class DeviceParams {
   public:
     DeviceParams() = default;
 
     DeviceParams(std::span<const ParamSegment> segments, std::span<const int> counts,
-                 std::span<const magda::ParameterUtils::ParameterDomain> domains, int stride,
+                 std::span<const magda::ParameterUtils::ParameterDomain> domains,
+                 std::span<const int> slots, std::span<const std::uint8_t> driven, int stride,
                  int numSamples)
         : segments_(segments),
           counts_(counts),
           domains_(domains),
+          slots_(slots),
+          driven_(driven),
           stride_(stride),
           numSamples_(numSamples) {}
 
+    /// How many of the device's parameters the table carries, not how many it
+    /// has.
     int size() const {
         return static_cast<int>(counts_.size());
     }
 
-    /// The device's parameter @p paramIndex. An index the device does not have
-    /// is an empty view: the table is sized from the device's own specs when the
-    /// plan is prepared, so this is a device asking for a parameter it never
-    /// declared.
+    /// The device's own parameter index at @p entry, or -1.
+    int slotAt(int entry) const;
+
+    /// The values at @p entry.
+    ParamValues valuesAt(int entry) const;
+
+    /// Whether the host is driving @p entry this block: a lane playing over it,
+    /// or a macro or modifier linked to it.
+    bool drivenAt(int entry) const;
+
+    /// The device's parameter @p paramIndex. Empty for one the table does not
+    /// carry: a fabricated zero is indistinguishable from a real value.
     ParamValues operator[](int paramIndex) const;
 
   private:
     std::span<const ParamSegment> segments_;
     std::span<const int> counts_;
     std::span<const magda::ParameterUtils::ParameterDomain> domains_;
+    std::span<const int> slots_;
+    std::span<const std::uint8_t> driven_;
     int stride_ = 0;
     int numSamples_ = 0;
 };
@@ -243,8 +258,10 @@ class ResolvedParams {
      */
     float sourceValue(int param) const;
 
-    /// The window a device reads: @p count parameters from @p firstParam.
-    DeviceParams device(int firstParam, int count) const;
+    /// The window a device reads: @p count parameters from @p firstParam, with
+    /// the slot each stands for (ParamTable::slotsIn, ParamTable::drivenIn).
+    DeviceParams device(int firstParam, int count, std::span<const int> slots,
+                        std::span<const std::uint8_t> driven) const;
 
     /// Where the resolver writes @p param's segments. Never null for a
     /// parameter the table has; @ref segmentCapacity() wide.

--- a/magda/engine/param/ParamBlock.hpp
+++ b/magda/engine/param/ParamBlock.hpp
@@ -143,9 +143,8 @@ class ParamValues {
 /**
  * @brief The parameters of one device, as (slot, value) pairs.
  *
- * One entry per parameter of this device the table carries, ascending by slot.
- * An entry's position is not the slot it stands for (#2629): walk the entries
- * for what the table has, ask by slot for one parameter.
+ * One entry per parameter the table carries, ascending by slot. An entry's
+ * position is not the slot it stands for (#2629).
  */
 class DeviceParams {
   public:

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -349,17 +349,6 @@ void resolveOneParam(const ParamTable& table, ResolvedParams& out, const ModRunt
                      std::span<ModContribution> links, std::span<ParamSegment> segments,
                      const BlockInfo& block, ParamId param) {
     const auto index = static_cast<std::size_t>(param);
-
-    // A hole in a sparse device window. Nothing declared it, so nothing may be
-    // published for it: no segments is the one answer a device can read as "not
-    // mine", and it is the answer it already gets for an index past the end of
-    // its window. A fabricated value here is indistinguishable from a real one
-    // (ParamSpec::declared).
-    if (!table.specs[index].declared) {
-        out.setSegmentCount(param, 0);
-        return;
-    }
-
     const auto reaching = table.linksFor(param);
 
     std::size_t used = 0;

--- a/magda/engine/param/ParamSpec.hpp
+++ b/magda/engine/param/ParamSpec.hpp
@@ -55,33 +55,6 @@ struct ParamSpec {
      * that is the granularity the cost is paid at.
      */
     bool segmentAccurate = false;
-
-    /**
-     * @brief Whether anything in the model actually declared this parameter.
-     *
-     * False for one slot only: the hole a device's window has to leave when its
-     * parameter indices are sparse. A window is contiguous and indexed from
-     * zero, because that is what lets a device be handed a span and read its own
-     * parameters by the index it declared them at, so an index nothing declared
-     * still costs a slot.
-     *
-     * What it must not cost is a value. A device cannot tell a fabricated zero
-     * from a real one, and the first real project to host a plugin found what
-     * that means: a project saved before the wet/dry pair was persisted has no
-     * parameters at indices 0 and 1, and a hole publishing 0.0 there set the
-     * pair to fully dry and fully attenuated -- silence, from a plugin whose own
-     * chunk was perfectly restored. A sparse array is normal for a hosted plugin
-     * (the fork's list is a filtered view of the instance's, and a project saves
-     * what it had), so this is a shape the value layer has to carry rather than
-     * a model to correct.
-     *
-     * Read where the block is resolved: an undeclared parameter publishes no
-     * segments, so the device sees an empty view and keeps whatever its own
-     * state put there. That is the same answer a device already gets for an
-     * index past the end of its window, which is the same question one step
-     * further out.
-     */
-    bool declared = true;
 };
 
 /** @brief The spec of the parameter @p info describes. Off the audio thread. */

--- a/magda/engine/param/ParamTable.cpp
+++ b/magda/engine/param/ParamTable.cpp
@@ -90,6 +90,35 @@ std::span<const magda::AutomationPoint> ParamTable::curveFor(ParamId param) cons
     return std::span<const magda::AutomationPoint>{curvePoints}.subspan(first, last - first);
 }
 
+std::span<const int> ParamTable::slotsIn(const DeviceWindow& window) const {
+    if (window.count <= 0 || window.first < 0 ||
+        window.first + window.count > static_cast<ParamId>(slots.size()))
+        return {};
+
+    return std::span<const int>{slots}.subspan(static_cast<std::size_t>(window.first),
+                                               static_cast<std::size_t>(window.count));
+}
+
+std::span<const std::uint8_t> ParamTable::drivenIn(const DeviceWindow& window) const {
+    if (window.count <= 0 || window.first < 0 ||
+        window.first + window.count > static_cast<ParamId>(driven.size()))
+        return {};
+
+    return std::span<const std::uint8_t>{driven}.subspan(static_cast<std::size_t>(window.first),
+                                                         static_cast<std::size_t>(window.count));
+}
+
+ParamId ParamTable::deviceParam(const DeviceKey& device, int slot) const {
+    const auto window = windowFor(device);
+    const auto carried = slotsIn(window);
+
+    const auto found = std::ranges::lower_bound(carried, slot);
+    if (found == carried.end() || *found != slot)
+        return INVALID_PARAM_ID;
+
+    return window.first + static_cast<ParamId>(std::distance(carried.begin(), found));
+}
+
 std::span<const magda::CurvePointData> ParamTable::modCurveFor(int modifier) const {
     if (modifier < 0 || modifier + 1 >= static_cast<int>(modCurveOffsets.size()))
         return {};

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -178,6 +178,14 @@ struct ParamTable {
     /// covers it.
     std::vector<float> base;
 
+    /// The device parameter index each entry carries, or -1. A window is read
+    /// through these: an entry's position is not the slot it stands for (#2629).
+    std::vector<int> slots;
+
+    /// Whether a lane, macro or modifier writes the parameter over its stored
+    /// value.
+    std::vector<std::uint8_t> driven;
+
     /// Links reaching parameter i: links[linkOffsets[i], linkOffsets[i + 1]).
     /// One vector rather than one per parameter, since almost no parameter
     /// has a link and a vector each would be an allocation each.
@@ -266,8 +274,8 @@ struct ParamTable {
         int count = 0;
     };
 
-    /// Contiguous per device and indexed from zero by the device's own
-    /// parameter index, which is what lets a device be handed a window.
+    /// Contiguous per device, one entry per parameter it declared, ascending by
+    /// slot. Which slot an entry carries is @ref slots.
     std::unordered_map<DeviceKey, DeviceWindow, DeviceKeyHash> deviceWindows;
 
     /// What the model asked for that this could not express, in the order
@@ -304,6 +312,16 @@ struct ParamTable {
         const auto found = deviceWindows.find(device);
         return found == deviceWindows.end() ? DeviceWindow{} : found->second;
     }
+
+    /// The slots @p window carries, one per entry, ascending.
+    std::span<const int> slotsIn(const DeviceWindow& window) const;
+
+    /// Whether each of @p window's entries is driven, one per entry.
+    std::span<const std::uint8_t> drivenIn(const DeviceWindow& window) const;
+
+    /// The parameter at @p slot of @p device, or INVALID_PARAM_ID for a slot
+    /// the window does not carry.
+    ParamId deviceParam(const DeviceKey& device, int slot) const;
 };
 
 /**

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -178,8 +178,8 @@ struct ParamTable {
     /// covers it.
     std::vector<float> base;
 
-    /// The device parameter index each entry carries, or -1. A window is read
-    /// through these: an entry's position is not the slot it stands for (#2629).
+    /// The device parameter index each entry carries, or -1. An entry's
+    /// position is not the slot it stands for (#2629).
     std::vector<int> slots;
 
     /// Whether a lane, macro or modifier writes the parameter over its stored

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -505,17 +505,13 @@ void Builder::allocateDevice(const Node& node) {
     if (declared.empty())
         return;
 
-    // A mistake for a device MAGDA ships and the normal shape of one it hosts:
-    // a hosted plugin's array is a filtered view of the instance's, and a
-    // project saved before the wet/dry pair was persisted starts at index two
-    // (#2175).
+    // Internal devices only: a hosted plugin's array skips its non-automatable
+    // parameters, so gaps in it are normal (#2175).
     const auto count = static_cast<int>(declared.size());
     if (const auto gaps = declared.rbegin()->first + 1 - count;
         gaps > 0 && device.format == magda::PluginFormat::Internal)
         diagnose(toString(scope) + ": parameter indices are not contiguous, so " +
-                 std::to_string(gaps) +
-                 " index(es) below the highest declared stand for no parameter and nothing can "
-                 "address them");
+                 std::to_string(gaps) + " index(es) below the highest stand for no parameter");
 
     table_.deviceWindows.emplace(scope.device, ParamTable::DeviceWindow{first, count});
 }

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -1,6 +1,7 @@
 #include "param/ParamTableCompiler.hpp"
 
 #include <algorithm>
+#include <map>
 #include <queue>
 #include <set>
 
@@ -283,6 +284,7 @@ class Builder {
     void resolveLinks();
     void orderAndBreakCycles();
     void flattenLinks();
+    void markDriven();
 
     void diagnose(const std::string& what) {
         table_.diagnostics.push_back(what);
@@ -330,6 +332,8 @@ ParamId Builder::add(const ParamKey& key, const ParamSpec& spec, float base) {
     table_.keys.push_back(key);
     table_.specs.push_back(spec);
     table_.base.push_back(base);
+    table_.slots.push_back(key.kind == ParamKey::Kind::DeviceParam ? key.index : -1);
+    table_.driven.push_back(0);
     perParam_.emplace_back();
     perParamCurve_.emplace_back();
     table_.byKey.emplace(key, id);
@@ -466,8 +470,8 @@ void Builder::allocateDevice(const Node& node) {
     const auto& scope = node.scope;
 
     // A device's parameters are one index space: its own, plus whatever its
-    // wrapper injected, which addresses the same slots.
-    int highest = -1;
+    // wrapper injected. Ascending, because the window is searched by slot.
+    std::map<int, const magda::ParameterInfo*> declared;
     const auto scan = [&](const std::vector<magda::ParameterInfo>& list) {
         for (const auto& info : list) {
             if (info.paramIndex < 0 || info.paramIndex > kMaxDeviceParamIndex) {
@@ -475,42 +479,19 @@ void Builder::allocateDevice(const Node& node) {
                          " is out of range and is ignored");
                 continue;
             }
-            highest = std::max(highest, info.paramIndex);
+            declared.emplace(info.paramIndex, &info);
         }
     };
     scan(device.parameters);
     scan(device.wrapperParameters);
 
-    const auto find = [&](int index) -> const magda::ParameterInfo* {
-        for (const auto* list : {&device.parameters, &device.wrapperParameters})
-            for (const auto& info : *list)
-                if (info.paramIndex == index)
-                    return &info;
-        return nullptr;
-    };
-
-    // Every index from zero, so a device reads its own parameters by the index
-    // it declared them at rather than by where they landed in the table. A gap
-    // is a slot nothing declared and nothing reads.
+    // One entry per parameter the device declared, and none for an index it did
+    // not: a device reads its parameters by slot (ParamTable::slots).
     const auto first = static_cast<ParamId>(table_.keys.size());
-    int gaps = 0;
-    for (int index = 0; index <= highest; ++index) {
+    for (const auto& [index, info] : declared) {
         ParamKey key = scope;
         key.kind = ParamKey::Kind::DeviceParam;
         key.index = index;
-
-        const auto* info = find(index);
-        if (info == nullptr) {
-            ++gaps;
-
-            // A slot, because the window is contiguous, and no value, because
-            // nothing declared one. See ParamSpec::declared: a fabricated zero
-            // is indistinguishable from a real one to the device reading it.
-            ParamSpec hole;
-            hole.declared = false;
-            add(key, hole, 0.0f);
-            continue;
-        }
 
         // The model's own inverse, rather than a straight read of the range:
         // an external plugin's stored value and its display range are not the
@@ -521,23 +502,22 @@ void Builder::allocateDevice(const Node& node) {
         add(key, paramSpecFrom(*info), normalised.value);
     }
 
-    // Reported for a device MAGDA ships and not for one it hosts, because it is
-    // a mistake in the first case and the normal shape of the second.
-    //
-    // An internal device declares its own parameters, so a gap is a device that
-    // skipped an index and the slot it left is one nothing will ever read. A
-    // hosted plugin's array is a filtered view of the instance's -- the
-    // non-automatable ones are not in it at all -- and a project saves whatever
-    // it had when it was saved, which for anything written before the wet/dry
-    // pair was persisted is an array starting at index two. Diagnosing that
-    // would make every real project hosting a plugin unmeasurable for having
-    // been saved by an older build (#2175).
-    if (gaps > 0 && device.format == magda::PluginFormat::Internal)
-        diagnose(toString(scope) + ": parameter indices are not contiguous, so " +
-                 std::to_string(gaps) + " slot(s) of the window belong to no parameter");
+    if (declared.empty())
+        return;
 
-    if (highest >= 0)
-        table_.deviceWindows.emplace(scope.device, ParamTable::DeviceWindow{first, highest + 1});
+    // A mistake for a device MAGDA ships and the normal shape of one it hosts:
+    // a hosted plugin's array is a filtered view of the instance's, and a
+    // project saved before the wet/dry pair was persisted starts at index two
+    // (#2175).
+    const auto count = static_cast<int>(declared.size());
+    if (const auto gaps = declared.rbegin()->first + 1 - count;
+        gaps > 0 && device.format == magda::PluginFormat::Internal)
+        diagnose(toString(scope) + ": parameter indices are not contiguous, so " +
+                 std::to_string(gaps) +
+                 " index(es) below the highest declared stand for no parameter and nothing can "
+                 "address them");
+
+    table_.deviceWindows.emplace(scope.device, ParamTable::DeviceWindow{first, count});
 }
 
 void Builder::walkFlat(const std::vector<magda::PostFxChainElement>& elements,
@@ -1043,6 +1023,13 @@ void Builder::flattenLinks() {
     }
 }
 
+/// After the lanes and links are flattened, since it is read off both (#2629).
+void Builder::markDriven() {
+    for (ParamId param = 0; param < static_cast<ParamId>(table_.keys.size()); ++param)
+        table_.driven[static_cast<std::size_t>(param)] = static_cast<std::uint8_t>(
+            !table_.curveFor(param).empty() || !table_.linksFor(param).empty());
+}
+
 ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
                         const magda::TrackInfo& master,
                         std::span<const magda::AutomationLaneInfo> lanes,
@@ -1063,6 +1050,7 @@ ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackIn
     orderAndBreakCycles();
     flattenLinks();
     flattenCurves();
+    markDriven();
 
     table_.layoutFingerprint = paramLayoutFingerprint(table_.keys);
     table_.modifierFingerprint = paramModifierFingerprint(table_.modifiers);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -343,6 +343,7 @@ set(TEST_SOURCES
     audio/test_demucs_chunking.cpp
     audio/test_demucs_separator.cpp
     audio/test_spleeter_separator.cpp
+    core/test_addressed_parameters.cpp
     core/test_device_info_predicates.cpp
     core/test_four_osc_translation.cpp
     core/test_ranges_helpers.cpp

--- a/tests/core/test_addressed_parameters.cpp
+++ b/tests/core/test_addressed_parameters.cpp
@@ -87,8 +87,7 @@ TEST_CASE("A device nothing touches addresses nothing", "[core][parameters][addr
 TEST_CASE("An automation lane addresses its parameter", "[core][parameters][addressed]") {
     const auto project = oneDevice(makeDevice(7));
 
-    // A lane the model is not playing still holds the value the user drew
-    // against, so its slot is mirrored like any other.
+    // A lane that is not playing still holds the value the user drew against.
     const auto state =
         GENERATE(AutomationAuthorityState::Reading, AutomationAuthorityState::Disabled,
                  AutomationAuthorityState::Writing);
@@ -169,18 +168,15 @@ TEST_CASE("A place in the device UI addresses a parameter", "[core][parameters][
 }
 
 TEST_CASE("A UI list holds array positions, not slots", "[core][parameters][addressed]") {
-    // A hosted plugin's own parameters start at slot 2: the wrapper pair holds
-    // 0 and 1 and lives in its own array (ExternalPluginState.hpp). The config
-    // dialog writes positions in DeviceInfo::parameters, so position 0 is the
-    // plugin's first automatable parameter and the slot it addresses is 2.
+    // A hosted plugin's own parameters start at slot 2, past the wrapper pair,
+    // so position 0 in the array addresses slot 2.
     auto device = makeDevice(7, 0);
     for (int slot = 2; slot < 6; ++slot)
         device.parameters.emplace_back(slot, "P" + juce::String(slot), "", 0.0f, 1.0f, 0.0f);
 
     device.visibleParameters = {0, 3};
 
-    // Past the end of the array: a stale config, which addresses nothing rather
-    // than a slot that is not there.
+    // Past the end of the array: a stale config addresses nothing.
     device.miniMixerParameters = {9};
 
     const auto project = oneDevice(std::move(device));
@@ -192,8 +188,7 @@ TEST_CASE("A UI list holds array positions, not slots", "[core][parameters][addr
 }
 
 TEST_CASE("An empty visible list addresses nothing", "[core][parameters][addressed]") {
-    // The UI reads "show what the device has" off the instance (#2634). Taking
-    // it as addressing every slot would mirror the whole array again for any
+    // Taking it as addressing every slot would mirror the whole array for any
     // plugin the user has not configured, which is every plugin by default.
     const auto project = oneDevice(makeDevice(7));
     const auto addressed = addressedIn({project.track});

--- a/tests/core/test_addressed_parameters.cpp
+++ b/tests/core/test_addressed_parameters.cpp
@@ -1,0 +1,242 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <variant>
+#include <vector>
+
+#include "core/AddressedParameters.hpp"
+#include "core/ChainWalk.hpp"
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+
+/**
+ * @file test_addressed_parameters.cpp
+ * @brief What counts as addressing a parameter, and what does not (#2630).
+ */
+
+using namespace magda;
+
+namespace {
+
+DeviceInfo makeDevice(DeviceId id, int numParameters = 4) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Device " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.format = PluginFormat::VST3;
+    device.macros = createDefaultMacros(2);
+    device.mods = createDefaultMods(0);
+
+    for (int index = 0; index < numParameters; ++index)
+        device.parameters.emplace_back(index, "P" + juce::String(index), "", 0.0f, 1.0f, 0.0f);
+
+    return device;
+}
+
+TrackInfo makeTrack(TrackId id = 1) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.macros = createDefaultMacros(2);
+    track.mods = createDefaultMods(1);
+    return track;
+}
+
+/// A track holding one device at track level, and that device's address.
+struct OneDevice {
+    TrackInfo track;
+    ChainNodePath path;
+};
+
+OneDevice oneDevice(DeviceInfo device) {
+    auto track = makeTrack();
+    const auto path = chain_walk::deviceIn(ChainNodePath::trackLevel(track.id), device.id);
+    track.chain.fxChainElements.push_back(makeDeviceElement(std::move(device)));
+    return {std::move(track), path};
+}
+
+AddressedParameters addressedIn(const std::vector<TrackInfo>& tracks,
+                                std::span<const AutomationLaneInfo> lanes = {},
+                                std::span<const ControlTarget> bound = {}) {
+    AddressingSources sources;
+    sources.tracks = tracks;
+    sources.lanes = lanes;
+    sources.bound = bound;
+    return AddressedParameters::from(sources);
+}
+
+AutomationLaneInfo laneOver(const ControlTarget& target,
+                            AutomationAuthorityState state = AutomationAuthorityState::Reading) {
+    AutomationLaneInfo lane;
+    lane.id = 1;
+    lane.target = target;
+    lane.authorityState = state;
+    return lane;
+}
+
+}  // namespace
+
+TEST_CASE("A device nothing touches addresses nothing", "[core][parameters][addressed]") {
+    const auto project = oneDevice(makeDevice(7));
+    const auto addressed = addressedIn({project.track});
+
+    CHECK(addressed.numDevices() == 0);
+    CHECK(addressed.forDevice(project.path).empty());
+    CHECK_FALSE(addressed.addresses(project.path, 0));
+}
+
+TEST_CASE("An automation lane addresses its parameter", "[core][parameters][addressed]") {
+    const auto project = oneDevice(makeDevice(7));
+
+    // A lane the model is not playing still holds the value the user drew
+    // against, so its slot is mirrored like any other.
+    const auto state =
+        GENERATE(AutomationAuthorityState::Reading, AutomationAuthorityState::Disabled,
+                 AutomationAuthorityState::Writing);
+
+    const std::vector<AutomationLaneInfo> lanes{
+        laneOver(ControlTarget::pluginParam(project.path, 2), state)};
+
+    const auto addressed = addressedIn({project.track}, lanes);
+
+    CHECK(addressed.addresses(project.path, 2));
+    CHECK_FALSE(addressed.addresses(project.path, 1));
+}
+
+TEST_CASE("A macro or modifier link addresses what it names", "[core][parameters][addressed]") {
+    auto project = oneDevice(makeDevice(7));
+
+    SECTION("at track scope") {
+        project.track.macros[0].links.push_back(
+            {ControlTarget::pluginParam(project.path, 1), 1.0f});
+    }
+    SECTION("from a track modifier") {
+        project.track.mods[0].addLink(ControlTarget::pluginParam(project.path, 1), 1.0f);
+    }
+    SECTION("from the device's own macro") {
+        auto& device = std::get<DeviceInfo>(project.track.chain.fxChainElements[0]);
+        device.macros[0].links.push_back({ControlTarget::pluginParam(project.path, 1), 1.0f});
+    }
+
+    const auto addressed = addressedIn({project.track});
+
+    CHECK(addressed.addresses(project.path, 1));
+    CHECK(addressed.forDevice(project.path).size() == 1);
+}
+
+TEST_CASE("A rack macro reaches a device in its chain", "[core][parameters][addressed]") {
+    RackInfo rack;
+    rack.id = 3;
+    rack.macros = createDefaultMacros(2);
+    rack.mods = createDefaultMods(0);
+
+    ChainInfo chain;
+    chain.id = 1;
+    chain.elements.push_back(makeDeviceElement(makeDevice(7)));
+    rack.chains.push_back(std::move(chain));
+
+    auto track = makeTrack();
+    const auto devicePath =
+        ChainNodePath::trackLevel(track.id).withRack(rack.id).withChain(1).withDevice(7);
+    rack.macros[0].links.push_back({ControlTarget::pluginParam(devicePath, 3), 1.0f});
+    track.chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto addressed = addressedIn({track});
+
+    CHECK(addressed.addresses(devicePath, 3));
+}
+
+TEST_CASE("A controller binding addresses its parameter", "[core][parameters][addressed]") {
+    const auto project = oneDevice(makeDevice(7));
+    const std::vector<ControlTarget> bound{ControlTarget::pluginParam(project.path, 0)};
+
+    const auto addressed = addressedIn({project.track}, {}, bound);
+
+    CHECK(addressed.addresses(project.path, 0));
+}
+
+TEST_CASE("A place in the device UI addresses a parameter", "[core][parameters][addressed]") {
+    auto device = makeDevice(7);
+    device.visibleParameters = {3, 1};
+    device.miniMixerParameters = {0};
+    device.aiSoundDesignerParameters = {2};
+
+    const auto project = oneDevice(std::move(device));
+    const auto addressed = addressedIn({project.track});
+
+    const auto slots = addressed.forDevice(project.path);
+    REQUIRE(slots.size() == 4);
+    CHECK(std::vector<int>(slots.begin(), slots.end()) == std::vector<int>{0, 1, 2, 3});
+}
+
+TEST_CASE("An empty visible list addresses nothing", "[core][parameters][addressed]") {
+    // The UI reads "show what the device has" off the instance (#2634). Taking
+    // it as addressing every slot would mirror the whole array again for any
+    // plugin the user has not configured, which is every plugin by default.
+    const auto project = oneDevice(makeDevice(7));
+    const auto addressed = addressedIn({project.track});
+
+    CHECK(addressed.forDevice(project.path).empty());
+}
+
+TEST_CASE("A slot addressed twice is listed once", "[core][parameters][addressed]") {
+    auto project = oneDevice(makeDevice(7));
+    project.track.macros[0].links.push_back({ControlTarget::pluginParam(project.path, 2), 1.0f});
+    project.track.macros[1].links.push_back({ControlTarget::pluginParam(project.path, 2), 0.5f});
+
+    const std::vector<AutomationLaneInfo> lanes{
+        laneOver(ControlTarget::pluginParam(project.path, 2))};
+
+    const auto addressed = addressedIn({project.track}, lanes);
+
+    const auto slots = addressed.forDevice(project.path);
+    REQUIRE(slots.size() == 1);
+    CHECK(slots[0] == 2);
+}
+
+TEST_CASE("Addressing something other than a plugin parameter addresses no slot",
+          "[core][parameters][addressed]") {
+    auto project = oneDevice(makeDevice(7));
+    project.track.macros[0].links.push_back({ControlTarget::deviceMacro(project.path, 0), 1.0f});
+
+    const std::vector<AutomationLaneInfo> lanes{laneOver(ControlTarget::trackVolume(1))};
+    const std::vector<ControlTarget> bound{ControlTarget::modParam(project.path, 1, 0)};
+
+    const auto addressed = addressedIn({project.track}, lanes, bound);
+
+    CHECK(addressed.numDevices() == 0);
+}
+
+TEST_CASE("Devices outside the FX tree are addressed by their own path",
+          "[core][parameters][addressed]") {
+    auto track = makeTrack();
+    track.chain.postFxChainElements.push_back({makeDevice(8)});
+    track.chain.mixerAnalysisElements.push_back({makeDevice(9)});
+
+    const auto postFx = ChainNodePath::postFxDevice(track.id, 8);
+    const auto analysis = ChainNodePath::mixerAnalysisDevice(track.id, 9);
+
+    const std::vector<ControlTarget> bound{ControlTarget::pluginParam(postFx, 1),
+                                           ControlTarget::pluginParam(analysis, 2)};
+
+    const auto addressed = addressedIn({track}, {}, bound);
+
+    CHECK(addressed.addresses(postFx, 1));
+    CHECK(addressed.addresses(analysis, 2));
+}
+
+TEST_CASE("The master track's devices are addressed too", "[core][parameters][addressed]") {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+
+    auto device = makeDevice(11);
+    device.visibleParameters = {1};
+    const auto path = chain_walk::deviceIn(ChainNodePath::trackLevel(master.id), device.id);
+    master.chain.fxChainElements.push_back(makeDeviceElement(std::move(device)));
+
+    AddressingSources sources;
+    sources.master = &master;
+
+    const auto addressed = AddressedParameters::from(sources);
+
+    CHECK(addressed.addresses(path, 1));
+}

--- a/tests/core/test_addressed_parameters.cpp
+++ b/tests/core/test_addressed_parameters.cpp
@@ -168,6 +168,29 @@ TEST_CASE("A place in the device UI addresses a parameter", "[core][parameters][
     CHECK(std::vector<int>(slots.begin(), slots.end()) == std::vector<int>{0, 1, 2, 3});
 }
 
+TEST_CASE("A UI list holds array positions, not slots", "[core][parameters][addressed]") {
+    // A hosted plugin's own parameters start at slot 2: the wrapper pair holds
+    // 0 and 1 and lives in its own array (ExternalPluginState.hpp). The config
+    // dialog writes positions in DeviceInfo::parameters, so position 0 is the
+    // plugin's first automatable parameter and the slot it addresses is 2.
+    auto device = makeDevice(7, 0);
+    for (int slot = 2; slot < 6; ++slot)
+        device.parameters.emplace_back(slot, "P" + juce::String(slot), "", 0.0f, 1.0f, 0.0f);
+
+    device.visibleParameters = {0, 3};
+
+    // Past the end of the array: a stale config, which addresses nothing rather
+    // than a slot that is not there.
+    device.miniMixerParameters = {9};
+
+    const auto project = oneDevice(std::move(device));
+    const auto addressed = addressedIn({project.track});
+
+    const auto slots = addressed.forDevice(project.path);
+    REQUIRE(slots.size() == 2);
+    CHECK(std::vector<int>(slots.begin(), slots.end()) == std::vector<int>{2, 5});
+}
+
 TEST_CASE("An empty visible list addresses nothing", "[core][parameters][addressed]") {
     // The UI reads "show what the device has" off the instance (#2634). Taking
     // it as addressing every slot would mirror the whole array again for any

--- a/tests/engine/test_engine_device_layer.cpp
+++ b/tests/engine/test_engine_device_layer.cpp
@@ -375,7 +375,9 @@ TEST_CASE("the plan's resolved values reach the device's parameters", "[engine][
 
     Block block(context);
     auto deviceBlock = block.deviceBlock();
-    deviceBlock.params = table.device(0, 1);
+    const std::vector<int> slots{0};
+    const std::vector<std::uint8_t> driven{0};
+    deviceBlock.params = table.device(0, 1, slots, driven);
     device->process(deviceBlock);
 
     CHECK(hosted->device().parameterValue(0) == Catch::Approx(position).margin(1.0e-5));

--- a/tests/engine/test_engine_external_device.cpp
+++ b/tests/engine/test_engine_external_device.cpp
@@ -769,23 +769,42 @@ adapter::RequestedPlugin requestFor(
  */
 class ParamArena {
   public:
+    /// @p values are the device's slots 0 upwards, all of them carried.
     explicit ParamArena(const std::vector<float>& values) {
         for (const auto value : values) {
             segments_.push_back({.startSample = 0, .startValue = value, .endValue = value});
             counts_.push_back(1);
             domains_.push_back(
                 {.scale = magda::ParameterScale::Linear, .minValue = 0.0f, .maxValue = 1.0f});
+            slots_.push_back(static_cast<int>(slots_.size()));
+            driven_.push_back(0);
         }
     }
 
+    /// Drop @p slot from the window, as a table not carrying it would (#2629).
+    void omit(int slot) {
+        const auto at = std::ranges::find(slots_, slot);
+        if (at == slots_.end())
+            return;
+
+        const auto index = static_cast<std::size_t>(std::distance(slots_.begin(), at));
+        segments_.erase(segments_.begin() + static_cast<std::ptrdiff_t>(index));
+        counts_.erase(counts_.begin() + static_cast<std::ptrdiff_t>(index));
+        domains_.erase(domains_.begin() + static_cast<std::ptrdiff_t>(index));
+        driven_.erase(driven_.begin() + static_cast<std::ptrdiff_t>(index));
+        slots_.erase(at);
+    }
+
     magda::engine::DeviceParams params(int numSamples) const {
-        return {segments_, counts_, domains_, 1, numSamples};
+        return {segments_, counts_, domains_, slots_, driven_, 1, numSamples};
     }
 
   private:
     std::vector<magda::engine::ParamSegment> segments_;
     std::vector<int> counts_;
     std::vector<magda::ParameterUtils::ParameterDomain> domains_;
+    std::vector<int> slots_;
+    std::vector<std::uint8_t> driven_;
 };
 
 /// A block of audio, its MIDI ports, and the description of where it is.
@@ -900,6 +919,29 @@ TEST_CASE("A plan slot addresses the fork's parameter, not the plugin's", "[engi
 
     CHECK(raw->gain->getValue() == Catch::Approx(0.75f));
     CHECK(raw->tone->getValue() == Catch::Approx(0.5f));
+}
+
+TEST_CASE("A slot the table does not carry is left to the plugin", "[engine][external]") {
+    auto plugin = std::make_unique<StubPlugin>();
+    auto* raw = plugin.get();
+
+    adapter::EngineExternalDevice device(std::move(plugin), externalDevice(), false);
+    const auto context = contextFor();
+    device.prepare(context);
+
+    raw->tone->setValue(0.25f);
+
+    // Slot three is addressed by nothing, so the window has no entry for it and
+    // the plugin keeps what its own state put there (#2629).
+    ParamArena arena({0.0f, 1.0f, 0.75f, 0.5f});
+    arena.omit(3);
+
+    Block block(context, 2);
+    auto deviceBlock = block.deviceBlock(arena.params(context.maxBlockSize));
+    device.process(deviceBlock);
+
+    CHECK(raw->gain->getValue() == Catch::Approx(0.75f));
+    CHECK(raw->tone->getValue() == Catch::Approx(0.25f));
 }
 
 TEST_CASE("A stereo plugin processes the block in place", "[engine][external]") {

--- a/tests/engine/test_param_lane.cpp
+++ b/tests/engine/test_param_lane.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
 #include <vector>
 
 #include "core/ParameterInfo.hpp"
@@ -414,11 +415,16 @@ TEST_CASE("A table hands a device its own parameters and no others", "[engine][p
         resolveParam(params, i, spec, sources);
     }
 
-    const auto device = params.device(/*firstParam=*/1, /*count=*/2);
+    // Table entries 1 and 2, standing for the device's slots 0 and 1.
+    const std::vector<int> slots{0, 1};
+    const std::vector<std::uint8_t> driven{0, 0};
+    const auto device = params.device(/*firstParam=*/1, /*count=*/2, slots, driven);
 
     REQUIRE(device.size() == 2);
     CHECK(device[0].value() == approx(25.0f));
     CHECK(device[1].value() == approx(50.0f));
+    CHECK(device.slotAt(0) == 0);
+    CHECK_FALSE(device.drivenAt(0));
 
     // A device asking for a parameter it never declared gets nothing rather
     // than its neighbour's value.

--- a/tests/engine/test_param_table.cpp
+++ b/tests/engine/test_param_table.cpp
@@ -109,6 +109,13 @@ ResolvedParams resolved(const ParamTable& table, magda::engine::BlockInfo block 
     return values;
 }
 
+/// The window @p device reads, as the executor assembles it.
+magda::engine::DeviceParams deviceWindow(const ParamTable& table, const ResolvedParams& values,
+                                         DeviceId device, ChainSegment segment = ChainSegment::Fx) {
+    const auto window = table.windowFor(magda::engine::DeviceKey{segment, device});
+    return values.device(window.first, window.count, table.slotsIn(window), table.drivenIn(window));
+}
+
 ParamKey deviceParam(TrackId track, DeviceId device, int index,
                      ChainSegment segment = ChainSegment::Fx) {
     ParamKey key;
@@ -150,21 +157,19 @@ TEST_CASE("A device's parameters are a window indexed from zero", "[engine][para
     CHECK(table.find(deviceParam(1, 7, 2)) == window.first + 2);
 
     const auto values = resolved(table);
-    const auto device = values.device(window.first, window.count);
+    const auto device = deviceWindow(table, values, 7);
     REQUIRE(device.size() == 3);
     CHECK(device[0].value() == approx(0.0f));
+    CHECK(device.slotAt(2) == 2);
 }
 
-TEST_CASE("A sparse device window publishes nothing in its holes", "[engine][param][table]") {
+TEST_CASE("A sparse device window carries only what the device declared",
+          "[engine][param][table]") {
     // The shape the first real project hosting a plugin arrived in (#2175). A
     // project saved before the wet/dry pair was persisted has no parameters at
     // indices 0 and 1, and the fork's list is a filtered view of the instance's
     // anyway, so a sparse array is the normal shape of a hosted plugin rather
     // than a model to correct.
-    //
-    // The window still covers the holes, because a window is contiguous and
-    // indexed from zero: that is what lets a device read its own parameters by
-    // the index it declared them at.
     auto device = makeDevice(7, 0);
     device.format = magda::PluginFormat::VST3;
 
@@ -179,20 +184,22 @@ TEST_CASE("A sparse device window publishes nothing in its holes", "[engine][par
 
     const auto table = tableFor({track});
     const auto window = table.windowFor(magda::engine::DeviceKey{ChainSegment::Fx, 7});
-    REQUIRE(window.count == 5);
+    REQUIRE(window.count == 3);
 
     const auto values = resolved(table);
-    const auto params = values.device(window.first, window.count);
-    REQUIRE(params.size() == 5);
+    const auto params = deviceWindow(table, values, 7);
+    REQUIRE(params.size() == 3);
 
-    // The holes: empty, which is the one answer a device can read as "not
-    // mine". A value here would be indistinguishable from a real one, and the
-    // project that found this rendered silent because 0.0 at slots zero and one
-    // is a wet/dry pair set fully dry and fully attenuated.
+    // Each entry says which slot it stands for.
+    CHECK(params.slotAt(0) == 2);
+    CHECK(params.slotAt(2) == 4);
+
+    // An index nothing declared: empty rather than a fabricated zero, which at
+    // slots zero and one is a wet/dry pair set fully dry (#2175).
     CHECK(params[0].empty());
     CHECK(params[1].empty());
 
-    // And the declared ones, which are unaffected.
+    // And the declared ones, read by slot.
     CHECK_FALSE(params[2].empty());
     CHECK(params[2].value() == approx(100.0f));
     CHECK_FALSE(params[4].empty());
@@ -206,7 +213,7 @@ TEST_CASE("A sparse device window publishes nothing in its holes", "[engine][par
 TEST_CASE("An internal device with a gap in its indices is reported", "[engine][param][table]") {
     // The mirror, and the reason the check is scoped rather than removed. An
     // internal device declares its own parameters, so a gap is a device that
-    // skipped an index and the slot it left is one nothing will ever read.
+    // skipped an index, and nothing can address what it skipped.
     auto device = makeDevice(7, 0);
     device.format = magda::PluginFormat::Internal;
 
@@ -223,12 +230,49 @@ TEST_CASE("An internal device with a gap in its indices is reported", "[engine][
     CHECK(mentions(table, "not contiguous"));
 
     // Reported and still carried the same way: the diagnostic says the model is
-    // wrong, and the hole is silent either way.
-    const auto window = table.windowFor(magda::engine::DeviceKey{ChainSegment::Fx, 7});
+    // wrong, and the index nobody declared is silent either way.
     const auto values = resolved(table);
-    const auto params = values.device(window.first, window.count);
-    REQUIRE(params.size() == 3);
+    const auto params = deviceWindow(table, values, 7);
+    REQUIRE(params.size() == 2);
     CHECK(params[1].empty());
+}
+
+TEST_CASE("A device's entries say which of them the host drives", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 4)));
+    track.mods = createDefaultMods(1);
+
+    const auto path = ChainNodePath::topLevelDevice(1, 7);
+    track.macros[0].links.push_back(MacroLink{ControlTarget::pluginParam(path, 0), 0.5f, false});
+    track.mods[0].links.push_back(ModLink{ControlTarget::pluginParam(path, 1), 1.0f, false, true});
+
+    AutomationPoint point;
+    point.id = 1;
+    point.beatPosition = 0.0;
+    point.value = 0.5f;
+
+    AutomationLaneInfo lane;
+    lane.id = 1;
+    lane.target = ControlTarget::pluginParam(path, 2);
+    lane.type = AutomationLaneType::Absolute;
+    lane.authorityState = AutomationAuthorityState::Reading;
+    lane.absolutePoints = {point};
+
+    const std::vector<TrackInfo> tracks{track};
+    const auto master = makeMaster();
+    const std::vector<AutomationLaneInfo> lanes{lane};
+    const auto table = compileParamTable(compileRenderPlan(tracks, master), tracks, master, lanes);
+
+    const auto values = resolved(table);
+    const auto params = deviceWindow(table, values, 7);
+    REQUIRE(params.size() == 4);
+
+    CHECK(params.drivenAt(0));
+    CHECK(params.drivenAt(1));
+    CHECK(params.drivenAt(2));
+
+    // Slot 3, which only ever reads its stored value.
+    CHECK_FALSE(params.drivenAt(3));
 }
 
 TEST_CASE("One device id in two sections is two parameters", "[engine][param][table]") {


### PR DESCRIPTION
The first two slices of #2629: the query that says which parameters are mirrored, and the delivery shape that lets a window leave one out. Nothing about what the model holds changes yet.

## Answer which of a device's parameters something addresses (#2630)

`magda/daw/core/AddressedParameters.{hpp,cpp}`, in `magda_types` with no manager behind it: one walk over tracks, racks and devices collecting macro and modifier links, plus the lanes, controller bindings and UI lists handed to it, answering per device path.

An empty `visibleParameters` addresses nothing. It is the UI's "show what the device has", which #2634 serves by reading the instance; taking it as addressing every slot would mirror the whole array for any plugin the user has not configured, which is every plugin by default.

Nothing calls it yet, so this slice is the query and its tests.

## Deliver a device's parameters as slot and value pairs (#2631)

A device window is one entry per parameter the device declared, ascending by slot, with `ParamTable::slots` saying which slot each entry stands for and `ParamTable::driven` saying whether a lane, macro or modifier writes it over its stored value.

- An index nothing declared gets no entry. The fabricated holes `allocateDevice` used to leave are gone, and `ParamSpec::declared` with them.
- `DeviceParams` walks entries (`slotAt`, `valuesAt`, `drivenAt`) and `operator[]` looks a slot up, so a device still reads its parameters by the index it declared them at.
- `EngineExternalDevice::writeParameters` writes the entries it is handed rather than every slot the plugin has, which is what lets #2635 leave a slot out without the device walking hundreds of parameters to find the handful that moved.
- The executor's Drum Grid pad lookup goes through the new `ParamTable::deviceParam(key, slot)` rather than assuming slot equals offset.

The gap diagnostic for an internal device stays, reworded for what it now means: no slot is wasted, but an index below the highest declared that stands for no parameter is one nothing can address.

No behaviour change: every window still holds every parameter the device declared, and a slot the table does not carry reads empty exactly as a hole did.

## Tests

Catch2: 4032 passed, 13 skipped, 0 failed. The new cases cover each source of addressing on its own, a sparse window's entries and their slots, the driven flag for a lane, a macro and a modifier link, and a plugin keeping its own value for a slot the window does not carry. The app target and the JUCE test target build.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF
