### PR TITLE
Read a hosted plugin's parameter list off its instance, and key its selections on slots

### DIFF
--- a/magda/agents/generic_sound_design_agent.cpp
+++ b/magda/agents/generic_sound_design_agent.cpp
@@ -223,11 +223,15 @@ juce::String GenericSoundDesignAgent::generateAndApply(const juce::String& promp
                                                includedParameterIndices_.end());
         params.reserve(included.empty() ? device->parameters.size() : included.size());
         for (size_t i = 0; i < device->parameters.size(); ++i) {
-            if (!included.empty() && included.find(static_cast<int>(i)) == included.end())
-                continue;
             const auto& info = device->parameters[i];
+            const auto slot = info.paramIndex >= 0 ? info.paramIndex : static_cast<int>(i);
+
+            // The opt-in names slots (#2638).
+            if (!included.empty() && !included.contains(slot))
+                continue;
+
             ParamSnapshot snap;
-            snap.index = info.paramIndex >= 0 ? info.paramIndex : static_cast<int>(i);
+            snap.index = slot;
             snap.name = info.name;
             snap.normalized = normalizeParamName(info.name);
             snap.unit = info.unit;

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -247,13 +247,10 @@ bool DeviceApiLive::setDeviceParameter(const ChainNodePath& devicePath, int para
     // writes to external plugins; internal devices accept writes on every
     // parameter. Enforced here so every facade consumer — agents, remote, Lua,
     // OSC, CLI — sees the same policy, not just the MCP handler (#2296). The
-    // opt-in list keys on position in `parameters`, not on paramIndex.
-    if (device->format != PluginFormat::Internal) {
-        const auto position = static_cast<int>(match - device->parameters.begin());
-        const auto& allowed = device->aiSoundDesignerParameters;
-        if (!std::ranges::contains(allowed, position))
-            return false;
-    }
+    // opt-in names slots (#2638).
+    if (device->format != PluginFormat::Internal &&
+        !std::ranges::contains(device->aiSoundDesignerParameters, match->paramIndex))
+        return false;
 
     // The caller speaks display units; the model may store TE-native values
     // (external plugin with a config display range), so convert before writing.

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -634,7 +634,14 @@ TrackDto makeTrackDto(const TrackInfo& track);
 ClipDto makeClipDto(const ClipInfo& clip);
 DeviceGraphDto makeDeviceGraphDto(const std::vector<TrackInfo>& tracks);
 DeviceCatalogEntryDto makeDeviceCatalogEntryDto(const DeviceCatalogEntry& entry);
-std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device);
+/**
+ * @brief One DTO per parameter of the device at @p devicePath.
+ *
+ * The list comes from DeviceParameterList.hpp, so a hosted plugin reports what
+ * its instance has (#2634); the flags come from @p device's own selections.
+ */
+std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device,
+                                                        const ChainNodePath& devicePath);
 SelectionDto makeSelectionDto(MagdaApi& api);
 TransportDto makeTransportDto(MagdaApi& api);
 SessionDto makeSessionDto(MagdaApi& api);

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <tuple>
 
+#include "../audio/DeviceParameterList.hpp"
 #include "../core/AutomationInfo.hpp"
 #include "../core/ClipInfo.hpp"
 #include "../core/DeviceInfo.hpp"
@@ -379,17 +380,19 @@ DeviceCatalogEntryDto makeDeviceCatalogEntryDto(const DeviceCatalogEntry& entry)
     return dto;
 }
 
-std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device) {
+std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device,
+                                                        const ChainNodePath& devicePath) {
     const auto contains = [](const std::vector<int>& positions, int position) {
         return std::ranges::contains(positions, position);
     };
     // The customization lists key on position in `parameters`, while the wire
     // `index` is `paramIndex` — the address parameter writes take. The two are
     // normally equal, but only the position indexes the user's selections.
+    const auto parameters = deviceParameterList(device, devicePath);
     std::vector<DeviceParameterDto> dtos;
-    dtos.reserve(device.parameters.size());
-    for (size_t i = 0; i < device.parameters.size(); ++i) {
-        const auto& info = device.parameters[i];
+    dtos.reserve(parameters.size());
+    for (size_t i = 0; i < parameters.size(); ++i) {
+        const auto& info = parameters[i];
         const auto position = static_cast<int>(i);
         DeviceParameterDto dto;
         dto.index = info.paramIndex >= 0 ? info.paramIndex : position;

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -382,12 +382,10 @@ DeviceCatalogEntryDto makeDeviceCatalogEntryDto(const DeviceCatalogEntry& entry)
 
 std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device,
                                                         const ChainNodePath& devicePath) {
-    const auto contains = [](const std::vector<int>& positions, int position) {
-        return std::ranges::contains(positions, position);
+    const auto contains = [](const std::vector<int>& slots, int slot) {
+        return std::ranges::contains(slots, slot);
     };
-    // The customization lists key on position in `parameters`, while the wire
-    // `index` is `paramIndex` — the address parameter writes take. The two are
-    // normally equal, but only the position indexes the user's selections.
+    // The selections and the wire `index` are both slots (#2638).
     const auto parameters = deviceParameterList(device, devicePath);
     std::vector<DeviceParameterDto> dtos;
     dtos.reserve(parameters.size());
@@ -411,12 +409,12 @@ std::vector<DeviceParameterDto> makeDeviceParameterDtos(const DeviceInfo& device
         dto.normalizedValue = normalized.value;
         dto.scale = info.scale;
         dto.choices = info.choices;
-        dto.visible = contains(device.visibleParameters, position);
-        dto.miniMixer = contains(device.miniMixerParameters, position);
+        dto.visible = contains(device.visibleParameters, dto.index);
+        dto.miniMixer = contains(device.miniMixerParameters, dto.index);
         // Configure Parameters offers the AI opt-in only for external plugins;
         // internal devices accept agent writes on every parameter.
         dto.aiAgentEnabled = device.format == PluginFormat::Internal ||
-                             contains(device.aiSoundDesignerParameters, position);
+                             contains(device.aiSoundDesignerParameters, dto.index);
         dtos.push_back(std::move(dto));
     }
     return dtos;

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -628,8 +628,7 @@ HandlerResult devicesSetParameterConfig(MagdaApi& api, const juce::var& input,
                                    "their parameters already accept agent writes");
 
     // The wire indices are the ones devices.listParameters reports, which are
-    // paramIndex when set; the customization lists key on position. Translate
-    // so the two operations speak the same addresses.
+    // slots; a config entry is addressed by its position in the described list.
     const auto parameters = deviceParameterList(*device, *path);
     std::unordered_map<int, int> positionByWireIndex;
     for (size_t i = 0; i < parameters.size(); ++i) {

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "../audio/DeviceParameterList.hpp"
 #include "../core/AutomationCommands.hpp"
 #include "../core/AutomationInfo.hpp"
 #include "../core/AutomationTypes.hpp"
@@ -560,7 +561,7 @@ HandlerResult devicesListParameters(MagdaApi& api, const juce::var& input, const
         return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
 
     std::vector<juce::var> items;
-    for (const auto& parameter : makeDeviceParameterDtos(*device))
+    for (const auto& parameter : makeDeviceParameterDtos(*device, *path))
         items.push_back(toJson(parameter));
     return HandlerResult::ok(toJsonArray(items));
 }
@@ -574,7 +575,7 @@ HandlerResult devicesSetParameter(MagdaApi& api, const juce::var& input, const R
         return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
 
     const auto parameterIndex = readInt(input, "parameterIndex", -1);
-    const auto parameters = makeDeviceParameterDtos(*device);
+    const auto parameters = makeDeviceParameterDtos(*device, *path);
     const auto named = std::ranges::find(parameters, parameterIndex, &DeviceParameterDto::index);
     if (named == parameters.end())
         return notFound("parameter", parameterIndex);
@@ -605,7 +606,7 @@ HandlerResult devicesSetParameter(MagdaApi& api, const juce::var& input, const R
     // the caller sees what the model now holds rather than what was sent.
     const auto* updated = api.devices().getDevice(*path);
     if (updated != nullptr) {
-        for (const auto& parameter : makeDeviceParameterDtos(*updated)) {
+        for (const auto& parameter : makeDeviceParameterDtos(*updated, *path)) {
             if (parameter.index == parameterIndex)
                 return HandlerResult::ok(toJson(parameter));
         }
@@ -629,9 +630,10 @@ HandlerResult devicesSetParameterConfig(MagdaApi& api, const juce::var& input,
     // The wire indices are the ones devices.listParameters reports, which are
     // paramIndex when set; the customization lists key on position. Translate
     // so the two operations speak the same addresses.
+    const auto parameters = deviceParameterList(*device, *path);
     std::unordered_map<int, int> positionByWireIndex;
-    for (size_t i = 0; i < device->parameters.size(); ++i) {
-        const auto& info = device->parameters[i];
+    for (size_t i = 0; i < parameters.size(); ++i) {
+        const auto& info = parameters[i];
         const auto position = static_cast<int>(i);
         positionByWireIndex.emplace(info.paramIndex >= 0 ? info.paramIndex : position, position);
     }
@@ -723,7 +725,7 @@ HandlerResult devicesSetParameterConfig(MagdaApi& api, const juce::var& input,
     if (updated == nullptr)
         return HandlerResult::fail(ErrorCode::NotFound, "no device at devicePath");
     std::vector<juce::var> items;
-    for (const auto& parameter : makeDeviceParameterDtos(*updated))
+    for (const auto& parameter : makeDeviceParameterDtos(*updated, *path))
         items.push_back(toJson(parameter));
     return HandlerResult::ok(toJsonArray(items));
 }

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -464,6 +464,8 @@ target_sources(magda_daw PRIVATE
     AudioBridge.cpp
     DeviceParameterDisplayTextProvider.cpp
     DeviceParameterDisplayTextProvider.hpp
+    DeviceParameterList.cpp
+    DeviceParameterList.hpp
     ClipCommands.cpp
     FourOscMigration.cpp
     FourOscTranslation.cpp

--- a/magda/daw/audio/DeviceParameterList.cpp
+++ b/magda/daw/audio/DeviceParameterList.cpp
@@ -46,7 +46,16 @@ std::vector<ParameterInfo> deviceParameterList(const DeviceInfo& device,
     auto described = asDevice(device, std::move(reported));
     PluginParameterConfigStore::applyToDevice(described);
     attachParameterTextProviders(described, devicePath);
-    return std::move(described.parameters);
+    return withModelValues(std::move(described.parameters), device);
+}
+
+std::vector<ParameterInfo> withModelValues(std::vector<ParameterInfo> described,
+                                           const DeviceInfo& device) {
+    for (auto& parameter : described)
+        if (const auto* mirrored = device.findParameterByIndex(parameter.paramIndex))
+            parameter.currentValue = mirrored->currentValue;
+
+    return described;
 }
 
 }  // namespace magda

--- a/magda/daw/audio/DeviceParameterList.cpp
+++ b/magda/daw/audio/DeviceParameterList.cpp
@@ -17,12 +17,7 @@ HostParameters reportedAt(const ChainNodePath& devicePath) {
     return engine != nullptr ? engine->describeDeviceParameters(devicePath) : HostParameters{};
 }
 
-/**
- * @brief @p reported in a device, shaped for the config store and the providers.
- *
- * Both work on a DeviceInfo, and the fields they read are the plugin's identity
- * and its lists.
- */
+/** @brief @p reported in a device, which is what the config store works on. */
 DeviceInfo asDevice(const DeviceInfo& device, HostParameters&& reported) {
     DeviceInfo described;
     described.id = device.id;
@@ -30,7 +25,10 @@ DeviceInfo asDevice(const DeviceInfo& device, HostParameters&& reported) {
     described.pluginId = device.pluginId;
     described.format = device.format;
     described.parameters = std::move(reported.parameters);
-    described.wrapperParameters = std::move(reported.wrapperParameters);
+
+    // The model owns the wrapper pair: no chunk carries it and the instance has
+    // never heard of it.
+    described.wrapperParameters = device.wrapperParameters;
     return described;
 }
 

--- a/magda/daw/audio/DeviceParameterList.cpp
+++ b/magda/daw/audio/DeviceParameterList.cpp
@@ -1,0 +1,54 @@
+#include "DeviceParameterList.hpp"
+
+#include "DeviceParameterDisplayTextProvider.hpp"
+#include "core/DeviceInfo.hpp"
+#include "core/PluginParameterConfigStore.hpp"
+#include "core/TrackManager.hpp"
+#include "engine/AudioEngine.hpp"
+#include "plugin_manager/ExternalPluginState.hpp"
+
+namespace magda {
+
+namespace {
+
+/** @brief What the engine's instance at @p devicePath reports. */
+HostParameters reportedAt(const ChainNodePath& devicePath) {
+    auto* engine = TrackManager::getInstance().getAudioEngine();
+    return engine != nullptr ? engine->describeDeviceParameters(devicePath) : HostParameters{};
+}
+
+/**
+ * @brief @p reported in a device, shaped for the config store and the providers.
+ *
+ * Both work on a DeviceInfo, and the fields they read are the plugin's identity
+ * and its lists.
+ */
+DeviceInfo asDevice(const DeviceInfo& device, HostParameters&& reported) {
+    DeviceInfo described;
+    described.id = device.id;
+    described.uniqueId = device.uniqueId;
+    described.pluginId = device.pluginId;
+    described.format = device.format;
+    described.parameters = std::move(reported.parameters);
+    described.wrapperParameters = std::move(reported.wrapperParameters);
+    return described;
+}
+
+}  // namespace
+
+std::vector<ParameterInfo> deviceParameterList(const DeviceInfo& device,
+                                               const ChainNodePath& devicePath) {
+    if (device.format == PluginFormat::Internal || !devicePath.isValid())
+        return device.parameters;
+
+    auto reported = reportedAt(devicePath);
+    if (reported.parameters.empty())
+        return device.parameters;
+
+    auto described = asDevice(device, std::move(reported));
+    PluginParameterConfigStore::applyToDevice(described);
+    attachParameterTextProviders(described, devicePath);
+    return std::move(described.parameters);
+}
+
+}  // namespace magda

--- a/magda/daw/audio/DeviceParameterList.hpp
+++ b/magda/daw/audio/DeviceParameterList.hpp
@@ -9,9 +9,7 @@
  * @file DeviceParameterList.hpp
  * @brief What a device's parameters are, for everything that shows them (#2634).
  *
- * A hosted plugin's list comes from the instance, which is the only thing that
- * can enumerate it; the model mirrors a value only for a slot something
- * addresses (#2629).
+ * Only a hosted plugin's instance can enumerate its parameters (#2629).
  */
 
 namespace magda {
@@ -21,9 +19,9 @@ struct DeviceInfo;
 /**
  * @brief The parameters of the device at @p devicePath, in list order.
  *
- * Positions are what the customization lists key on and `paramIndex` is the
- * slot a write addresses, exactly as DeviceInfo::parameters has them. Internal
- * devices and plugins the engine holds no instance for answer from the model.
+ * Shaped like DeviceInfo::parameters: `paramIndex` is the slot a write
+ * addresses. Answered from the model for an internal device, and for a plugin
+ * the engine holds no instance for.
  */
 std::vector<ParameterInfo> deviceParameterList(const DeviceInfo& device,
                                                const ChainNodePath& devicePath);

--- a/magda/daw/audio/DeviceParameterList.hpp
+++ b/magda/daw/audio/DeviceParameterList.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+
+#include "core/ChainNodePath.hpp"
+#include "core/ParameterInfo.hpp"
+
+/**
+ * @file DeviceParameterList.hpp
+ * @brief What a device's parameters are, for everything that shows them (#2634).
+ *
+ * A hosted plugin's list comes from the instance, which is the only thing that
+ * can enumerate it; the model mirrors a value only for a slot something
+ * addresses (#2629).
+ */
+
+namespace magda {
+
+struct DeviceInfo;
+
+/**
+ * @brief The parameters of the device at @p devicePath, in list order.
+ *
+ * Positions are what the customization lists key on and `paramIndex` is the
+ * slot a write addresses, exactly as DeviceInfo::parameters has them. Internal
+ * devices and plugins the engine holds no instance for answer from the model.
+ */
+std::vector<ParameterInfo> deviceParameterList(const DeviceInfo& device,
+                                               const ChainNodePath& devicePath);
+
+}  // namespace magda

--- a/magda/daw/audio/DeviceParameterList.hpp
+++ b/magda/daw/audio/DeviceParameterList.hpp
@@ -26,4 +26,14 @@ struct DeviceInfo;
 std::vector<ParameterInfo> deviceParameterList(const DeviceInfo& device,
                                                const ChainNodePath& devicePath);
 
+/**
+ * @brief @p described at the values @p device holds for the slots it carries.
+ *
+ * A write reaches the model at once and the plugin a block later, so the model
+ * is what a reader is shown for a slot it mirrors. The rest keep the values the
+ * instance reported.
+ */
+std::vector<ParameterInfo> withModelValues(std::vector<ParameterInfo> described,
+                                           const DeviceInfo& device);
+
 }  // namespace magda

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -701,18 +701,7 @@ magda::SavedStateOutcome EngineExternalDevice::applyState(const magda::DeviceInf
 }
 
 magda::HostParameters EngineExternalDevice::describeParameters() const {
-    auto described = magda::describeHostParameters(*instance_, magda::DeviceInfo{});
-
-    // The wrapper pair is the host's own, so its live values are these rather
-    // than anything the instance holds.
-    for (auto& parameter : described.wrapperParameters) {
-        if (parameter.wrapperRole == magda::WrapperRole::DryGain)
-            parameter.currentValue = dryGain_;
-        else if (parameter.wrapperRole == magda::WrapperRole::WetGain)
-            parameter.currentValue = wetGain_;
-    }
-
-    return described;
+    return magda::describeHostParameters(*instance_, magda::DeviceInfo{});
 }
 
 juce::String EngineExternalDevice::parameterText(int slot, float normalised) const {

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.cpp
@@ -700,6 +700,21 @@ magda::SavedStateOutcome EngineExternalDevice::applyState(const magda::DeviceInf
     return magda::applySavedPluginState(*instance_, saved);
 }
 
+magda::HostParameters EngineExternalDevice::describeParameters() const {
+    auto described = magda::describeHostParameters(*instance_, magda::DeviceInfo{});
+
+    // The wrapper pair is the host's own, so its live values are these rather
+    // than anything the instance holds.
+    for (auto& parameter : described.wrapperParameters) {
+        if (parameter.wrapperRole == magda::WrapperRole::DryGain)
+            parameter.currentValue = dryGain_;
+        else if (parameter.wrapperRole == magda::WrapperRole::WetGain)
+            parameter.currentValue = wetGain_;
+    }
+
+    return described;
+}
+
 juce::String EngineExternalDevice::parameterText(int slot, float normalised) const {
     if (slot < 0 || slot >= static_cast<int>(parameters_.size()))
         return {};

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -173,6 +173,8 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
      *
      * Message thread, on the same terms as parameterText(): a query that
      * suspends nothing. What the model mirrors is a subset of this (#2629).
+     * The wrapper pair carries its defaults, since the model owns those values
+     * and this device's own copies are written on the audio thread.
      */
     magda::HostParameters describeParameters() const;
 

--- a/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
+++ b/magda/daw/audio/plugins/engine/EngineExternalDevice.hpp
@@ -168,6 +168,14 @@ class EngineExternalDevice final : public magda::engine::EngineDevice {
      */
     juce::String parameterText(int slot, float normalised) const;
 
+    /**
+     * @brief Every parameter the instance reports, at the values it holds now.
+     *
+     * Message thread, on the same terms as parameterText(): a query that
+     * suspends nothing. What the model mirrors is a subset of this (#2629).
+     */
+    magda::HostParameters describeParameters() const;
+
     // ===== The plugin's own window (#2580) =====
     //
     // Here for the same reason again: the instance has no accessor, and the

--- a/magda/daw/core/AddressedParameters.cpp
+++ b/magda/daw/core/AddressedParameters.cpp
@@ -37,19 +37,11 @@ AddressedParameters AddressedParameters::from(const AddressingSources& sources) 
     const auto device = [&links, &record](const DeviceInfo& info, const ChainNodePath& path) {
         links(info);
 
-        // Positions in DeviceInfo::parameters, not slots: a hosted plugin's
-        // array starts at slot 2, past the wrapper pair.
-        const auto slotAt = [&info](int position) {
-            return position >= 0 && position < static_cast<int>(info.parameters.size())
-                       ? info.parameters[static_cast<std::size_t>(position)].paramIndex
-                       : -1;
-        };
-
         // An empty list is the UI's "show everything" (#2634): it addresses none.
         for (const auto* list :
              {&info.visibleParameters, &info.miniMixerParameters, &info.aiSoundDesignerParameters})
-            for (const auto position : *list)
-                record(path, slotAt(position));
+            for (const auto slot : *list)
+                record(path, slot);
     };
 
     const auto track = [&links, &device](const TrackInfo& info) {

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -1,6 +1,7 @@
 #include "PluginParameterConfigStore.hpp"
 
 #include <algorithm>
+#include <ranges>
 #include <unordered_map>
 
 #include "AppPaths.hpp"
@@ -50,8 +51,8 @@ bool refreshFlatParameterConfig(const juce::String& uniqueId,
 /// The entry describing `device`'s parameter at `index` as it stands now.
 PluginParameterConfigEntry entryFor(const DeviceInfo& device, size_t index) {
     const auto& info = device.parameters[index];
-    const auto selected = [index](const std::vector<int>& indices) {
-        return std::find(indices.begin(), indices.end(), static_cast<int>(index)) != indices.end();
+    const auto selected = [slot = info.paramIndex](const std::vector<int>& slots) {
+        return std::ranges::contains(slots, slot);
     };
 
     PluginParameterConfigEntry entry;
@@ -280,11 +281,9 @@ bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device) {
     device.aiSoundDesignerParameters.clear();
     device.aiSoundDesignerPrompt = config->aiPrompt;
 
-    // device.parameters holds only the plugin's own params — TE's slot dry/wet
-    // live in device.wrapperParameters — so a stored index maps 1:1 to the
-    // device array. (Configs saved before the wrapper-param split assumed
-    // indices 0/1 were dry/wet; those resolve to the wrong slots once and need
-    // to be re-saved.)
+    // An entry is matched to a parameter by stable id and the selection is
+    // stored as that parameter's slot (#2638), so a list survives the array it
+    // was resolved against changing shape.
     const auto count = static_cast<int>(device.parameters.size());
 
     std::vector<juce::String> currentIds;
@@ -299,14 +298,15 @@ bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device) {
         const auto index = positions[at];
         if (index < 0 || index >= count)
             continue;
-        if (entry.visible)
-            device.visibleParameters.push_back(index);
-        if (entry.miniMixer)
-            device.miniMixerParameters.push_back(index);
-        if (entry.aiAgent)
-            device.aiSoundDesignerParameters.push_back(index);
-
         auto& parameter = device.parameters[static_cast<size_t>(index)];
+
+        if (entry.visible)
+            device.visibleParameters.push_back(parameter.paramIndex);
+        if (entry.miniMixer)
+            device.miniMixerParameters.push_back(parameter.paramIndex);
+        if (entry.aiAgent)
+            device.aiSoundDesignerParameters.push_back(parameter.paramIndex);
+
         if (entry.unit)
             parameter.unit = *entry.unit;
         if (entry.scale)

--- a/magda/daw/core/PluginParameterConfigStore.cpp
+++ b/magda/daw/core/PluginParameterConfigStore.cpp
@@ -281,9 +281,8 @@ bool applyToDevice(const juce::String& uniqueId, DeviceInfo& device) {
     device.aiSoundDesignerParameters.clear();
     device.aiSoundDesignerPrompt = config->aiPrompt;
 
-    // An entry is matched to a parameter by stable id and the selection is
-    // stored as that parameter's slot (#2638), so a list survives the array it
-    // was resolved against changing shape.
+    // An entry is matched by stable id, and its selection stored as the slot
+    // of the parameter it lands on (#2638).
     const auto count = static_cast<int>(device.parameters.size());
 
     std::vector<juce::String> currentIds;

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "../audio/midi/RecordingNoteQueue.hpp"
+#include "../audio/plugin_manager/ExternalPluginState.hpp"
 #include "../core/ChainNodePath.hpp"
 #include "../core/ClipTypes.hpp"
 #include "../core/ParameterDetector.hpp"
@@ -306,6 +307,16 @@ class AudioEngine : public AudioEngineListener {
      */
     virtual juce::String formatDeviceParameter(const ChainNodePath& /*devicePath*/,
                                                int /*paramIndex*/, float /*normalised*/) const {
+        return {};
+    }
+
+    /**
+     * @brief Every parameter the plugin at @p devicePath reports (#2629).
+     *
+     * Message thread. Empty where the engine holds no instance for the path,
+     * which leaves the reader on the model's own array.
+     */
+    virtual HostParameters describeDeviceParameters(const ChainNodePath& /*devicePath*/) const {
         return {};
     }
 

--- a/magda/daw/engine/AudioEngine.hpp
+++ b/magda/daw/engine/AudioEngine.hpp
@@ -313,8 +313,7 @@ class AudioEngine : public AudioEngineListener {
     /**
      * @brief Every parameter the plugin at @p devicePath reports (#2629).
      *
-     * Message thread. Empty where the engine holds no instance for the path,
-     * which leaves the reader on the model's own array.
+     * Message thread. Empty for a path this engine holds no instance for.
      */
     virtual HostParameters describeDeviceParameters(const ChainNodePath& /*devicePath*/) const {
         return {};

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -365,6 +365,11 @@ juce::String MagdaAudioEngine::formatDeviceParameter(const ChainNodePath& device
 
     return tracktion_->formatDeviceParameter(devicePath, paramIndex, normalised);
 }
+/** @brief Only the host holds instances; the fork's readers keep the model's array. */
+HostParameters MagdaAudioEngine::describeDeviceParameters(const ChainNodePath& devicePath) const {
+    return host_ != nullptr ? host_->describeDeviceParameters(devicePath) : HostParameters{};
+}
+
 MidiBridge* MagdaAudioEngine::getMidiBridge() {
     return tracktion_->getMidiBridge();
 }

--- a/magda/daw/engine/MagdaAudioEngine.cpp
+++ b/magda/daw/engine/MagdaAudioEngine.cpp
@@ -365,7 +365,7 @@ juce::String MagdaAudioEngine::formatDeviceParameter(const ChainNodePath& device
 
     return tracktion_->formatDeviceParameter(devicePath, paramIndex, normalised);
 }
-/** @brief Only the host holds instances; the fork's readers keep the model's array. */
+/** @brief The host's instances, which are the only ones there are (#2579). */
 HostParameters MagdaAudioEngine::describeDeviceParameters(const ChainNodePath& devicePath) const {
     return host_ != nullptr ? host_->describeDeviceParameters(devicePath) : HostParameters{};
 }

--- a/magda/daw/engine/MagdaAudioEngine.hpp
+++ b/magda/daw/engine/MagdaAudioEngine.hpp
@@ -146,6 +146,8 @@ class MagdaAudioEngine final : public AudioEngine, public LiveMidiSink {
     bool isDeviceEditorOpen(const ChainNodePath& devicePath) const override;
     juce::String formatDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
                                        float normalised) const override;
+
+    HostParameters describeDeviceParameters(const ChainNodePath& devicePath) const override;
     MidiBridge* getMidiBridge() override;
     const MidiBridge* getMidiBridge() const override;
     MagdaApi& getMagdaApi() override;

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -925,7 +925,6 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
         return held != nullptr ? externalIn(*held) : nullptr;
     }
 
-    /** @brief Every parameter the plugin at @p devicePath reports (#2629). */
     HostParameters describeDeviceParameters(const ChainNodePath& devicePath) const {
         auto* external = externalDeviceAt(devicePath);
         return external != nullptr ? external->describeParameters() : HostParameters{};

--- a/magda/daw/engine/host/EngineHost.cpp
+++ b/magda/daw/engine/host/EngineHost.cpp
@@ -907,20 +907,28 @@ struct EngineHost::Impl final : private juce::AudioIODeviceCallback,
      */
     juce::String formatDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
                                        float normalised) const {
+        auto* external = externalDeviceAt(devicePath);
+        return external != nullptr ? external->parameterText(paramIndex, normalised)
+                                   : juce::String{};
+    }
+
+    /** @brief The plugin rendering at @p devicePath, or null. Message thread. */
+    adapter::EngineExternalDevice* externalDeviceAt(const ChainNodePath& devicePath) const {
         if (session_ == nullptr)
-            return {};
+            return nullptr;
 
         const auto key = keyOfDeviceAt(devicePath);
         if (!key.has_value())
-            return {};
+            return nullptr;
 
         auto held = session_->device(*key);
-        if (held == nullptr)
-            return {};
+        return held != nullptr ? externalIn(*held) : nullptr;
+    }
 
-        auto* external = externalIn(*held);
-        return external != nullptr ? external->parameterText(paramIndex, normalised)
-                                   : juce::String{};
+    /** @brief Every parameter the plugin at @p devicePath reports (#2629). */
+    HostParameters describeDeviceParameters(const ChainNodePath& devicePath) const {
+        auto* external = externalDeviceAt(devicePath);
+        return external != nullptr ? external->describeParameters() : HostParameters{};
     }
 
     void captureExternalPluginStateAt(const ChainNodePath& devicePath) {
@@ -1178,6 +1186,10 @@ bool EngineHost::isDeviceEditorOpen(const ChainNodePath& devicePath) {
 juce::String EngineHost::formatDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
                                                float normalised) const {
     return impl_->formatDeviceParameter(devicePath, paramIndex, normalised);
+}
+
+HostParameters EngineHost::describeDeviceParameters(const ChainNodePath& devicePath) const {
+    return impl_->describeDeviceParameters(devicePath);
 }
 
 void EngineHost::play() {

--- a/magda/daw/engine/host/EngineHost.hpp
+++ b/magda/daw/engine/host/EngineHost.hpp
@@ -16,7 +16,8 @@ class String;
 
 namespace magda {
 class TempoMap;
-}
+struct HostParameters;
+}  // namespace magda
 
 /**
  * @file EngineHost.hpp
@@ -138,6 +139,9 @@ class EngineHost {
      */
     juce::String formatDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
                                        float normalised) const;
+
+    /** @brief Every parameter the plugin at @p devicePath reports (#2629). */
+    HostParameters describeDeviceParameters(const ChainNodePath& devicePath) const;
 
     // ===== The plugins' own windows (#2580) =====
     //

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -54,9 +54,8 @@ std::vector<int> readInts(const juce::DynamicObject& obj, const char* key) {
 /**
  * @brief The three parameter selections, whichever way the project holds them.
  *
- * They are slots from #2638 on. A project written before that holds positions
- * in the device's parameter array, which still carries every slot at load, so
- * the position is translated through it.
+ * Slots from #2638 on. An older project holds positions, translated through
+ * the saved array, which still carries every slot at load.
  */
 void readParameterSelections(const juce::DynamicObject& obj, DeviceInfo& device) {
     const auto selection = [&obj, &device](const char* slotsKey, const char* positionsKey) {
@@ -502,8 +501,8 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
     }
     obj->setProperty("parameters", juce::var(paramsArray));
 
-    // The selections, as parameter slots (#2638). Written under their own keys
-    // so a reader can tell them from the positions older projects hold.
+    // Slots (#2638), under their own keys so a reader can tell them from the
+    // positions older projects hold.
     const auto writeSlots = [&obj](const char* key, const std::vector<int>& slots) {
         juce::Array<juce::var> array;
         for (const auto slot : slots)

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -33,6 +33,51 @@ void migrateUtilityWidthToPercent(DeviceInfo& device) {
     }
 }
 
+/// The slot at @p position of @p device's parameter array, or -1.
+int slotAtPosition(const DeviceInfo& device, int position) {
+    if (position < 0 || position >= static_cast<int>(device.parameters.size()))
+        return -1;
+
+    return device.parameters[static_cast<std::size_t>(position)].paramIndex;
+}
+
+std::vector<int> readInts(const juce::DynamicObject& obj, const char* key) {
+    std::vector<int> values;
+    const auto var = obj.getProperty(key);
+    if (const auto* array = var.getArray())
+        for (const auto& value : *array)
+            values.push_back(static_cast<int>(value));
+
+    return values;
+}
+
+/**
+ * @brief The three parameter selections, whichever way the project holds them.
+ *
+ * They are slots from #2638 on. A project written before that holds positions
+ * in the device's parameter array, which still carries every slot at load, so
+ * the position is translated through it.
+ */
+void readParameterSelections(const juce::DynamicObject& obj, DeviceInfo& device) {
+    const auto selection = [&obj, &device](const char* slotsKey, const char* positionsKey) {
+        auto slots = readInts(obj, slotsKey);
+        if (!slots.empty() || obj.hasProperty(slotsKey))
+            return slots;
+
+        std::vector<int> translated;
+        for (const auto position : readInts(obj, positionsKey))
+            if (const auto slot = slotAtPosition(device, position); slot >= 0)
+                translated.push_back(slot);
+
+        return translated;
+    };
+
+    device.visibleParameters = selection("visibleParameterSlots", "visibleParameters");
+    device.miniMixerParameters = selection("miniMixerParameterSlots", "miniMixerParameters");
+    device.aiSoundDesignerParameters =
+        selection("aiSoundDesignerParameterSlots", "aiSoundDesignerParameters");
+}
+
 void enforcePostFxAnalysisDeviceOrder(std::vector<PostFxChainElement>& elements) {
     const auto analysisOrderOf = [](const PostFxChainElement& element) {
         return daw::audio::internalPostFxAnalysisOrder(element.device.pluginId);
@@ -457,26 +502,18 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
     }
     obj->setProperty("parameters", juce::var(paramsArray));
 
-    // Visible parameters
-    juce::Array<juce::var> visibleParamsArray;
-    for (auto index : device.visibleParameters) {
-        visibleParamsArray.add(index);
-    }
-    obj->setProperty("visibleParameters", juce::var(visibleParamsArray));
+    // The selections, as parameter slots (#2638). Written under their own keys
+    // so a reader can tell them from the positions older projects hold.
+    const auto writeSlots = [&obj](const char* key, const std::vector<int>& slots) {
+        juce::Array<juce::var> array;
+        for (const auto slot : slots)
+            array.add(slot);
+        obj->setProperty(key, juce::var(array));
+    };
 
-    // Mini mixer parameters
-    juce::Array<juce::var> miniMixerParamsArray;
-    for (auto index : device.miniMixerParameters) {
-        miniMixerParamsArray.add(index);
-    }
-    obj->setProperty("miniMixerParameters", juce::var(miniMixerParamsArray));
-
-    // AI sound-designer parameters
-    juce::Array<juce::var> aiSoundDesignerParamsArray;
-    for (auto index : device.aiSoundDesignerParameters) {
-        aiSoundDesignerParamsArray.add(index);
-    }
-    obj->setProperty("aiSoundDesignerParameters", juce::var(aiSoundDesignerParamsArray));
+    writeSlots("visibleParameterSlots", device.visibleParameters);
+    writeSlots("miniMixerParameterSlots", device.miniMixerParameters);
+    writeSlots("aiSoundDesignerParameterSlots", device.aiSoundDesignerParameters);
     obj->setProperty("aiSoundDesignerPrompt", device.aiSoundDesignerPrompt);
 
     // Device volume
@@ -661,32 +698,7 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
 
     migrateUtilityWidthToPercent(outDevice);
 
-    // Visible parameters
-    auto visibleParamsVar = obj->getProperty("visibleParameters");
-    if (visibleParamsVar.isArray()) {
-        auto* arr = visibleParamsVar.getArray();
-        for (const auto& indexVar : *arr) {
-            outDevice.visibleParameters.push_back(static_cast<int>(indexVar));
-        }
-    }
-
-    // Mini mixer parameters
-    auto miniMixerParamsVar = obj->getProperty("miniMixerParameters");
-    if (miniMixerParamsVar.isArray()) {
-        auto* arr = miniMixerParamsVar.getArray();
-        for (const auto& indexVar : *arr) {
-            outDevice.miniMixerParameters.push_back(static_cast<int>(indexVar));
-        }
-    }
-
-    // AI sound-designer parameters
-    auto aiSoundDesignerParamsVar = obj->getProperty("aiSoundDesignerParameters");
-    if (aiSoundDesignerParamsVar.isArray()) {
-        auto* arr = aiSoundDesignerParamsVar.getArray();
-        for (const auto& indexVar : *arr) {
-            outDevice.aiSoundDesignerParameters.push_back(static_cast<int>(indexVar));
-        }
-    }
+    readParameterSelections(*obj, outDevice);
     outDevice.aiSoundDesignerPrompt = obj->getProperty("aiSoundDesignerPrompt").toString();
 
     // Device volume

--- a/magda/daw/ui/components/automation/AutomationMenu.cpp
+++ b/magda/daw/ui/components/automation/AutomationMenu.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 
+#include "audio/DeviceParameterList.hpp"
 #include "core/AutomationInfo.hpp"
 #include "core/AutomationManager.hpp"
 #include "core/ChainNodePath.hpp"
@@ -190,10 +191,14 @@ void showAutomationMenu(
                                               ? ChainNodePath::topLevelDevice(trackId, device.id)
                                               : parentPath.withDevice(device.id);
 
+                        // A lane can be drawn on any parameter the plugin has,
+                        // so the list comes from the instance (#2634).
+                        const auto parameters = deviceParameterList(device, devicePath);
+
                         // Params submenu
-                        if (!device.parameters.empty()) {
+                        if (!parameters.empty()) {
                             juce::PopupMenu paramsMenu;
-                            for (const auto& p : device.parameters) {
+                            for (const auto& p : parameters) {
                                 AutomationTarget target;
                                 target.kind = ControlTarget::Kind::PluginParam;
                                 target.devicePath.trackId = trackId;

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -7,6 +7,7 @@
 
 #include "ai/AIPanelComponent.hpp"
 #include "audio/AudioBridge.hpp"
+#include "audio/DeviceParameterList.hpp"
 #include "audio/plugin_manager/PluginManager.hpp"
 #include "audio/plugins/InternalPluginRegistry.hpp"
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
@@ -757,8 +758,18 @@ void DeviceSlotComponent::syncModMacroControlsAvailability() {
     }
 }
 
+/** @brief Draw from what the plugin has, which for a hosted one is its instance. */
+void DeviceSlotComponent::adoptParameterList() {
+    device_.parameters = magda::deviceParameterList(device_, nodePath_);
+}
+
 void DeviceSlotComponent::setNodePath(const magda::ChainNodePath& path) {
     NodeComponent::setNodePath(path);
+
+    // The path is what reaches the plugin, so the list can only be taken once
+    // it is known (#2634).
+    adoptParameterList();
+
     customUI_.setDevicePath(path);
     updateDeviceSlotInlineUi(device_, compiledPanel_.get(), customUI_);
 
@@ -915,6 +926,7 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     }
 
     device_ = device;
+    adoptParameterList();
     refreshDeviceTraits(device);
     syncModMacroControlsAvailability();
     drum_grid_slot::applySlotName(*this, traits_.isDrumGrid, device.name);

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -758,7 +758,6 @@ void DeviceSlotComponent::syncModMacroControlsAvailability() {
     }
 }
 
-/** @brief Draw from what the plugin has, which for a hosted one is its instance. */
 void DeviceSlotComponent::adoptParameterList() {
     device_.parameters = magda::deviceParameterList(device_, nodePath_);
 }
@@ -766,8 +765,7 @@ void DeviceSlotComponent::adoptParameterList() {
 void DeviceSlotComponent::setNodePath(const magda::ChainNodePath& path) {
     NodeComponent::setNodePath(path);
 
-    // The path is what reaches the plugin, so the list can only be taken once
-    // it is known (#2634).
+    // The path is what reaches the plugin (#2634).
     adoptParameterList();
 
     customUI_.setDevicePath(path);

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -224,6 +224,10 @@ class DeviceSlotComponent : public NodeComponent,
     void aiSoundDesignerPreferenceChanged(const juce::String& pluginIdentifier) override;
 
   private:
+    /// Take the parameter list from whatever holds it: a hosted plugin's own
+    /// instance, or the model (#2634).
+    void adoptParameterList();
+
     magda::DeviceInfo device_;
     DeviceSlotTraits traits_;
     DeviceSlotModMacroCommandCallbacks modMacroCommandCallbacks();

--- a/magda/daw/ui/components/chain/layout/StandardDeviceLayout.cpp
+++ b/magda/daw/ui/components/chain/layout/StandardDeviceLayout.cpp
@@ -11,12 +11,23 @@ int visibleCountFor(const magda::DeviceInfo& device) {
                                             : static_cast<int>(device.visibleParameters.size());
 }
 
+/// Where @p slot sits in the device's parameter array, or -1.
+int positionOfSlot(const magda::DeviceInfo& device, int slot) {
+    const auto found =
+        std::ranges::find(device.parameters, slot, &magda::ParameterInfo::paramIndex);
+    return found == device.parameters.end()
+               ? -1
+               : static_cast<int>(std::distance(device.parameters.begin(), found));
+}
+
 int paramArrayIndexFor(const magda::DeviceInfo& device, int slotIndex) {
     if (device.visibleParameters.empty())
         return slotIndex;
     if (slotIndex < 0 || slotIndex >= static_cast<int>(device.visibleParameters.size()))
         return -1;
-    return device.visibleParameters[static_cast<size_t>(slotIndex)];
+
+    // The selections name slots (#2638); the grid draws from array positions.
+    return positionOfSlot(device, device.visibleParameters[static_cast<size_t>(slotIndex)]);
 }
 
 bool gateEnabled(const magda::DeviceInfo& device, const magda::ParameterInfo& param) {

--- a/magda/daw/ui/components/chain/slot/DeviceSlotAutomationControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotAutomationControls.cpp
@@ -66,26 +66,32 @@ void applyDeviceSlotAutomationValueChange(magda::DeviceInfo& device, ParamHostCo
 
     if (paramGrid != nullptr) {
         const int paramsPerPage = paramGrid->getSlotCount();
-        const int currentPage = paramGrid->getCurrentPage();
-        const int pageOffset = currentPage * paramsPerPage;
-        const bool useVisibilityFilter = !device.visibleParameters.empty();
+        const int pageOffset = paramGrid->getCurrentPage() * paramsPerPage;
+
+        // Which slot the grid draws in each cell: the user's selection where
+        // there is one (#2638), the array in order otherwise.
+        const auto slotInCell = [&device](int cell) {
+            const auto at = [](const auto& list, int index) {
+                return index >= 0 && index < static_cast<int>(list.size());
+            };
+
+            if (!device.visibleParameters.empty())
+                return at(device.visibleParameters, cell)
+                           ? device.visibleParameters[static_cast<size_t>(cell)]
+                           : -1;
+
+            return at(device.parameters, cell)
+                       ? device.parameters[static_cast<size_t>(cell)].paramIndex
+                       : -1;
+        };
 
         for (int slotIndex = 0; slotIndex < paramsPerPage; ++slotIndex) {
-            const int visibleParamIndex = pageOffset + slotIndex;
-            int actualParamIndex = 0;
-            if (useVisibilityFilter) {
-                if (visibleParamIndex >= static_cast<int>(device.visibleParameters.size()))
-                    continue;
-                actualParamIndex = device.visibleParameters[static_cast<size_t>(visibleParamIndex)];
-            } else {
-                actualParamIndex = visibleParamIndex;
-            }
+            if (slotInCell(pageOffset + slotIndex) != paramIndex)
+                continue;
 
-            if (actualParamIndex == paramIndex) {
-                if (auto* slot = paramGrid->getSlot(slotIndex))
-                    slot->setParamValue(modelValue);
-                break;
-            }
+            if (auto* slot = paramGrid->getSlot(slotIndex))
+                slot->setParamValue(modelValue);
+            break;
         }
     }
 

--- a/magda/daw/ui/components/mixer/MiniChainRow.cpp
+++ b/magda/daw/ui/components/mixer/MiniChainRow.cpp
@@ -174,15 +174,13 @@ void MiniChainRow::resolveParams() {
     };
 
     // 1) Explicit user selection from the parameter config dialog's "Mini"
-    //    column (indices into devInfo->parameters), in the order chosen.
-    for (int idx : devInfo->miniMixerParameters) {
+    //    column (slots, #2638), in the order chosen.
+    for (const int slot : devInfo->miniMixerParameters) {
         if (static_cast<int>(trackedParamIndices_.size()) >= kMaxExpandedParams)
             break;
-        if (idx >= 0 && idx < static_cast<int>(devInfo->parameters.size())) {
-            const auto& paramInfo = devInfo->parameters[static_cast<size_t>(idx)];
-            if (!paramInfo.hidden)
-                addParamSlider(paramInfo);
-        }
+        if (const auto* paramInfo = devInfo->findParameterByIndex(slot);
+            paramInfo != nullptr && !paramInfo->hidden)
+            addParamSlider(*paramInfo);
     }
 
     // 2) Fallback (no explicit selection): first N non-hidden parameters in

--- a/magda/daw/ui/components/mixer/MiniChainRow.cpp
+++ b/magda/daw/ui/components/mixer/MiniChainRow.cpp
@@ -2,7 +2,10 @@
 
 #include <BinaryData.h>
 
+#include <algorithm>
+
 #include "../../../audio/AudioBridge.hpp"
+#include "../../../audio/DeviceParameterList.hpp"
 #include "../../../engine/AudioEngine.hpp"
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
@@ -173,20 +176,28 @@ void MiniChainRow::resolveParams() {
         paramSliders_.push_back(std::move(slider));
     };
 
+    // What the plugin has, which for a hosted one comes from its instance
+    // (#2634).
+    const auto parameters = deviceParameterList(*devInfo, devicePath_);
+
+    const auto parameterAt = [&parameters](int slot) -> const ParameterInfo* {
+        const auto found = std::ranges::find(parameters, slot, &ParameterInfo::paramIndex);
+        return found == parameters.end() ? nullptr : &*found;
+    };
+
     // 1) Explicit user selection from the parameter config dialog's "Mini"
     //    column (slots, #2638), in the order chosen.
     for (const int slot : devInfo->miniMixerParameters) {
         if (static_cast<int>(trackedParamIndices_.size()) >= kMaxExpandedParams)
             break;
-        if (const auto* paramInfo = devInfo->findParameterByIndex(slot);
-            paramInfo != nullptr && !paramInfo->hidden)
+        if (const auto* paramInfo = parameterAt(slot); paramInfo != nullptr && !paramInfo->hidden)
             addParamSlider(*paramInfo);
     }
 
     // 2) Fallback (no explicit selection): first N non-hidden parameters in
     //    device order.
     if (trackedParamIndices_.empty()) {
-        for (const auto& paramInfo : devInfo->parameters) {
+        for (const auto& paramInfo : parameters) {
             if (static_cast<int>(trackedParamIndices_.size()) >= kMaxExpandedParams)
                 break;
             if (paramInfo.hidden)

--- a/magda/daw/ui/components/mixer/MiniChainRow.cpp
+++ b/magda/daw/ui/components/mixer/MiniChainRow.cpp
@@ -176,8 +176,7 @@ void MiniChainRow::resolveParams() {
         paramSliders_.push_back(std::move(slider));
     };
 
-    // What the plugin has, which for a hosted one comes from its instance
-    // (#2634).
+    // What the plugin has (#2634).
     const auto parameters = deviceParameterList(*devInfo, devicePath_);
 
     const auto parameterAt = [&parameters](int slot) -> const ParameterInfo* {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -344,6 +344,7 @@ set(TEST_SOURCES
     audio/test_demucs_separator.cpp
     audio/test_spleeter_separator.cpp
     core/test_addressed_parameters.cpp
+    core/test_device_parameter_list.cpp
     core/test_device_info_predicates.cpp
     core/test_four_osc_translation.cpp
     core/test_ranges_helpers.cpp

--- a/tests/core/test_addressed_parameters.cpp
+++ b/tests/core/test_addressed_parameters.cpp
@@ -168,9 +168,8 @@ TEST_CASE("A place in the device UI addresses a parameter", "[core][parameters][
 }
 
 TEST_CASE("A UI list names slots", "[core][parameters][addressed]") {
-    // A hosted plugin's own parameters start at slot 2, past the wrapper pair.
-    // The selections name those slots (#2638), so nothing has to translate a
-    // position through an array that #2635 shortens.
+    // A hosted plugin's own parameters start at slot 2, past the wrapper pair,
+    // and the selections name those slots (#2638).
     auto device = makeDevice(7, 0);
     for (int slot = 2; slot < 6; ++slot)
         device.parameters.emplace_back(slot, "P" + juce::String(slot), "", 0.0f, 1.0f, 0.0f);

--- a/tests/core/test_addressed_parameters.cpp
+++ b/tests/core/test_addressed_parameters.cpp
@@ -167,24 +167,23 @@ TEST_CASE("A place in the device UI addresses a parameter", "[core][parameters][
     CHECK(std::vector<int>(slots.begin(), slots.end()) == std::vector<int>{0, 1, 2, 3});
 }
 
-TEST_CASE("A UI list holds array positions, not slots", "[core][parameters][addressed]") {
-    // A hosted plugin's own parameters start at slot 2, past the wrapper pair,
-    // so position 0 in the array addresses slot 2.
+TEST_CASE("A UI list names slots", "[core][parameters][addressed]") {
+    // A hosted plugin's own parameters start at slot 2, past the wrapper pair.
+    // The selections name those slots (#2638), so nothing has to translate a
+    // position through an array that #2635 shortens.
     auto device = makeDevice(7, 0);
     for (int slot = 2; slot < 6; ++slot)
         device.parameters.emplace_back(slot, "P" + juce::String(slot), "", 0.0f, 1.0f, 0.0f);
 
-    device.visibleParameters = {0, 3};
-
-    // Past the end of the array: a stale config addresses nothing.
-    device.miniMixerParameters = {9};
+    device.visibleParameters = {2, 5};
+    device.miniMixerParameters = {3};
 
     const auto project = oneDevice(std::move(device));
     const auto addressed = addressedIn({project.track});
 
     const auto slots = addressed.forDevice(project.path);
-    REQUIRE(slots.size() == 2);
-    CHECK(std::vector<int>(slots.begin(), slots.end()) == std::vector<int>{2, 5});
+    REQUIRE(slots.size() == 3);
+    CHECK(std::vector<int>(slots.begin(), slots.end()) == std::vector<int>{2, 3, 5});
 }
 
 TEST_CASE("An empty visible list addresses nothing", "[core][parameters][addressed]") {

--- a/tests/core/test_device_parameter_list.cpp
+++ b/tests/core/test_device_parameter_list.cpp
@@ -1,0 +1,49 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "audio/DeviceParameterList.hpp"
+#include "core/DeviceInfo.hpp"
+
+/**
+ * @file test_device_parameter_list.cpp
+ * @brief Which value a reader is shown for a slot (#2634).
+ */
+
+using namespace magda;
+
+namespace {
+
+/// A hosted plugin's own parameters, which start at slot 2.
+std::vector<ParameterInfo> reported(float value) {
+    std::vector<ParameterInfo> described;
+    for (int slot = 2; slot < 5; ++slot) {
+        ParameterInfo info(slot, "P" + juce::String(slot), "", 0.0f, 1.0f, 0.0f);
+        info.currentValue = value;
+        described.push_back(info);
+    }
+    return described;
+}
+
+}  // namespace
+
+TEST_CASE("The model's value wins for a slot it mirrors", "[device-parameters][2634]") {
+    // A write reaches the model at once and the plugin a block later
+    // (EngineHost::deviceParameterChanged queues a publish), so a read taken
+    // between the two must not report the value the write replaced.
+    DeviceInfo device;
+    device.format = PluginFormat::VST3;
+    ParameterInfo mirrored(3, "P3", "", 0.0f, 1.0f, 0.0f);
+    mirrored.currentValue = 0.75f;
+    device.parameters.push_back(mirrored);
+
+    const auto shown = withModelValues(reported(0.25f), device);
+
+    REQUIRE(shown.size() == 3);
+    CHECK(shown[1].paramIndex == 3);
+    CHECK(shown[1].currentValue == Catch::Approx(0.75f));
+
+    // The slots the model does not carry keep what the instance reported.
+    CHECK(shown[0].currentValue == Catch::Approx(0.25f));
+    CHECK(shown[2].currentValue == Catch::Approx(0.25f));
+}

--- a/tests/devices/test_device_api.cpp
+++ b/tests/devices/test_device_api.cpp
@@ -474,6 +474,41 @@ TEST_CASE("Bypass is applied and reported through the facade", "[device-api][mut
     TrackManager::getInstance().clearAllTracks();
 }
 
+TEST_CASE("The AI opt-in gate names slots", "[device-api][mutation][2638]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Synth");
+
+    // A hosted plugin's own parameters start at slot 2, past the wrapper pair,
+    // so a selection of the first one is {2} rather than {0}.
+    DeviceInfo device;
+    device.name = "Plugin";
+    device.pluginId = "com.example.plugin";
+    device.format = PluginFormat::VST3;
+    for (int slot = 2; slot < 5; ++slot) {
+        ParameterInfo info;
+        info.paramIndex = slot;
+        info.name = "P" + juce::String(slot);
+        info.minValue = 0.0f;
+        info.maxValue = 1.0f;
+        info.currentValue = 0.0f;
+        device.parameters.push_back(info);
+    }
+    device.aiSoundDesignerParameters = {2};
+
+    const auto deviceId = tracks.addDeviceToTrack(trackId, device);
+    const auto path = tracks.findDevicePath(deviceId);
+
+    DeviceApiLive devices;
+
+    CHECK(devices.setDeviceParameter(path, 2, 0.5f));
+
+    // Slot 4 sits where the selection's own number would land if this counted
+    // positions, and nobody opted it in.
+    CHECK_FALSE(devices.setDeviceParameter(path, 4, 0.5f));
+
+    tracks.clearAllTracks();
+}
+
 TEST_CASE("Parameter writes are range-checked rather than clamped", "[device-api][mutation]") {
     auto& tracks = TrackManager::getInstance();
     const auto trackId = freshTrack("Synth");

--- a/tests/devices/test_plugin_parameter_config_store.cpp
+++ b/tests/devices/test_plugin_parameter_config_store.cpp
@@ -249,10 +249,11 @@ TEST_CASE("A config follows its parameter when the plugin renumbers",
 
     REQUIRE(store::applyToDevice(updated));
 
-    // Mode is at three now, and that is where its override landed.
+    // Mode is at three now, and that is where its override landed. The
+    // selection names its slot, which the renumber did not move (#2638).
     CHECK(updated.parameters[3].name == "Mode");
     CHECK(updated.parameters[3].unit == "shape");
-    CHECK(updated.visibleParameters == std::vector<int>{3});
+    CHECK(updated.visibleParameters == std::vector<int>{2});
 
     // The parameter that took the old position is untouched.
     CHECK(updated.parameters[2].unit == "%");

--- a/tests/project/test_project_serialization.cpp
+++ b/tests/project/test_project_serialization.cpp
@@ -907,6 +907,68 @@ TEST_CASE("Project Serialization Basics", "[project][serialization]") {
     }
 }
 
+TEST_CASE("A device's parameter selections are saved as slots", "[project][serialization]") {
+    using magda::DeviceInfo;
+    using magda::ParameterInfo;
+    using magda::ProjectSerializer;
+
+    // A hosted plugin's own parameters start at slot 2, past the wrapper pair.
+    DeviceInfo device;
+    device.id = 1;
+    device.name = "Plugin";
+    device.pluginId = "com.example.plugin";
+    device.format = magda::PluginFormat::VST3;
+    for (int slot = 2; slot < 6; ++slot)
+        device.parameters.emplace_back(slot, "P" + juce::String(slot), "", 0.0f, 1.0f, 0.0f);
+
+    device.visibleParameters = {3, 5};
+    device.miniMixerParameters = {2};
+    device.aiSoundDesignerParameters = {5};
+
+    DeviceInfo restored;
+    REQUIRE(ProjectSerializer::deserializeDeviceInfo(ProjectSerializer::serializeDeviceInfo(device),
+                                                     restored));
+
+    CHECK(restored.visibleParameters == std::vector<int>{3, 5});
+    CHECK(restored.miniMixerParameters == std::vector<int>{2});
+    CHECK(restored.aiSoundDesignerParameters == std::vector<int>{5});
+}
+
+TEST_CASE("An older project's parameter selections are read as positions",
+          "[project][serialization]") {
+    using magda::DeviceInfo;
+    using magda::ProjectSerializer;
+
+    // Written before #2638: the lists hold positions in the parameter array,
+    // which still carries every slot at load.
+    auto json = std::make_unique<juce::DynamicObject>();
+    json->setProperty("id", 1);
+    json->setProperty("name", "Plugin");
+    json->setProperty("pluginId", "com.example.plugin");
+    json->setProperty("format", static_cast<int>(magda::PluginFormat::VST3));
+
+    juce::Array<juce::var> parameters;
+    for (int slot = 2; slot < 6; ++slot) {
+        auto param = std::make_unique<juce::DynamicObject>();
+        param->setProperty("paramIndex", slot);
+        param->setProperty("name", "P" + juce::String(slot));
+        param->setProperty("minValue", 0.0);
+        param->setProperty("maxValue", 1.0);
+        parameters.add(juce::var(param.release()));
+    }
+    json->setProperty("parameters", juce::var(parameters));
+
+    json->setProperty("visibleParameters", juce::var(juce::Array<juce::var>{1, 3}));
+    json->setProperty("miniMixerParameters", juce::var(juce::Array<juce::var>{0}));
+
+    DeviceInfo restored;
+    REQUIRE(ProjectSerializer::deserializeDeviceInfo(juce::var(json.release()), restored));
+
+    CHECK(restored.visibleParameters == std::vector<int>{3, 5});
+    CHECK(restored.miniMixerParameters == std::vector<int>{2});
+    CHECK(restored.aiSoundDesignerParameters.empty());
+}
+
 TEST_CASE("Audio clip serialization separates source facts from interpretation",
           "[project][serialization][audio]") {
     ProjectTestFixture fixture;

--- a/tests/remote/test_remote_api_contract.cpp
+++ b/tests/remote/test_remote_api_contract.cpp
@@ -516,7 +516,7 @@ TEST_CASE("devices.listParameters projects real units and customization flags",
     device.miniMixerParameters = {1};
     device.aiSoundDesignerParameters = {1};
 
-    const auto parameters = makeDeviceParameterDtos(device);
+    const auto parameters = makeDeviceParameterDtos(device, {});
     REQUIRE(parameters.size() == 3);
 
     REQUIRE(parameters[0].index == 0);
@@ -564,7 +564,7 @@ TEST_CASE("configured external parameters project model values into display unit
     gain.defaultValue = 0.5f;   // model / TE domain
     device.parameters.push_back(gain);
 
-    const auto parameters = makeDeviceParameterDtos(device);
+    const auto parameters = makeDeviceParameterDtos(device, {});
     REQUIRE(parameters.size() == 1);
     // 0.75 of a -24..24 dB range reads +12 dB, not 0.75 dB.
     REQUIRE(std::abs(parameters[0].currentValue - 12.0) < 1e-4);
@@ -580,7 +580,7 @@ TEST_CASE("internal devices accept agent writes on every parameter", "[remote-ap
     device.parameters.emplace_back(0, "Drive", "", 0.0f, 1.0f, 0.5f);
     device.parameters.emplace_back(1, "Tone", "", 0.0f, 1.0f, 0.5f);
 
-    const auto parameters = makeDeviceParameterDtos(device);
+    const auto parameters = makeDeviceParameterDtos(device, {});
     REQUIRE(parameters.size() == 2);
     for (const auto& parameter : parameters)
         REQUIRE(parameter.aiAgentEnabled);


### PR DESCRIPTION
Two slices of #2629: the projection that can answer from a live plugin (#2634, first half), and the addressing change the cut needs before it (#2638).

## Read a hosted plugin's parameter list off its instance (#2634)

`EngineExternalDevice::describeParameters` reports what the instance has, at the values it holds now, and `AudioEngine::describeDeviceParameters` reaches it on the message thread the way `formatDeviceParameter` already does: a query that suspends nothing.

One projection, `deviceParameterList`, is what readers needing the whole list go through. It applies the saved config and the live text providers to the described list, exactly as the model's own array gets them. `devices.listParameters`, `devices.setParameter`, `devices.setParameterConfig` and the automation menu now ask the instance.

Internal devices, and paths the engine holds no instance for, answer from the model, so the fork's readers are unchanged.

The parameter config dialog needed nothing: it already scans a throwaway instance through `scanPluginParameters`.

The device slot grid and the mini chain row take the list too: the slot adopts it when it learns its path, since the path is what reaches the plugin, and again whenever the device it draws changes. That covers the case a hosted plugin is in before anyone configures it, where the grid shows every parameter the plugin has.

## Key a device's parameter selections on slots (#2638)

`visibleParameters`, `miniMixerParameters` and `aiSoundDesignerParameters` were read two ways: as positions in `DeviceInfo::parameters` by the config store, the grid layout, the mini chain row and the remote DTOs, and as slots by `DeviceParamMigrations::migrateIndices`, which maps them through the same function that remaps `paramIndex`. The two agree only for a device whose array is dense from zero, which a hosted plugin's is not: its own parameters start at slot 2, past the wrapper pair.

They are slots now.

- The config store resolves an entry by stable id and stores the slot it lands on, so saved files need no format change.
- A project writes `visibleParameterSlots`, `miniMixerParameterSlots` and `aiSoundDesignerParameterSlots`. An older project's keys are read as positions and translated through its saved parameter array, which still carries every slot at load.
- The grid layout, the mini chain row, the DTO projection and `AddressedParameters` follow.

This has to land before #2635. Once the array holds only addressed slots, a position into it names nothing, and the addressed-set query would be circular: it reads the lists, and the lists would need the array it determines.

### A bug this fixes

The device slot's automation refresh compared an array position against a lane's slot whenever a device had no visible selection, so a lane on a hosted plugin drove the wrong cell or none.

## Tests

4035 passed, 13 skipped, 0 failed. New cases cover a selection round trip as slots, an older project's positions translating on load, and the addressed set reading slots directly. One expectation changed with the convention: a config following its parameter through a plugin renumber now names the slot, which the renumber does not move, rather than the position it moved to. The app target and the JUCE test target build.

https://claude.ai/code/session_01WYXRjLSLhk3uChENwsLETF

